### PR TITLE
[P1.1] Domain models: Tier, DimensionScores, ExtractedFacts, LeadAssessment, RoutingDecision

### DIFF
--- a/src/leadquali/domain/models.py
+++ b/src/leadquali/domain/models.py
@@ -1,0 +1,248 @@
+"""The core domain contract: what the model judges, and what code decides.
+
+Two families of types live here, and the boundary between them is the most important line
+in the system:
+
+* :class:`LeadAssessment` (with :class:`DimensionScores` and :class:`ExtractedFacts`) is
+  the **model's** output. It carries judgment — scores, extracted facts, confidence — and
+  nothing else. It is handed to the LLM verbatim as a structured-output schema, so every
+  field is JSON-schema-expressible and carries a description that steers the model.
+* :class:`RoutingDecision` (with :class:`Tier`, :class:`Action` and
+  :class:`EscalationReason`) is **code's** output, produced by the deterministic layer from
+  an assessment plus tenant configuration.
+
+Invariant 2 of ``CLAUDE.md`` is absolute: ``tier``, ``total_score`` and any routing
+instruction must never appear in :class:`LeadAssessment`, at any depth. A reviewer should
+be able to confirm that by reading this module alone; ``tests/unit/
+test_assessment_schema_purity.py`` proves it against the generated JSON schema.
+
+Every model is frozen. An assessment is a record of what the model said at one instant and
+a decision is a record of what policy concluded from it — both are values, not workspaces.
+Mutating one after the fact would make the audit trail a lie, and freezing also makes them
+hashable and safe to pass across layers. Every model is ``extra="forbid"``: if the model
+volunteers a field we did not ask for (a tier, most of all), validation fails loudly
+instead of silently dropping it.
+
+Pure Pydantic v2 and the standard library: no I/O, no SDK imports, no configuration
+values. Thresholds, weights and routing rules are tenant configuration (invariant 1) and
+live nowhere near this file.
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, Field, model_validator
+
+#: Highest value ``DimensionScores`` can sum to, and the scale weighted totals are
+#: normalised onto. Thresholds that carve this range into tiers are tenant configuration.
+MAX_TOTAL_SCORE: float = 100.0
+
+
+class Tier(StrEnum):
+    """How much of a salesperson's attention a lead has earned.
+
+    Ordering is **not** the enum's string ordering — ``Tier.COLD < Tier.HOT`` is ``True``
+    only because ``"cold"`` sorts before ``"hot"``. Compare :attr:`rank` instead.
+    """
+
+    HOT = "hot"
+    WARM = "warm"
+    COLD = "cold"
+    DISQUALIFIED = "disqualified"
+
+    @property
+    def rank(self) -> int:
+        """Order by value to the business, ascending: disqualified 0 … hot 3.
+
+        Use this for every comparison, sort and "at least as good as" check. The
+        lexicographic ordering inherited from :class:`str` would rank ``cold`` above
+        ``hot`` and no one would notice until sales did.
+        """
+        return _TIER_RANKS[self]
+
+
+_TIER_RANKS: dict[Tier, int] = {
+    Tier.DISQUALIFIED: 0,
+    Tier.COLD: 1,
+    Tier.WARM: 2,
+    Tier.HOT: 3,
+}
+
+
+class Action(StrEnum):
+    """What the system does with a lead once it has been placed in a tier."""
+
+    EMAIL_SALES = "email_sales"
+    """Notify the sales destination configured for the tenant."""
+
+    ESCALATE_HUMAN = "escalate_human"
+    """Put it in front of a person because the system is not sure. Never a dead end."""
+
+    SUPPRESS = "suppress"
+    """Record it and stop. Reachable only from an explicit spam/test determination."""
+
+
+class EscalationReason(StrEnum):
+    """Why a decision fell back to a human.
+
+    Recorded so observability and the eval harness can group on it: a rise in
+    ``LOW_CONFIDENCE`` is a prompt or rubric problem, a rise in ``API_ERROR`` is an
+    operational one, and the two need different people woken up.
+    """
+
+    LOW_CONFIDENCE = "low_confidence"
+    MODEL_REFUSAL = "model_refusal"
+    PARSE_ERROR = "parse_error"
+    API_ERROR = "api_error"
+    TIMEOUT = "timeout"
+
+
+class DimensionScores(BaseModel):
+    """The five judgment axes, each bounded by its own weight in the rubric.
+
+    The bounds are the model's answer space, not the tenant's policy: a tenant reweights
+    these dimensions in configuration, it does not change what a raw ``icp_fit`` of 30
+    means.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    icp_fit: int = Field(
+        ge=0,
+        le=30,
+        description="How closely the lead matches the ideal customer profile, 0-30.",
+    )
+    intent: int = Field(
+        ge=0,
+        le=25,
+        description="Evidence the lead is trying to solve this problem now, 0-25.",
+    )
+    authority: int = Field(
+        ge=0,
+        le=15,
+        description="Evidence the contact can buy or sponsor a purchase, 0-15.",
+    )
+    urgency: int = Field(
+        ge=0,
+        le=15,
+        description="Evidence of a deadline, trigger event or compelling event, 0-15.",
+    )
+    budget_signal: int = Field(
+        ge=0,
+        le=15,
+        description="Evidence the lead can fund a purchase of this size, 0-15.",
+    )
+
+
+class ExtractedFacts(BaseModel):
+    """Facts read off the submission, each ``None`` when the lead did not supply it.
+
+    Every field is required-but-nullable rather than defaulted: a web-form lead is usually
+    sparse, and an explicit ``null`` from the model ("I looked, it is not there") is a
+    different and more useful signal than a key the model forgot to emit.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    company_name: str | None = Field(description="Company name as stated, or null.")
+    industry: str | None = Field(description="Industry or sector, or null.")
+    company_size_estimate: str | None = Field(
+        description="Headcount or revenue band as stated or inferred, or null."
+    )
+    role_seniority: str | None = Field(
+        description="Seniority of the contact, e.g. 'ic', 'manager', 'vp', or null."
+    )
+    stated_use_case: str | None = Field(
+        description="What the lead says they want to do, in their own words, or null."
+    )
+    stated_timeline: str | None = Field(
+        description="Any timeframe the lead states for deciding or buying, or null."
+    )
+
+
+class LeadAssessment(BaseModel):
+    """The model's complete output for one lead — judgment only, never policy.
+
+    Handed to the LLM as its structured-output schema, so the field descriptions are part
+    of the prompt. Nothing here says what happens next.
+    """
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    dimension_scores: DimensionScores = Field(
+        description="Score for each rubric dimension, within its stated range."
+    )
+    extracted: ExtractedFacts = Field(
+        description="Facts read off the submission; null for anything not stated."
+    )
+    reasoning: str = Field(
+        min_length=1,
+        description="2-4 sentences citing specific evidence from the lead for the scores.",
+    )
+    confidence: float = Field(
+        ge=0.0,
+        le=1.0,
+        description=(
+            "How confident you are in this assessment, 0.0-1.0. Be honest: a low value is "
+            "handled safely, an overconfident one is not."
+        ),
+    )
+    missing_information: list[str] = Field(
+        description="Facts that would most change this assessment if known. May be empty."
+    )
+    suggested_first_question: str | None = Field(
+        description="One question a salesperson should open with, or null if none helps."
+    )
+    spam_or_test_submission: bool = Field(
+        description=(
+            "True only for an obvious spam, bot or internal test submission. A vague or "
+            "unpromising lead is not spam."
+        )
+    )
+
+
+class RoutingDecision(BaseModel):
+    """What the deterministic layer concluded. Produced by code, never by the model."""
+
+    model_config = ConfigDict(frozen=True, extra="forbid")
+
+    tier: Tier
+    action: Action
+    total_score: float = Field(
+        default=0.0,
+        ge=0.0,
+        le=MAX_TOTAL_SCORE,
+        description=(
+            "Weighted total on the 0-100 scale. Zero when no score was computed, e.g. a "
+            "suppressed spam submission or a failure before assessment."
+        ),
+    )
+    note: str = Field(
+        default="",
+        description="Human-readable explanation, shown to whoever receives the lead.",
+    )
+    escalation_reason: EscalationReason | None = Field(
+        default=None,
+        description="Set when this decision is a fallback to a human, for grouping.",
+    )
+
+    @property
+    def escalated(self) -> bool:
+        """Whether this decision was reached by falling back to a human."""
+        return self.escalation_reason is not None
+
+    @model_validator(mode="after")
+    def _escalation_is_never_suppression(self) -> RoutingDecision:
+        """Invariant 3: a lead is never silently dropped.
+
+        Suppression is only ever an explicit spam/test determination. If something went
+        wrong or we were unsure, that is an escalation, and the two can never be the same
+        decision.
+        """
+        if self.escalation_reason is not None and self.action is Action.SUPPRESS:
+            raise ValueError(
+                "an escalated decision cannot suppress the lead: "
+                f"escalation_reason={self.escalation_reason.value}"
+            )
+        return self

--- a/tests/unit/test_assessment_schema_purity.py
+++ b/tests/unit/test_assessment_schema_purity.py
@@ -1,0 +1,119 @@
+"""Invariant 2 guard rail: the model assesses, code routes.
+
+``LeadAssessment`` is handed to Anthropic as a structured-output schema. If a routing
+concept ever leaks into it — a tier, an action, a total score, a destination — then the
+model, not Python, is deciding policy, and every downstream guarantee (deterministic
+routing, offline-testable decisions, prompt-injection containment) is void.
+
+This file is deliberately narrow and deliberately paranoid: it walks the *generated JSON
+schema*, not the class, so a leak introduced through an inherited model, a nested model or
+a field description is caught too.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+import pytest
+
+from leadquali.domain.models import DimensionScores, ExtractedFacts, LeadAssessment
+
+#: Concepts that belong to the deterministic layer and must never reach the model.
+FORBIDDEN_NAMES = frozenset(
+    {
+        "tier",
+        "action",
+        "total_score",
+        "destination",
+        "route",
+        "routing",
+        "escalation_reason",
+        "assigned_to",
+    }
+)
+
+#: Substrings that must not occur anywhere in the schema text, in any casing — not as a
+#: property name, not in a description, not in an enum value.
+FORBIDDEN_SUBSTRINGS = ("tier", "total_score", "destination", "routing")
+
+
+def _walk(node: Any, path: str = "$") -> list[tuple[str, str]]:
+    """Yield ``(path, key)`` for every mapping key in a JSON-schema-shaped structure."""
+    found: list[tuple[str, str]] = []
+    if isinstance(node, dict):
+        for key, value in node.items():
+            found.append((path, str(key)))
+            found.extend(_walk(value, f"{path}.{key}"))
+    elif isinstance(node, list):
+        for index, value in enumerate(node):
+            found.extend(_walk(value, f"{path}[{index}]"))
+    return found
+
+
+def test_schema_has_no_routing_key_at_any_depth() -> None:
+    schema = LeadAssessment.model_json_schema()
+    offenders = [f"{path}.{key}" for path, key in _walk(schema) if key.lower() in FORBIDDEN_NAMES]
+    assert offenders == [], f"routing concepts leaked into the model's schema: {offenders}"
+
+
+def test_no_property_name_at_any_depth_is_a_routing_concept() -> None:
+    schema = LeadAssessment.model_json_schema()
+    offenders = [
+        f"{path}.{key}"
+        for path, key in _walk(schema)
+        if path.endswith(".properties") and key.lower() in FORBIDDEN_NAMES
+    ]
+    assert offenders == []
+
+
+@pytest.mark.parametrize("needle", FORBIDDEN_SUBSTRINGS)
+def test_schema_text_never_mentions_a_routing_concept(needle: str) -> None:
+    """Not even in a description — a hint is enough to make the model volunteer a tier."""
+    schema_text = json.dumps(LeadAssessment.model_json_schema()).lower()
+    assert needle not in schema_text
+
+
+def test_schema_text_never_mentions_an_action_as_a_word() -> None:
+    schema_text = json.dumps(LeadAssessment.model_json_schema()).lower()
+    assert re.search(r"\bactions?\b", schema_text) is None
+
+
+def test_assessment_rejects_a_smuggled_routing_field() -> None:
+    """``extra="forbid"`` means a model that volunteers a tier fails validation loudly."""
+    payload = json.loads(_valid_assessment().model_dump_json())
+    payload["tier"] = "hot"
+    with pytest.raises(ValueError, match="tier"):
+        LeadAssessment.model_validate(payload)
+
+
+def test_schema_is_closed_and_fully_required() -> None:
+    """A structured-output schema Anthropic can be held to: no extras, no absent keys."""
+    schema = LeadAssessment.model_json_schema()
+    assert schema["additionalProperties"] is False
+    assert set(schema["required"]) == set(schema["properties"])
+    for definition in schema.get("$defs", {}).values():
+        assert definition["additionalProperties"] is False
+        assert set(definition["required"]) == set(definition["properties"])
+
+
+def _valid_assessment() -> LeadAssessment:
+    return LeadAssessment(
+        dimension_scores=DimensionScores(
+            icp_fit=20, intent=15, authority=10, urgency=8, budget_signal=7
+        ),
+        extracted=ExtractedFacts(
+            company_name="Acme",
+            industry="logistics",
+            company_size_estimate="50-200",
+            role_seniority="director",
+            stated_use_case="route planning",
+            stated_timeline="this quarter",
+        ),
+        reasoning="Director at a mid-size logistics firm naming a concrete use case.",
+        confidence=0.8,
+        missing_information=["budget"],
+        suggested_first_question="What does your current routing stack cost you?",
+        spam_or_test_submission=False,
+    )

--- a/tests/unit/test_domain_models.py
+++ b/tests/unit/test_domain_models.py
@@ -1,0 +1,301 @@
+"""Behaviour of the domain contract every other module is written against."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from leadquali.domain.models import (
+    MAX_TOTAL_SCORE,
+    Action,
+    DimensionScores,
+    EscalationReason,
+    ExtractedFacts,
+    LeadAssessment,
+    RoutingDecision,
+    Tier,
+)
+
+VALID_SCORES: dict[str, Any] = {
+    "icp_fit": 20,
+    "intent": 15,
+    "authority": 10,
+    "urgency": 8,
+    "budget_signal": 7,
+}
+
+DIMENSION_BOUNDS: list[tuple[str, int]] = [
+    ("icp_fit", 30),
+    ("intent", 25),
+    ("authority", 15),
+    ("urgency", 15),
+    ("budget_signal", 15),
+]
+
+
+def make_scores(**overrides: int) -> DimensionScores:
+    return DimensionScores.model_validate({**VALID_SCORES, **overrides})
+
+
+def make_facts(**overrides: str | None) -> ExtractedFacts:
+    base: dict[str, str | None] = {
+        "company_name": "Acme Freight",
+        "industry": "logistics",
+        "company_size_estimate": "50-200",
+        "role_seniority": "director",
+        "stated_use_case": "route planning",
+        "stated_timeline": "this quarter",
+    }
+    return ExtractedFacts.model_validate({**base, **overrides})
+
+
+def make_assessment(**overrides: Any) -> LeadAssessment:
+    base: dict[str, Any] = {
+        "dimension_scores": make_scores(),
+        "extracted": make_facts(),
+        "reasoning": "Director at a mid-size logistics firm naming a concrete use case.",
+        "confidence": 0.82,
+        "missing_information": ["budget"],
+        "suggested_first_question": "What does routing cost you per week today?",
+        "spam_or_test_submission": False,
+    }
+    return LeadAssessment.model_validate({**base, **overrides})
+
+
+# --------------------------------------------------------------------------- Tier
+
+
+def test_tier_values_are_the_wire_strings() -> None:
+    assert [t.value for t in Tier] == ["hot", "warm", "cold", "disqualified"]
+    assert Tier("hot") is Tier.HOT
+    assert f"{Tier.WARM}" == "warm"
+
+
+def test_tier_rank_orders_by_business_value_not_alphabetically() -> None:
+    ordered = sorted(Tier, key=lambda t: t.rank)
+    assert ordered == [Tier.DISQUALIFIED, Tier.COLD, Tier.WARM, Tier.HOT]
+    assert Tier.HOT.rank > Tier.WARM.rank > Tier.COLD.rank > Tier.DISQUALIFIED.rank
+
+
+def test_string_ordering_on_tier_is_the_trap_rank_exists_to_avoid() -> None:
+    """Pin the footgun: ``<`` on a ``StrEnum`` ranks ``cold`` above ``hot``."""
+    assert Tier.COLD < Tier.HOT  # lexicographic, and exactly backwards
+    assert Tier.COLD.rank < Tier.HOT.rank
+
+
+def test_every_tier_has_a_distinct_rank() -> None:
+    ranks = [t.rank for t in Tier]
+    assert sorted(ranks) == [0, 1, 2, 3]
+
+
+# ------------------------------------------------------------------- enums / actions
+
+
+def test_action_covers_notify_escalate_and_suppress() -> None:
+    assert {a.value for a in Action} >= {"email_sales", "escalate_human", "suppress"}
+
+
+def test_escalation_reasons_cover_every_non_answer_path() -> None:
+    assert {r.value for r in EscalationReason} == {
+        "low_confidence",
+        "model_refusal",
+        "parse_error",
+        "api_error",
+        "timeout",
+    }
+
+
+# ------------------------------------------------------------------- DimensionScores
+
+
+@pytest.mark.parametrize(("field", "maximum"), DIMENSION_BOUNDS)
+def test_dimension_accepts_both_ends_of_its_range(field: str, maximum: int) -> None:
+    assert getattr(make_scores(**{field: 0}), field) == 0
+    assert getattr(make_scores(**{field: maximum}), field) == maximum
+
+
+@pytest.mark.parametrize(("field", "maximum"), DIMENSION_BOUNDS)
+def test_dimension_rejects_one_over_its_maximum(field: str, maximum: int) -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        make_scores(**{field: maximum + 1})
+    assert excinfo.value.errors()[0]["type"] == "less_than_equal"
+
+
+@pytest.mark.parametrize(("field", "_maximum"), DIMENSION_BOUNDS)
+def test_dimension_rejects_negative(field: str, _maximum: int) -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        make_scores(**{field: -1})
+    assert excinfo.value.errors()[0]["type"] == "greater_than_equal"
+
+
+def test_dimension_bounds_are_the_ones_the_rubric_promises() -> None:
+    """The per-dimension ceilings sum to the 0-100 scale the thresholds are stated on."""
+    assert sum(maximum for _, maximum in DIMENSION_BOUNDS) == MAX_TOTAL_SCORE
+
+
+def test_scores_are_required_not_defaulted() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        DimensionScores.model_validate({"icp_fit": 10})
+    assert {e["type"] for e in excinfo.value.errors()} == {"missing"}
+
+
+def test_scores_coerce_a_numeric_string_and_a_whole_float() -> None:
+    """Lax validation: the wire is JSON, and a model that emits "30" is still right."""
+    assert DimensionScores.model_validate({**VALID_SCORES, "icp_fit": "30"}).icp_fit == 30
+    assert DimensionScores.model_validate({**VALID_SCORES, "icp_fit": 12.0}).icp_fit == 12
+
+
+def test_scores_reject_a_fractional_float_and_none() -> None:
+    for bad in (12.5, None, "high"):
+        with pytest.raises(ValidationError):
+            DimensionScores.model_validate({**VALID_SCORES, "icp_fit": bad})
+
+
+def test_scores_reject_an_unknown_field() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        DimensionScores.model_validate({**VALID_SCORES, "vibes": 5})
+    assert excinfo.value.errors()[0]["type"] == "extra_forbidden"
+
+
+# --------------------------------------------------------------------- ExtractedFacts
+
+
+def test_every_extracted_fact_may_be_null() -> None:
+    facts = ExtractedFacts.model_validate(dict.fromkeys(ExtractedFacts.model_fields))
+    assert all(getattr(facts, name) is None for name in ExtractedFacts.model_fields)
+
+
+def test_extracted_facts_are_required_even_though_nullable() -> None:
+    """An explicit null is a signal; a missing key is a bug we want to hear about."""
+    with pytest.raises(ValidationError) as excinfo:
+        ExtractedFacts.model_validate({"company_name": "Acme"})
+    assert {e["type"] for e in excinfo.value.errors()} == {"missing"}
+    assert len(excinfo.value.errors()) == len(ExtractedFacts.model_fields) - 1
+
+
+# --------------------------------------------------------------------- LeadAssessment
+
+
+def test_assessment_accepts_a_complete_sparse_lead() -> None:
+    assessment = make_assessment(
+        extracted=make_facts(company_name=None, stated_timeline=None),
+        missing_information=[],
+        suggested_first_question=None,
+    )
+    assert assessment.extracted.company_name is None
+    assert assessment.missing_information == []
+    assert assessment.suggested_first_question is None
+
+
+@pytest.mark.parametrize("confidence", [0.0, 0.5, 1.0])
+def test_confidence_accepts_the_closed_unit_interval(confidence: float) -> None:
+    assert make_assessment(confidence=confidence).confidence == confidence
+
+
+@pytest.mark.parametrize("confidence", [-0.01, 1.01, 2.0, -1.0])
+def test_confidence_rejects_anything_outside_it(confidence: float) -> None:
+    with pytest.raises(ValidationError):
+        make_assessment(confidence=confidence)
+
+
+def test_reasoning_must_not_be_empty() -> None:
+    with pytest.raises(ValidationError) as excinfo:
+        make_assessment(reasoning="")
+    assert excinfo.value.errors()[0]["type"] == "string_too_short"
+
+
+def test_assessment_is_frozen() -> None:
+    assessment = make_assessment()
+    with pytest.raises(ValidationError) as excinfo:
+        assessment.confidence = 1.0
+    assert excinfo.value.errors()[0]["type"] == "frozen_instance"
+
+
+def test_nested_models_are_frozen_too() -> None:
+    scores = make_scores()
+    with pytest.raises(ValidationError):
+        scores.icp_fit = 0
+
+
+def test_assessment_round_trips_through_json() -> None:
+    assessment = make_assessment(extracted=make_facts(industry=None), suggested_first_question=None)
+    restored = LeadAssessment.model_validate_json(assessment.model_dump_json())
+    assert restored == assessment
+    assert restored.extracted.industry is None
+
+
+def test_assessment_round_trip_preserves_every_field() -> None:
+    assessment = make_assessment()
+    assert LeadAssessment.model_validate(assessment.model_dump()) == assessment
+
+
+# --------------------------------------------------------------------- RoutingDecision
+
+
+def test_routing_decision_defaults_to_no_score_and_no_note() -> None:
+    decision = RoutingDecision(tier=Tier.DISQUALIFIED, action=Action.SUPPRESS)
+    assert decision.total_score == 0.0
+    assert decision.note == ""
+    assert decision.escalation_reason is None
+    assert decision.escalated is False
+
+
+def test_routing_decision_records_why_it_escalated() -> None:
+    decision = RoutingDecision(
+        tier=Tier.WARM,
+        action=Action.ESCALATE_HUMAN,
+        total_score=61.5,
+        note="low model confidence - human review",
+        escalation_reason=EscalationReason.LOW_CONFIDENCE,
+    )
+    assert decision.escalated is True
+    assert decision.escalation_reason is EscalationReason.LOW_CONFIDENCE
+    assert decision.tier.rank > Tier.COLD.rank
+
+
+def test_an_escalation_can_never_suppress_the_lead() -> None:
+    """Invariant 3 encoded in the type: uncertainty escalates, it never bins."""
+    with pytest.raises(ValidationError) as excinfo:
+        RoutingDecision(
+            tier=Tier.DISQUALIFIED,
+            action=Action.SUPPRESS,
+            escalation_reason=EscalationReason.API_ERROR,
+        )
+    assert "cannot suppress" in str(excinfo.value)
+
+
+@pytest.mark.parametrize("total", [0.0, 55.0, MAX_TOTAL_SCORE])
+def test_total_score_accepts_the_whole_scale(total: float) -> None:
+    decision = RoutingDecision(tier=Tier.COLD, action=Action.EMAIL_SALES, total_score=total)
+    assert decision.total_score == total
+
+
+@pytest.mark.parametrize("total", [-0.1, MAX_TOTAL_SCORE + 0.1])
+def test_total_score_rejects_anything_off_the_scale(total: float) -> None:
+    with pytest.raises(ValidationError):
+        RoutingDecision(tier=Tier.HOT, action=Action.EMAIL_SALES, total_score=total)
+
+
+def test_routing_decision_is_frozen_and_round_trips() -> None:
+    decision = RoutingDecision(
+        tier=Tier.HOT,
+        action=Action.EMAIL_SALES,
+        total_score=88.0,
+        note="strong fit, named timeline",
+    )
+    with pytest.raises(ValidationError):
+        decision.tier = Tier.COLD
+    assert RoutingDecision.model_validate_json(decision.model_dump_json()) == decision
+
+
+def test_routing_decision_serialises_enums_as_their_wire_strings() -> None:
+    payload = RoutingDecision(
+        tier=Tier.HOT,
+        action=Action.EMAIL_SALES,
+        escalation_reason=None,
+    ).model_dump(mode="json")
+    assert payload["tier"] == "hot"
+    assert payload["action"] == "email_sales"
+    assert payload["escalation_reason"] is None


### PR DESCRIPTION
Closes #7. Stacked on #40 (CI) → #39 (scaffold).

The most load-bearing PR in the epic: every later issue imports these names, and one of these tests is the guard rail for the product's second invariant.

## The contract

`leadquali.domain.models` — pure Pydantic v2 + stdlib, no I/O, no SDK imports. All models `frozen=True, extra="forbid"`.

| Name | Shape |
|---|---|
| `Tier` | StrEnum `hot`/`warm`/`cold`/`disqualified`, plus a `rank` property |
| `Action` | StrEnum `email_sales`/`escalate_human`/`suppress` |
| `EscalationReason` | StrEnum `low_confidence`/`model_refusal`/`parse_error`/`api_error`/`timeout` |
| `DimensionScores` | `icp_fit` 0–30, `intent` 0–25, `authority`/`urgency`/`budget_signal` 0–15 |
| `ExtractedFacts` | six `str \| None` fields, required-but-nullable |
| `LeadAssessment` | **the LLM output schema** — dimension scores, extracted, reasoning, confidence 0–1, missing_information, suggested_first_question, spam_or_test_submission |
| `RoutingDecision` | **code's output** — tier, action, total_score 0–100, note, escalation_reason |

## Why these choices

- **`Tier.rank`.** `StrEnum` ordering is lexicographic, which silently ranks `cold` above `hot`. Any comparison in scoring, evals or drift metrics goes through `rank`, and there is a test pinning the order.
- **Schema purity is a test, not a convention.** `test_assessment_schema_purity.py` asserts the generated JSON schema of `LeadAssessment` contains no `tier`, `action`, `total_score` or `destination` key **at any depth**. That is invariant 2 — "the model assesses, code routes" — enforced mechanically for the rest of the epic. It was mutation-verified: adding a `tier` field to `LeadAssessment` fails five tests.
- **Frozen models.** An assessment is a record of what the model said at a point in time; mutating one after the fact would make `prompt_version` and the stored token counts lie.
- **`extra="forbid"`.** A model that returns an unexpected field should fail loudly at the boundary rather than have it silently dropped.
- **Required-but-nullable** on `ExtractedFacts` and `suggested_first_question`, per plan §5: the model must state "not present", which is information, rather than omit the key, which is ambiguous.
- **`RoutingDecision` rejects `escalation_reason` together with `Action.SUPPRESS`** — invariant 3 ("uncertainty never disqualifies") expressed in the type rather than in a comment.
- **No `Lead` input model.** Issue #7 does not ask for one and #17 owns the inbound payload schema. Deliberately not invented here.

## Verification

68 tests: bounds rejection at both ends, coercion, None handling, JSON round-trip, the schema-purity guard rail, and the tier ordering. `ruff`, `ruff format`, `mypy --strict` and `pytest` all green. `grep -ri anthropic src/leadquali/domain/` returns nothing.

## Note for #9

`total_score` is bounded 0–100, so `weighted_total` must normalise onto that scale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_