### PR TITLE
[P1.4] Rubric prompt v1: versioned instructions with a cacheable stable prefix

### DIFF
--- a/src/leadquali/prompts/__init__.py
+++ b/src/leadquali/prompts/__init__.py
@@ -1,1 +1,36 @@
-"""Versioned prompt assets."""
+"""Versioned prompt assets and the system-prompt assembly that uses them.
+
+``rubric_vN.md`` files are the instructional text; :mod:`leadquali.prompts.rubric` loads
+one and assembles it with a tenant's block into the two-block system prompt. A released
+version's text is never edited — assessments reference it by name.
+"""
+
+from leadquali.prompts.rubric import (
+    BLOCK_SEPARATOR,
+    CONSERVATIVE_CHARS_PER_TOKEN,
+    MIN_CACHEABLE_PREFIX_TOKENS,
+    PROMPT_VERSION,
+    RUBRIC_FILENAME,
+    PromptAssetError,
+    PromptBlock,
+    PromptVersionMismatchError,
+    build_system_blocks,
+    estimate_tokens,
+    render_system_prompt,
+    rubric_text,
+)
+
+__all__ = [
+    "BLOCK_SEPARATOR",
+    "CONSERVATIVE_CHARS_PER_TOKEN",
+    "MIN_CACHEABLE_PREFIX_TOKENS",
+    "PROMPT_VERSION",
+    "RUBRIC_FILENAME",
+    "PromptAssetError",
+    "PromptBlock",
+    "PromptVersionMismatchError",
+    "build_system_blocks",
+    "estimate_tokens",
+    "render_system_prompt",
+    "rubric_text",
+]

--- a/src/leadquali/prompts/rubric.py
+++ b/src/leadquali/prompts/rubric.py
@@ -1,0 +1,218 @@
+"""Loading the versioned rubric, and assembling the system prompt around it.
+
+The system prompt is two blocks, in this order and never the other:
+
+1. **The rubric** — :func:`rubric_text`, read from ``rubric_v1.md``. Byte-identical for
+   every request, for every tenant, for the life of a version. This is the cacheable
+   prefix, and *only* a byte-identical prefix caches: prompt caching is a prefix match, so
+   a single differing byte anywhere in it invalidates everything from that byte onward.
+2. **The tenant block** — :meth:`~leadquali.domain.tenant_config.TenantConfig.icp_block`.
+   Varies per customer, so it goes after the cache breakpoint, where varying is free.
+
+:func:`build_system_blocks` returns those blocks as data, tagged with which one carries the
+breakpoint, so that #11 can render them into the SDK's ``system`` list and attach
+``cache_control`` to the first without this module importing ``anthropic`` (``CLAUDE.md``:
+the SDK lives in ``adapters/llm_anthropic.py`` and nowhere else).
+
+Why the loaded text is not simply the file's bytes: an HTML comment header addressed to
+maintainers is stripped, line endings are normalised to ``\\n`` and trailing whitespace is
+dropped. The header keeps the versioning rule next to the thing it governs without
+spending tokens on it every request; the normalisation is what stops the same file checked
+out on Windows from being a different cache entry than the one on Lambda.
+
+Cacheability has a floor. A prefix below the model's minimum silently does not cache — no
+error, ``cache_creation_input_tokens`` simply stays zero — so
+:data:`MIN_CACHEABLE_PREFIX_TOKENS` is asserted against in the test suite rather than
+assumed.
+
+Not here, deliberately:
+
+* **The user turn.** Rendering the lead itself, inside untrusted-data delimiters, is #12.
+  It appends to ``messages``, never to the system blocks, so it changes nothing this
+  module produces and cannot move the cache prefix.
+* **The API call**, token accounting and ``cache_control`` rendering: #11.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from functools import cache
+from importlib import resources
+from typing import Final
+
+from leadquali.domain.tenant_config import TenantConfig
+
+#: The rubric revision this build ships, recorded on every assessment it produces. Bumping
+#: it means adding a new ``rubric_vN.md``; the text of a released version never changes.
+PROMPT_VERSION: Final[str] = "rubric_v1"
+
+#: Derived from the version rather than written twice, so the two cannot drift.
+RUBRIC_FILENAME: Final[str] = f"{PROMPT_VERSION}.md"
+
+_RUBRIC_PACKAGE: Final[str] = "leadquali.prompts"
+
+#: Minimum prefix length that caches at all on ``claude-opus-5`` (plan §1), in input
+#: tokens. Source: the ``claude-api`` skill, ``shared/prompt-caching.md`` § API reference.
+#: The minimum is model-dependent and not monotonic across generations — 512 here, 1024 on
+#: Opus 4.8 and Sonnet 5, 2048 on Opus 4.7, 4096 on Opus 4.6 and Haiku 4.5 — so a prompt
+#: that caches today can stop caching purely because someone changed the model string.
+#: Below the minimum there is no error and no warning; the cache simply never fills.
+MIN_CACHEABLE_PREFIX_TOKENS: Final[int] = 512
+
+#: Characters per token used by :func:`estimate_tokens`. English prose runs nearer four
+#: for this tokenizer, so six deliberately *understates* the token count: an estimate that
+#: clears the minimum above is a claim we can stand behind offline. An exact count needs
+#: ``client.messages.count_tokens``, which is a billable API call and belongs to #11.
+CONSERVATIVE_CHARS_PER_TOKEN: Final[int] = 6
+
+#: What joins the blocks when they are flattened into one string for humans or for evals.
+BLOCK_SEPARATOR: Final[str] = "\n\n"
+
+_HTML_COMMENT: Final[re.Pattern[str]] = re.compile(r"<!--.*?-->", re.DOTALL)
+
+
+class PromptAssetError(RuntimeError):
+    """A versioned prompt file is missing, unreadable, or empty.
+
+    A packaging fault rather than a user error: the asset ships inside the wheel (see
+    ``[tool.setuptools.package-data]``), so if it is absent at runtime the build is wrong
+    and every request would otherwise go out with an empty rubric.
+    """
+
+
+class PromptVersionMismatchError(ValueError):
+    """A tenant is pinned to a rubric revision this build does not contain.
+
+    Serving ``rubric_v1`` while recording the tenant's pinned ``rubric_v2`` would quietly
+    corrupt the one measurement the version string exists for — "did last Tuesday's prompt
+    change make things worse?" — so this is loud, and it names the tenant.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class PromptBlock:
+    """One system-prompt block, in render order.
+
+    ``cacheable`` marks where the cache breakpoint goes. It is advice about *stability*,
+    not about the SDK: this layer does not know what ``cache_control`` is, and the adapter
+    that does (#11) is free to spend its four breakpoints differently.
+    """
+
+    text: str
+    cacheable: bool
+
+
+def _canonicalise(text: str) -> str:
+    """Collapse a prompt asset to one stable byte sequence, whatever wrote the file.
+
+    CRLF becomes LF, trailing whitespace goes from every line, and leading and trailing
+    blank lines go entirely. Mirrors the normalisation
+    :mod:`leadquali.domain.tenant_config` applies to tenant text, and for the same reason:
+    the plan has development happening on Windows and production on Lambda, and a checkout
+    that differs by line ending is a prompt that differs by every byte after the first
+    newline.
+    """
+    lines = text.replace("\r\n", "\n").replace("\r", "\n").split("\n")
+    return "\n".join(line.rstrip() for line in lines).strip()
+
+
+@cache
+def rubric_text() -> str:
+    """The rubric instructions, canonicalised — the cacheable half of the system prompt.
+
+    Cached for the life of the process: this is read once per Lambda container, and the
+    identity of the returned string across calls is itself part of the guarantee that the
+    prefix does not move.
+
+    Raises:
+        PromptAssetError: the file is missing, unreadable, or empty once stripped.
+    """
+    try:
+        asset = resources.files(_RUBRIC_PACKAGE).joinpath(RUBRIC_FILENAME)
+        raw = asset.read_text(encoding="utf-8")
+    except (FileNotFoundError, ModuleNotFoundError) as exc:
+        raise PromptAssetError(
+            f"prompt asset '{RUBRIC_FILENAME}' is not packaged with {_RUBRIC_PACKAGE}; "
+            "check [tool.setuptools.package-data] and the build"
+        ) from exc
+    except OSError as exc:
+        raise PromptAssetError(
+            f"prompt asset '{RUBRIC_FILENAME}' could not be read: {exc}"
+        ) from exc
+
+    text = _canonicalise(_HTML_COMMENT.sub("", raw))
+    if not text:
+        raise PromptAssetError(
+            f"prompt asset '{RUBRIC_FILENAME}' is empty once its maintainer header is "
+            "stripped; a request built from it would carry no instructions at all"
+        )
+    return text
+
+
+def build_system_blocks(config: TenantConfig) -> tuple[PromptBlock, PromptBlock]:
+    """The system prompt for one tenant: stable rubric first, tenant block second.
+
+    The order is the whole design. Everything before the breakpoint is shared by every
+    request this service ever makes; everything after it is one customer's policy. Reverse
+    them and the cacheable part sits behind bytes that change per tenant, which caches
+    nothing while still paying the write premium.
+
+    Args:
+        config: the tenant whose ICP block forms the second, varying block.
+
+    Returns:
+        Exactly two blocks, in render order. The first is byte-identical for every tenant.
+
+    Raises:
+        PromptVersionMismatchError: the tenant is pinned to another rubric revision.
+        PromptAssetError: the rubric file is missing or unreadable.
+    """
+    if config.prompt_version != PROMPT_VERSION:
+        raise PromptVersionMismatchError(
+            f"tenant '{config.tenant_id}' is pinned to prompt version "
+            f"'{config.prompt_version}', but this build ships '{PROMPT_VERSION}'; deploy "
+            f"the build that contains '{config.prompt_version}.md' or repin the tenant"
+        )
+    return (
+        PromptBlock(text=rubric_text(), cacheable=True),
+        PromptBlock(text=config.icp_block(), cacheable=False),
+    )
+
+
+def render_system_prompt(config: TenantConfig) -> str:
+    """The same blocks flattened into one string, for evals, review and debugging.
+
+    Not the request path. #11 sends :func:`build_system_blocks` as separate blocks, because
+    a single joined string has nowhere to hang a cache breakpoint and would cost the full
+    input price on every call.
+    """
+    return BLOCK_SEPARATOR.join(block.text for block in build_system_blocks(config))
+
+
+def estimate_tokens(text: str) -> int:
+    """A pessimistic offline lower bound on the token count of ``text``.
+
+    Used to prove — without a network call — that the cacheable prefix clears
+    :data:`MIN_CACHEABLE_PREFIX_TOKENS`. It divides by
+    :data:`CONSERVATIVE_CHARS_PER_TOKEN`, which is above the real average for English
+    prose, so the answer errs towards "too short to cache". That is the safe direction:
+    the failure it guards against is silent.
+    """
+    return len(text) // CONSERVATIVE_CHARS_PER_TOKEN
+
+
+__all__ = [
+    "BLOCK_SEPARATOR",
+    "CONSERVATIVE_CHARS_PER_TOKEN",
+    "MIN_CACHEABLE_PREFIX_TOKENS",
+    "PROMPT_VERSION",
+    "RUBRIC_FILENAME",
+    "PromptAssetError",
+    "PromptBlock",
+    "PromptVersionMismatchError",
+    "build_system_blocks",
+    "estimate_tokens",
+    "render_system_prompt",
+    "rubric_text",
+]

--- a/src/leadquali/prompts/rubric_v1.md
+++ b/src/leadquali/prompts/rubric_v1.md
@@ -1,0 +1,216 @@
+<!--
+rubric_v1 — the stable, tenant-independent half of the qualification system prompt.
+
+VERSIONING RULE, read before editing.
+Every assessment records the prompt_version it was produced under, so that a change in
+quality can be traced back to a change in wording. That only works if a version is
+immutable. Any change to the text below — including a typo fix — ships as a new file,
+rubric_v2.md, with PROMPT_VERSION bumped alongside it in prompts/rubric.py. Never edit
+this file in place; never rename it.
+
+Three further rules, all enforced by tests/unit/test_rubric_prompt.py:
+
+  * No tenant specifics. No company name, no ideal-customer text, no per-customer
+    emphasis. Those arrive in the second system block, from TenantConfig.icp_block().
+    This block must be byte-identical for every tenant or it is not cacheable.
+  * No numerals anywhere in the body. Score ranges live in the assessment schema's own
+    field descriptions and are not restated here, so the rubric has no legitimate use for
+    a digit — which makes "no digits at all" a rule that cannot be got subtly wrong, and
+    makes it impossible for a tier boundary or a confidence gate to leak in.
+  * No policy vocabulary. Tiers, boundaries and what happens to a lead afterwards are the
+    deterministic layer's business. A model that can see the boundary it is measured
+    against starts aiming for it.
+
+This comment is stripped when the file is loaded. The model never sees it.
+-->
+
+# Lead qualification rubric
+
+You assess one inbound web-form submission at a time, on behalf of the business described
+in the tenant profile that follows this rubric. You produce a judgement, not a decision:
+another part of the system reads your assessment and acts on it. Your job is to describe
+what the evidence supports, accurately and without hedging, and to be equally clear about
+what the evidence does not support.
+
+## What counts as evidence
+
+What the person wrote, and the form fields they filled in. That is the whole of it.
+
+You may also use widely known public facts about a company the submission names — that a
+household-name retailer is large, that a well-known regulator exists. Say in `reasoning`
+when a score rests on such an inference rather than on something stated.
+
+You may not use anything else. If a fact is neither stated nor widely known, it is
+missing: it belongs in `missing_information`, never in `extracted`, and never as a quiet
+assumption inside a score.
+
+## How to score a dimension
+
+Score each of the five dimensions independently, within the range the schema gives for it.
+Do not let a strong dimension pull a weak one up, or the reverse — the point of separate
+scores is that they are allowed to disagree.
+
+Within a dimension's range:
+
+- **Bottom** — no evidence at all, or evidence pointing the other way.
+- **Lower middle** — a hint: something indirect, generic, or open to more than one reading.
+- **Upper middle** — clear evidence for part of what the dimension asks about, or good
+  evidence you had to take one inferential step to reach.
+- **Top** — direct, specific, stated evidence for what the dimension asks about, with
+  nothing in the submission arguing against it.
+
+Absence is not contradiction. A submission that says nothing about money scores near the
+bottom of `budget_signal` and earns a line in `missing_information`; a submission that
+says there is no money to spend scores at the floor and needs no such line.
+
+### `icp_fit` — how closely this lead matches the customer profile you were given
+
+Raises it: a company whose industry, size, market and situation line up with the profile;
+a contact whose function is the one the profile describes; a use case the profile was
+plainly written for.
+
+Keeps it low: an individual with no company behind them; a business the profile excludes;
+a market, scale or business model it rules out; a reseller, an agency, a supplier or a job
+seeker approaching for their own purposes rather than as a buyer.
+
+Do not be fooled by: an impressive company that is nonetheless outside the profile. Fit is
+measured against the profile you were given, not against your own sense of a good name. A
+lead that matches part of the profile belongs in the middle, not at either end.
+
+### `intent` — evidence that they are trying to solve this problem now
+
+Raises it: they describe the problem in their own words; they say what they do today and
+why it is not working; they ask about a specific capability, about pricing, about a trial,
+a demonstration or an implementation; they mention comparing alternatives; they refer to a
+project already under way.
+
+Keeps it low: a bare greeting; "please send me more information" with nothing attached;
+research or newsletter curiosity; a student, a job applicant, or somebody pitching you
+their own services.
+
+Do not be fooled by: enthusiasm, politeness or length. A long friendly note with no
+specifics is not intent. Two blunt sentences about a process that is breaking are.
+
+### `authority` — evidence that this contact can buy, or can sponsor a purchase
+
+Raises it: a stated role that owns the budget or the decision for a purchase of this kind;
+the language of ownership — "my team", "we are choosing", "I need to take this to my
+board"; the founder or owner of a small business; somebody convening the people who
+decide.
+
+Keeps it low: no role given at all; a role plainly outside the buying path; a student or
+an intern; somebody gathering information for a person they do not name.
+
+Do not be fooled by: a senior title in an unrelated function, which is not authority over
+this purchase; or a personal email address, which is weak evidence at most and never a
+verdict on its own. Somebody researching openly for a named senior sponsor is real
+authority at one remove — that belongs in the middle, and say so.
+
+### `urgency` — evidence of a deadline, a trigger, or a compelling event
+
+Raises it: a named date or period by which something has to happen; a contract ending; a
+migration, launch, audit, funding round, acquisition, reorganisation or new hire that
+forces the issue; an incident that has just cost them something; a stated consequence of
+not acting.
+
+Keeps it low: "sometime", "eventually", "just looking"; no timing of any kind.
+
+Do not be fooled by: an urgent tone with no cause behind it. "As soon as possible" is a
+preference; a renewal date is a trigger. Keep this separate from `intent`: somebody can
+want a solution badly and have no timetable, and somebody can face a hard deadline while
+still browsing casually.
+
+### `budget_signal` — evidence they can fund a purchase of this size
+
+Raises it: a budget stated, approved, or asked about; a paid tool they are replacing;
+questions about procurement, security review, invoicing or contract terms; a scale of
+company, funding or headcount at which spending of this size is routine.
+
+Keeps it low: asking for a free or discounted option as the opening move; a personal
+project, a pre-revenue idea, or an unfunded team with nothing else to go on; complete
+silence about money.
+
+Do not be fooled by: reading silence as poverty. Most web forms never mention money — that
+is a low score and a line in `missing_information`, not a finding that they cannot pay.
+Company scale is indirect evidence; a sentence about money is direct evidence, and direct
+evidence outranks it.
+
+## Sparse submissions
+
+Most inbound leads are thin. That is normal, and it is nobody's failure.
+
+- **Score what is there.** A thin submission usually produces low scores across several
+  dimensions. That is the correct answer, not an evasion.
+- **Invent nothing.** Do not supply a company that was not named, a title that was not
+  given, a timeline that was not stated, or a budget that was not mentioned. Leave the
+  matching `extracted` field null.
+- **Record what is missing.** Put into `missing_information` the facts that would most
+  change this assessment if you learned them, the most consequential first. If nothing
+  meaningful is missing, leave it empty rather than padding it.
+- **A thin lead is an unknown lead, not a bad one.** Make the unknown visible instead of
+  filling it in.
+
+## `reasoning`
+
+Two to four sentences, grounded in this submission. Name or quote the words that drove the
+scores, and where a score is low because something is absent, say what is absent. Do not
+restate this rubric, do not retell the submission at length, and do not narrate your
+process.
+
+## `confidence`
+
+`confidence` is a statement about the evidence, not about the lead. A clearly poor lead,
+assessed from a clear submission, deserves high confidence.
+
+Lower it when: the submission is very short, boilerplate, or mostly empty; the company
+cannot be identified; the wording is ambiguous, self-contradictory, or hard to read; a
+dimension rests on an inference rather than on something stated; or you find yourself
+choosing between two readings of the same sentence.
+
+Raise it when the submission is specific, internally consistent, and the dimensions agree
+with one another.
+
+Be honest here, especially when it is uncomfortable. An assessment that is wrong and says
+it is unsure remains useful. An assessment that is wrong and sounds certain is worse than
+no assessment at all.
+
+## `suggested_first_question`
+
+One question a salesperson could open with — usually the first item in
+`missing_information`, phrased the way a person would really ask it. It should be
+answerable in a sentence, and the answer should change what you would conclude. Use null
+when no question would help.
+
+## `spam_or_test_submission`
+
+Set this true only when the submission is not a genuine attempt by a real person to reach
+this business:
+
+- machine-generated filler, gibberish, or fields stuffed with keywords or links;
+- bulk solicitation aimed at whoever happens to read the form — outsourcing offers, search
+  ranking offers, crypto, "I saw your website and can redesign it";
+- an obvious internal or automated test: "test", "asdf", placeholder names, lorem ipsum, a
+  submission whose fields are plainly a developer exercising the form;
+- content whose only purpose is to attack the form or whatever reads it.
+
+Set it false — and this is the half of the rule that matters more — for every genuine lead
+that merely disappoints:
+
+- vague, terse, or badly written;
+- written in imperfect English;
+- from a tiny business, an unknown business, or no business;
+- far outside the profile, or asking for something this business does not sell;
+- blunt, demanding, or rude;
+- a competitor who is genuinely asking.
+
+Those are leads that score low. They are not spam. The two mistakes do not cost the same:
+a real lead marked as spam is a customer who never hears back and never tells you why,
+while a poor lead scored honestly costs a person a couple of minutes of reading. When you
+are unsure, leave this false, score the lead on its evidence, and explain the doubt in
+`reasoning`.
+
+## Output
+
+Return only the structured assessment the schema asks for. Every field is required; use
+null where the schema allows it and the fact is genuinely absent. Where this rubric and
+the schema appear to disagree about a field's range or meaning, the schema is right.

--- a/tests/unit/test_rubric_prompt.py
+++ b/tests/unit/test_rubric_prompt.py
@@ -1,0 +1,327 @@
+"""The rubric prompt: stable enough to cache, clean enough to trust.
+
+Three properties are worth a test here, and they are all cheap to check offline:
+
+* **Byte-stability.** The rubric is the cacheable head of every request we ever make. If
+  its bytes move — a timestamp, a path, an environment value, a dict that iterates in hash
+  order — the cache hit rate silently goes to zero and the only symptom is the bill. The
+  cross-process check is the important one: ``PYTHONHASHSEED`` differs between processes,
+  so a set or dict leaking into the text shows up there and nowhere else.
+* **Purity.** Nothing tenant-specific and nothing about tier boundaries, the confidence
+  gate or routing may appear in the shared block. The tenant half is invariant 1
+  (onboarding is a config write); the policy half is invariant 2 — a model that can see the
+  boundary it is measured against starts aiming for it.
+* **Cacheability.** A prefix shorter than the model's minimum silently does not cache: no
+  error, ``cache_creation_input_tokens`` just stays zero. The rubric has to clear that bar.
+
+Nothing here asserts on model prose or calls the API — that is #11.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from leadquali.domain.models import DimensionScores, LeadAssessment
+from leadquali.domain.tenant_config import DEFAULT_PROMPT_VERSION, TenantConfig
+from leadquali.prompts import (
+    BLOCK_SEPARATOR,
+    CONSERVATIVE_CHARS_PER_TOKEN,
+    MIN_CACHEABLE_PREFIX_TOKENS,
+    PROMPT_VERSION,
+    RUBRIC_FILENAME,
+    PromptBlock,
+    PromptVersionMismatchError,
+    build_system_blocks,
+    estimate_tokens,
+    render_system_prompt,
+    rubric_text,
+)
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+MINIMAL: dict[str, Any] = {
+    "tenant_id": "acme",
+    "name": "Acme Corp",
+    "icp_description": "B2B SaaS companies with 50-500 employees in North America.",
+    "routing_rules": {
+        "hot": {"action": "email_sales", "destination": "hot@acme.test"},
+        "warm": {"action": "email_sales", "destination": "sales@acme.test"},
+        "cold": {"action": "email_sales", "destination": "nurture@acme.test"},
+        "disqualified": {"action": "suppress"},
+    },
+}
+
+OTHER: dict[str, Any] = {
+    "tenant_id": "globex",
+    "name": "Globex Industrial",
+    "icp_description": "Mid-market manufacturers replacing a legacy MES in the EU.",
+    "weights": {
+        "authority": 2.5,
+        "budget_signal": 1.0,
+        "icp_fit": 0.5,
+        "intent": 1.0,
+        "urgency": 1.0,
+    },
+    "thresholds": {"hot": 90.0, "warm": 60.0, "cold": 20.0},
+    "min_confidence": 0.8,
+    "routing_rules": MINIMAL["routing_rules"],
+}
+
+
+def packaged_rubric() -> Path:
+    """The rubric file as it sits in the source tree, comments and all."""
+    return REPO_ROOT / "src" / "leadquali" / "prompts" / RUBRIC_FILENAME
+
+
+def make_config(**overrides: Any) -> TenantConfig:
+    """A valid config with only the named fields changed."""
+    return TenantConfig.model_validate({**MINIMAL, **overrides})
+
+
+@pytest.fixture
+def fresh_rubric() -> str:
+    """The rubric, loaded past the process-lifetime cache."""
+    rubric_text.cache_clear()
+    return rubric_text()
+
+
+# --------------------------------------------------------------------------- stability
+
+
+def test_two_loads_are_byte_identical(fresh_rubric: str) -> None:
+    rubric_text.cache_clear()
+    assert rubric_text().encode("utf-8") == fresh_rubric.encode("utf-8")
+
+
+def test_the_environment_does_not_leak_into_the_rubric(
+    fresh_rubric: str, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A prompt that reads its environment is a prompt with a per-host cache entry."""
+    monkeypatch.setenv("LEADQUALI_CANARY", "if-this-appears-the-prefix-is-not-stable")
+    monkeypatch.setenv("TZ", "Pacific/Kiritimati")
+    rubric_text.cache_clear()
+    assert rubric_text() == fresh_rubric
+
+
+def test_the_rubric_is_byte_identical_in_a_separate_process(fresh_rubric: str) -> None:
+    """``PYTHONHASHSEED`` differs per process, so set/dict iteration order shows up here."""
+    src = str(REPO_ROOT / "src")
+    program = (
+        "import sys, hashlib;"
+        f"sys.path.insert(0, {src!r});"
+        "from leadquali.prompts import rubric_text;"
+        "sys.stdout.write(hashlib.sha256(rubric_text().encode('utf-8')).hexdigest())"
+    )
+    completed = subprocess.run(  # noqa: S603 - fixed argv, no shell, no external input
+        [sys.executable, "-c", program],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    import hashlib
+
+    assert completed.stdout == hashlib.sha256(fresh_rubric.encode("utf-8")).hexdigest()
+
+
+def test_nothing_is_interpolated_into_the_rubric(fresh_rubric: str) -> None:
+    """No format placeholders survive: the text is data, not a template."""
+    assert re.search(r"\{[A-Za-z_]+\}", fresh_rubric) is None
+    assert "%s" not in fresh_rubric
+    assert str(REPO_ROOT) not in fresh_rubric
+
+
+def test_maintainer_notes_never_reach_the_model(fresh_rubric: str) -> None:
+    """The versioning rule is documented in the file header, which is stripped at load."""
+    header = packaged_rubric().read_text(encoding="utf-8")
+    assert "VERSIONING RULE" in header, "the file header must document the versioning rule"
+    assert "VERSIONING RULE" not in fresh_rubric
+    assert "<!--" not in fresh_rubric
+    assert "-->" not in fresh_rubric
+
+
+def test_the_rubric_is_canonicalised(fresh_rubric: str) -> None:
+    """CRLF from a Windows checkout would otherwise be a different cache entry."""
+    assert "\r" not in fresh_rubric
+    assert fresh_rubric == fresh_rubric.strip()
+    assert not any(line != line.rstrip() for line in fresh_rubric.split("\n"))
+
+
+# ------------------------------------------------------------------------------ purity
+
+
+#: Policy vocabulary that belongs to the deterministic layer (invariant 2). A model that
+#: can see the tier boundary it is measured against starts aiming for it.
+FORBIDDEN_WORDS = (
+    "hot",
+    "warm",
+    "cold",
+    "tier",
+    "tiers",
+    "threshold",
+    "thresholds",
+    "route",
+    "routed",
+    "routing",
+    "escalate",
+    "escalation",
+    "suppress",
+    "suppressed",
+    "disqualified",
+    "disqualify",
+    "notify",
+    "inbox",
+)
+
+
+@pytest.mark.parametrize("word", FORBIDDEN_WORDS)
+def test_the_rubric_carries_no_policy_vocabulary(fresh_rubric: str, word: str) -> None:
+    assert re.search(rf"\b{word}\b", fresh_rubric, flags=re.IGNORECASE) is None
+
+
+def test_the_rubric_contains_no_numerals(fresh_rubric: str) -> None:
+    """The blunt version of the rule above: no digit can hide a boundary.
+
+    Score ranges live in the assessment schema's own field descriptions and are not
+    restated here, so the rubric has no legitimate use for a numeral — which makes "no
+    digits at all" a rule that cannot be got subtly wrong. 80, 55 and 30 are covered by
+    construction.
+    """
+    offenders = sorted(set(re.findall(r"\d+", fresh_rubric)))
+    assert offenders == [], f"numerals in the rubric: {offenders}"
+
+
+def test_the_rubric_carries_no_tenant_specifics(fresh_rubric: str) -> None:
+    """Everything customer-shaped arrives in the second block, from ``icp_block()``."""
+    for tenant_word in ("Acme", "Globex", "JAT-LeadQuali", "tenant_profile", "@"):
+        assert tenant_word not in fresh_rubric
+
+
+def test_the_rubric_is_the_same_block_for_every_tenant() -> None:
+    first, _ = build_system_blocks(make_config())
+    second, _ = build_system_blocks(TenantConfig.model_validate(OTHER))
+    assert first == second
+    assert first.text == rubric_text()
+
+
+def test_the_rubric_names_every_scored_dimension(fresh_rubric: str) -> None:
+    """Adding a dimension to the schema without documenting it is a silent zero."""
+    for dimension in DimensionScores.model_fields:
+        assert re.search(rf"\b{dimension}\b", fresh_rubric), f"{dimension} is undocumented"
+
+
+def test_the_rubric_covers_the_judgement_fields(fresh_rubric: str) -> None:
+    for field in ("reasoning", "confidence", "missing_information", "spam_or_test_submission"):
+        assert field in LeadAssessment.model_fields
+        assert re.search(rf"\b{field}\b", fresh_rubric), f"{field} is unexplained"
+
+
+def test_the_rubric_separates_spam_from_a_poor_lead(fresh_rubric: str) -> None:
+    """The distinction that costs the most to get wrong is stated explicitly."""
+    spam_section = fresh_rubric.split("spam_or_test_submission")[-1]
+    assert "not spam" in spam_section.lower()
+
+
+# -------------------------------------------------------------------------- assembly
+
+
+def test_the_stable_block_comes_first_and_carries_the_breakpoint() -> None:
+    blocks = build_system_blocks(make_config())
+    assert [block.cacheable for block in blocks] == [True, False]
+    assert blocks[0].text == rubric_text()
+    assert blocks[1].text == make_config().icp_block()
+
+
+def test_at_most_one_breakpoint_is_requested() -> None:
+    """The API allows four; asking for one keeps three free for #11's message blocks."""
+    blocks = build_system_blocks(make_config())
+    assert sum(block.cacheable for block in blocks) == 1
+
+
+def test_blocks_are_values() -> None:
+    block = PromptBlock(text="x", cacheable=True)
+    with pytest.raises(AttributeError):
+        block.text = "y"  # type: ignore[misc]
+
+
+def test_two_tenants_share_an_identical_prefix_and_differ_only_after_it() -> None:
+    one = render_system_prompt(make_config())
+    two = render_system_prompt(TenantConfig.model_validate(OTHER))
+    prefix = rubric_text() + BLOCK_SEPARATOR
+
+    assert one.startswith(prefix)
+    assert two.startswith(prefix)
+    assert one != two
+    # The divergence starts exactly at the end of the shared prefix, not one byte earlier.
+    shared = len(prefix)
+    assert one[:shared] == two[:shared]
+    assert one[shared:] != two[shared:]
+
+
+def test_the_tenant_block_carries_no_policy_numbers() -> None:
+    """#8's promise, restated where it matters: the assembled prompt hides the boundary."""
+    cfg = TenantConfig.model_validate(OTHER)
+    rendered = render_system_prompt(cfg)
+    for hidden in ("90", "60", "20", "0.8"):
+        assert hidden not in rendered
+
+
+def test_a_tenant_pinned_to_another_revision_fails_loudly() -> None:
+    """Recording ``rubric_v2`` beside text that is ``rubric_v1`` corrupts the one
+    measurement the version string exists for."""
+    cfg = make_config(prompt_version="rubric_v2")
+    with pytest.raises(PromptVersionMismatchError) as excinfo:
+        build_system_blocks(cfg)
+    message = str(excinfo.value)
+    assert "acme" in message
+    assert "rubric_v2" in message
+    assert PROMPT_VERSION in message
+
+
+# ----------------------------------------------------------------------- cacheability
+
+
+def test_the_rubric_clears_the_minimum_cacheable_prefix(fresh_rubric: str) -> None:
+    """Below the minimum, ``cache_control`` is a no-op with no error at all.
+
+    The minimum for ``claude-opus-5`` is 512 input tokens (per the ``claude-api`` skill,
+    ``shared/prompt-caching.md`` § API reference — the minimum is model-dependent and *not*
+    monotonic across generations: 512 here, 1024 on Opus 4.8 / Sonnet 5, 2048 on Opus 4.7,
+    4096 on Opus 4.6 / Haiku 4.5). Exact counts need ``messages.count_tokens``, which is an
+    API call; ``estimate_tokens`` is a deliberately pessimistic offline proxy, so clearing
+    the bar here means clearing it for real.
+    """
+    assert estimate_tokens(fresh_rubric) >= MIN_CACHEABLE_PREFIX_TOKENS
+
+
+def test_the_estimate_understates_the_true_token_count() -> None:
+    """The proxy must err towards "not cacheable", never towards a false green test."""
+    assert CONSERVATIVE_CHARS_PER_TOKEN >= 5  # English prose runs nearer four
+    assert estimate_tokens("x" * (CONSERVATIVE_CHARS_PER_TOKEN * 10)) == 10
+    assert estimate_tokens("") == 0
+
+
+def test_the_tenant_block_is_not_counted_towards_the_cacheable_prefix() -> None:
+    """The prefix that must clear the minimum is the rubric alone: it is the only part
+    that is byte-identical across tenants, and therefore the only part worth caching."""
+    blocks = build_system_blocks(make_config())
+    assert estimate_tokens(blocks[0].text) >= MIN_CACHEABLE_PREFIX_TOKENS
+
+
+# --------------------------------------------------------------------------- versioning
+
+
+def test_the_version_is_consistent_everywhere() -> None:
+    assert PROMPT_VERSION == "rubric_v1"
+    assert PROMPT_VERSION == DEFAULT_PROMPT_VERSION
+    assert make_config().prompt_version == PROMPT_VERSION
+    assert f"{PROMPT_VERSION}.md" == RUBRIC_FILENAME
+
+
+def test_the_versioned_file_is_the_one_that_ships() -> None:
+    assert packaged_rubric().is_file()


### PR DESCRIPTION
Closes #10. Based on #49 (TenantConfig). Independent of #9 — different files, so the two can land in either order.

## What landed

- `src/leadquali/prompts/rubric_v1.md` — ~9.7k characters of instructional text: what each of the five dimensions means and what evidence justifies a high vs. low score, how to handle sparse leads (score what is there, put the gaps in `missing_information`, never invent facts), how to use `confidence` honestly, and what counts as `spam_or_test_submission` — with an explicit statement that a vague or unpromising lead is **not** spam, since that distinction is the difference between a lost deal and a wasted ten minutes.
- `leadquali.prompts` — `PROMPT_VERSION`, `rubric_text()`, `build_system_blocks(config)`, `PromptBlock`, `render_system_prompt(config)`, `estimate_tokens()`, `PromptAssetError`, `PromptVersionMismatchError`.

## The design points that matter

**Block order is the cache design.** `build_system_blocks` returns `(rubric, cacheable=True)` then `(tenant icp_block, cacheable=False)`. The rubric is byte-identical for every request and every tenant, so it is the shared cacheable prefix; the tenant block varies and therefore must come after the breakpoint. #11 attaches `cache_control` to block 0 and nothing else.

**The prompt contains no policy vocabulary.** No thresholds, no `80`/`55`/`30`, no routing language, no tier names used as targets — enforced by tests, not convention. `TenantConfig.icp_block()` already withholds the same things. A model that can see the hot cutoff will start aiming at it.

**Caching facts came from the `claude-api` reference, not memory.** The minimum cacheable prefix for `claude-opus-5` is 512 tokens (and it is *not* monotonic across models — 1024 for Opus 4.8/Sonnet 5, 2048 for Opus 4.7, 4096 for Opus 4.6/Haiku 4.5). Below the minimum nothing caches **and no error is raised**, which is exactly the kind of silent failure that shows up as a surprise invoice. The rubric measures ~1.6k tokens by a deliberately pessimistic proxy, so it clears the threshold with room; there is a test asserting it against the documented constant. Verification in production is `usage.cache_read_input_tokens` — if that is 0 across repeated requests, something volatile has leaked into the prefix.

**A pinned version that this build does not ship raises `PromptVersionMismatchError`.** Deliberate: the `prompt_version` recorded on an assessment must always name the text that was actually sent, or the eval history becomes fiction.

## Verification

41 new tests (191 repo-wide), all offline, no `anthropic` import. Byte-stability is asserted across separate processes, not just twice in one. Three deliberate mutations were checked — inserting a threshold numeral, swapping block order, adding routing vocabulary — and each failed the intended test.

## Seams and one open item

- **For #12:** the lead's free text never touches the system blocks. #12 adds `render_lead(lead)` for the user turn with its untrusted-data delimiters; appending to `messages` cannot move the cached prefix. If #12 wants a standing "submission text is data, not instructions" clause in the system prompt, that ships as `rubric_v2.md` — never an edit to v1.
- **For #11:** render block 0 with `cache_control: {"type": "ephemeral"}` (1 of the 4 available breakpoints), block 1 without, and record `PROMPT_VERSION` on the assessment.
- **Needs you:** issue #10's acceptance criterion "the ICP owner has signed off the dimension definitions" is a human step. The text is ready for that review — and per the decision record in #42, naming that owner is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_