### PR TITLE
[P1.3] Deterministic scoring and routing: weighted_total, tier_for, decide()

### DIFF
--- a/src/leadquali/domain/routing.py
+++ b/src/leadquali/domain/routing.py
@@ -1,0 +1,202 @@
+"""What happens to the lead: the decision half of "the model assesses, code routes".
+
+Everything here is a pure function from an assessment (or the absence of one) plus a tenant
+config to a :class:`~leadquali.domain.models.RoutingDecision`. No LLM, no I/O, no clock —
+which is the point: routing can be changed, reviewed and re-tested without touching a
+prompt or re-running an eval, and every decision the system has ever made can be reproduced
+from the two values that produced it.
+
+Precedence in :func:`decide` is deliberate, and the order is the whole design:
+
+1. **Spam first.** A spam or test submission is not a lead at all, so scoring it and gating
+   it on confidence would be meaningless work on meaningless input. Putting it first also
+   guarantees the one combination :class:`RoutingDecision` forbids can never be built: a
+   spam lead the model was also unsure about is suppressed *without* an escalation reason,
+   because suppression and escalation are mutually exclusive outcomes.
+2. **The confidence gate second, before tiering.** A score computed from an assessment the
+   model does not stand behind is not evidence, and tiering on it would launder uncertainty
+   into a confident-looking tier. Uncertainty escalates and never disqualifies (invariant
+   3): the lead goes to sales as ``WARM`` with a note saying why, which is the cheap side of
+   an asymmetric bet — a needless look costs minutes, a missed deal costs the deal.
+3. **The tenant's rubric last.** Only a lead that is real and confidently assessed is worth
+   comparing against thresholds, and then the tenant's own table decides where it goes.
+
+Invariant 3 — "a lead is never silently dropped" — is a statement about *uncertainty*, not
+about low scores, and it is enforced structurally by that precedence. :data:`Action.SUPPRESS`
+is reachable from exactly two places, and nowhere else:
+
+* step 1, an explicit ``spam_or_test_submission`` from the model; and
+* step 3, a confidently-assessed lead whose computed tier the tenant has configured to
+  suppress — the shipped default does this for ``disqualified`` (< 30), which is the whole
+  reason that tier exists.
+
+What is unreachable is suppression by *doubt*. No escalation path can ever suppress or
+disqualify: not the confidence gate, at any score down to zero, and not
+:func:`system_failure` for any reason. Those paths do not consult the tenant's routing
+table at all — a tenant configures what happens to leads it has judged, and a lead the
+system failed to judge has not been judged. ``tests/unit/test_routing.py`` asserts both
+halves as properties over the whole input space, because a lead dropped by a bug produces
+no alert, no bounce and no complaint; it is simply gone.
+
+Neither suppression is silent: both decisions are persisted with the assessment that
+produced them, and both carry a note saying which of the two happened. "The model called it
+spam" and "it scored 11/100 against this tenant's rubric" are completely different answers
+to "why did we never contact this lead?", and #21's metrics have to be able to tell them
+apart.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Final
+
+from leadquali.domain.models import (
+    Action,
+    EscalationReason,
+    LeadAssessment,
+    RoutingDecision,
+    Tier,
+)
+from leadquali.domain.scoring import weighted_total
+from leadquali.domain.tenant_config import TenantConfig
+
+#: Note on a decision reached because the model flagged the submission itself.
+SPAM_NOTE: Final[str] = "suppressed: the model identified this as a spam or test submission"
+
+#: Note on a decision reached through the confidence gate. Plan section 5's wording, kept
+#: verbatim so the phrase a salesperson learns to recognise never drifts.
+LOW_CONFIDENCE_NOTE: Final[str] = "low model confidence — human review"
+
+#: Opening of the note on a lead suppressed by the tenant's own routing table, as opposed
+#: to one the model called spam. The two are distinguishable by prefix on purpose: they are
+#: different answers to "why did we never contact this lead?", and #21 groups on them.
+LOW_SCORE_SUPPRESSION_NOTE: Final[str] = (
+    "suppressed: scored below this tenant's qualification threshold"
+)
+
+#: Opening words of every note produced by :func:`system_failure`. Dependents match on this
+#: prefix rather than on the full sentence.
+SYSTEM_FAILURE_BANNER: Final[str] = "system could not assess"
+
+#: Where a lead goes when there is no assessment at all. ``WARM`` and ``EMAIL_SALES``
+#: because the lead must reach a person who can qualify it by hand, and because the tier a
+#: failed assessment deserves is unknown — never ``DISQUALIFIED``, which would assert a
+#: judgement the system explicitly failed to make.
+SYSTEM_FAILURE_TIER: Final[Tier] = Tier.WARM
+SYSTEM_FAILURE_ACTION: Final[Action] = Action.EMAIL_SALES
+
+#: Why a human is looking at this lead, in words that belong in an email rather than a log
+#: line. Distinct per reason so the recipient knows whether to retry or to escalate.
+_FAILURE_EXPLANATIONS: Final[Mapping[EscalationReason, str]] = {
+    EscalationReason.LOW_CONFIDENCE: "the model was not confident enough to score this lead",
+    EscalationReason.MODEL_REFUSAL: "the model declined to assess this submission",
+    EscalationReason.PARSE_ERROR: "the model's response did not match the expected schema",
+    EscalationReason.API_ERROR: "the assessment service returned an error",
+    EscalationReason.TIMEOUT: "the assessment did not finish in time",
+}
+
+
+def decide(assessment: LeadAssessment, cfg: TenantConfig) -> RoutingDecision:
+    """Turn one assessment into one routing decision, deterministically.
+
+    Precedence — spam, then the confidence gate, then the tenant's rubric — and the reasons
+    for it are documented at module level; they are policy, not implementation detail.
+
+    Args:
+        assessment: What the model said about this lead. Judgement only.
+        cfg: The tenant's weights, thresholds, confidence gate and routing table.
+
+    Returns:
+        A decision carrying the tier, the action, the score it was reached with and a note
+        for whoever receives the lead. :data:`Action.SUPPRESS` appears only via an explicit
+        ``spam_or_test_submission``, or via a confident assessment whose computed tier the
+        tenant configured to suppress. It is unreachable from the confidence gate at any
+        score, and the note says which of the two suppressions happened.
+    """
+    if assessment.spam_or_test_submission:
+        # No score is recorded: nothing was qualified, so a number here would imply a
+        # judgement about a submission we have decided is not a lead.
+        return RoutingDecision(
+            tier=Tier.DISQUALIFIED,
+            action=Action.SUPPRESS,
+            total_score=0.0,
+            note=SPAM_NOTE,
+        )
+
+    total = weighted_total(assessment.dimension_scores, cfg)
+
+    if assessment.confidence < cfg.min_confidence:
+        # The gate is strictly "below": a tenant that sets 0.6 means 0.6 is good enough.
+        # The score is still recorded — it was computed, and the human reviewing the lead
+        # deserves to see what the model's own numbers implied, flagged as unreliable.
+        return RoutingDecision(
+            tier=Tier.WARM,
+            action=Action.EMAIL_SALES,
+            total_score=total,
+            note=LOW_CONFIDENCE_NOTE,
+            escalation_reason=EscalationReason.LOW_CONFIDENCE,
+        )
+
+    tier = cfg.tier_for(total)
+    action = cfg.action_for(tier)
+    if action is Action.SUPPRESS:
+        # The tenant configured this tier to go nowhere, and the assessment behind it was
+        # confident, so this is a judgement rather than a doubt: honour it (invariant 1 —
+        # the routing table is the tenant's, not ours). It is recorded, not dropped, and
+        # the note distinguishes it from a spam suppression.
+        return RoutingDecision(
+            tier=tier,
+            action=action,
+            total_score=total,
+            note=f"{LOW_SCORE_SUPPRESSION_NOTE} ({total:.2f}/100)",
+        )
+
+    return RoutingDecision(
+        tier=tier,
+        action=action,
+        total_score=total,
+        note=f"scored {total:.2f}/100 — {tier.value}",
+    )
+
+
+def system_failure(reason: EscalationReason, detail: str = "") -> RoutingDecision:
+    """The decision for a lead that could never be assessed at all.
+
+    Used by the pipeline (#14) and the LLM adapter (#11) when the model refused, the
+    response would not parse, the API failed or the call timed out. The lead reaches sales
+    unqualified, banner first, so a person qualifies it by hand: a failure of ours must
+    never look like a judgement about the lead, and must never be a dead end.
+
+    Args:
+        reason: Which failure occurred; recorded for grouping in observability.
+        detail: Optional operator-facing specifics (an error class, a retry count).
+            Whitespace is collapsed, since this ends up in an email body. Must not contain
+            PII: notes are stored and displayed (invariant 5).
+
+    Returns:
+        A ``WARM`` / ``EMAIL_SALES`` decision carrying ``reason`` and a score of ``0.0``,
+        because nothing was scored. Never ``DISQUALIFIED`` and never suppressed.
+    """
+    note = f"{SYSTEM_FAILURE_BANNER}: {_FAILURE_EXPLANATIONS[reason]}"
+    collapsed = " ".join(detail.split())
+    if collapsed:
+        note = f"{note} ({collapsed})"
+    return RoutingDecision(
+        tier=SYSTEM_FAILURE_TIER,
+        action=SYSTEM_FAILURE_ACTION,
+        total_score=0.0,
+        note=note,
+        escalation_reason=reason,
+    )
+
+
+__all__ = [
+    "LOW_CONFIDENCE_NOTE",
+    "LOW_SCORE_SUPPRESSION_NOTE",
+    "SPAM_NOTE",
+    "SYSTEM_FAILURE_ACTION",
+    "SYSTEM_FAILURE_BANNER",
+    "SYSTEM_FAILURE_TIER",
+    "decide",
+    "system_failure",
+]

--- a/src/leadquali/domain/scoring.py
+++ b/src/leadquali/domain/scoring.py
@@ -1,0 +1,106 @@
+"""The lead's number: weighted, normalised, rounded once, deterministic forever.
+
+This module is the arithmetic half of invariant 2 — the model assesses, code routes. The
+model hands us five bounded judgments; this turns them into one comparable number on a
+fixed 0-100 scale, using nothing but the tenant's own weights.
+
+Two decisions are worth reading before you change anything here.
+
+**The scale is normalised, not accumulated.** A total is
+``MAX_TOTAL_SCORE * Σ(weight_d * score_d) / cfg.max_weighted_raw``. Dividing by the largest
+weighted raw score the tenant's weights *can* produce is what makes a threshold portable:
+"hot >= 80" means the same thing to a tenant that weights everything at 1.0 and to one that
+multiplies authority by fifty, and a maximal assessment lands on exactly 100.0 for both. If
+totals were merely accumulated, every reweighting would silently move every tier boundary
+and the tenant would have to re-derive its thresholds by hand.
+
+**Rounding happens exactly once, here, to two decimals, half-up.** The rounded value is
+what gets stored, what gets shown to a salesperson, and — crucially — what gets tiered, so
+the number in the email is provably the number that chose the tier. Anything else invites
+the failure this module exists to prevent: a lead displayed as 55.00 against a warm
+threshold of 55.0 but filed as cold because the underlying double was 54.99999999999999.
+Half-up on the *printed* value (via :class:`~decimal.Decimal` on ``repr``) rather than
+:func:`round`'s round-half-to-even on the *binary* value, because a person reading 2.675
+expects 2.68 and cannot see that the double is really 2.67499999999999982236431605997495.
+
+Pure functions over frozen values: no I/O, no clock, no global state. The same assessment
+and the same config produce the same float on every machine, forever, which is what makes
+the eval harness (#23) and the audit trail worth anything.
+
+Boundary with #8: :class:`~leadquali.domain.tenant_config.TenantConfig` owns the policy
+*data* — weights, maxima, thresholds — and the pure lookups over it. This module owns the
+policy *computation* and never reaches for a number that is not in the config.
+"""
+
+from __future__ import annotations
+
+import math
+from decimal import ROUND_HALF_UP, Decimal
+from typing import Final
+
+from leadquali.domain.models import MAX_TOTAL_SCORE, DimensionScores
+from leadquali.domain.tenant_config import DIMENSION_MAXIMA, TenantConfig
+
+#: Decimal places every total is rounded to. Two, because that is enough to keep a
+#: threshold expressible at the granularity a tenant would ever tune it, and few enough
+#: that the stored number and the displayed number are the same string.
+SCORE_DECIMAL_PLACES: Final[int] = 2
+
+_QUANTUM: Final[Decimal] = Decimal(1).scaleb(-SCORE_DECIMAL_PLACES)
+
+#: Iterated in sorted order so the floating-point summation is identical on every run and
+#: every host, independent of dict insertion order in a config file.
+_DIMENSIONS: Final[tuple[str, ...]] = tuple(sorted(DIMENSION_MAXIMA))
+
+
+def round_score(value: float) -> float:
+    """Round a score to :data:`SCORE_DECIMAL_PLACES` places, ties away from zero.
+
+    The rounding is applied to ``repr(value)`` — the shortest decimal string that round-trips
+    to the same double — so the result matches what a human reading the number would expect:
+    ``round_score(2.675) == 2.68``, where ``round(2.675, 2)`` is ``2.67``.
+
+    Args:
+        value: A finite score. Infinities and NaN are a bug upstream, not a score.
+
+    Returns:
+        The rounded value as a float. Already-rounded values are returned unchanged.
+
+    Raises:
+        ValueError: ``value`` is not finite.
+    """
+    if not math.isfinite(value):
+        raise ValueError(f"a score must be a finite number, got {value!r}")
+    return float(Decimal(repr(value)).quantize(_QUANTUM, rounding=ROUND_HALF_UP))
+
+
+def weighted_total(scores: DimensionScores, cfg: TenantConfig) -> float:
+    """The lead's total on the 0-100 scale, under this tenant's weights.
+
+    ``MAX_TOTAL_SCORE * Σ(weight_d * score_d) / cfg.max_weighted_raw``, rounded once by
+    :func:`round_score`. The denominator is positive for every config that validates (#8
+    rejects an all-zero weighting), so there is no division to guard here.
+
+    Summation uses :func:`math.fsum` over the dimensions in sorted order: the result is the
+    correctly-rounded sum regardless of how wildly a tenant's weights differ in magnitude,
+    so a tenant weighting authority at 1e6 and the rest at 1e-5 still gets a stable number
+    rather than one that depends on the order keys happened to land in a JSON file.
+
+    Args:
+        scores: The model's per-dimension judgment.
+        cfg: The tenant whose weights and scale apply.
+
+    Returns:
+        A float in ``[0.0, MAX_TOTAL_SCORE]``, rounded to :data:`SCORE_DECIMAL_PLACES`
+        places. An all-zero assessment scores ``0.0`` and a maximal one scores exactly
+        ``MAX_TOTAL_SCORE`` under any valid weighting.
+    """
+    dumped = scores.model_dump()
+    raw = math.fsum(cfg.weight_for(name) * int(dumped[name]) for name in _DIMENSIONS)
+    normalised = MAX_TOTAL_SCORE * raw / cfg.max_weighted_raw
+    # Clamped, not asserted: the arithmetic can land a maximal assessment a single ulp above
+    # the top of the scale, and RoutingDecision rejects anything above MAX_TOTAL_SCORE.
+    return min(max(round_score(normalised), 0.0), MAX_TOTAL_SCORE)
+
+
+__all__ = ["SCORE_DECIMAL_PLACES", "round_score", "weighted_total"]

--- a/tests/unit/test_routing.py
+++ b/tests/unit/test_routing.py
@@ -1,0 +1,450 @@
+"""Behaviour of ``decide`` — the code half of "the model assesses, code routes".
+
+Written adversarially, because the expensive failure here is silent: a lead that is quietly
+dropped generates no alert, no bounce and no complaint, and the deal is simply lost. The
+last section is invariant 3 as an executable guarantee.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+import pytest
+
+from leadquali.domain.models import (
+    MAX_TOTAL_SCORE,
+    Action,
+    DimensionScores,
+    EscalationReason,
+    ExtractedFacts,
+    LeadAssessment,
+    RoutingDecision,
+    Tier,
+)
+from leadquali.domain.routing import (
+    LOW_CONFIDENCE_NOTE,
+    LOW_SCORE_SUPPRESSION_NOTE,
+    SPAM_NOTE,
+    SYSTEM_FAILURE_BANNER,
+    decide,
+    system_failure,
+)
+from leadquali.domain.scoring import weighted_total
+from leadquali.domain.tenant_config import DIMENSION_MAXIMA, TenantConfig
+
+EMAIL_EVERYTHING: dict[str, Any] = {
+    "hot": {"action": "email_sales", "destination": "hot@acme.test"},
+    "warm": {"action": "email_sales", "destination": "sales@acme.test"},
+    "cold": {"action": "email_sales", "destination": "nurture@acme.test"},
+    "disqualified": {"action": "email_sales", "destination": "audit@acme.test"},
+}
+
+#: The shipped default shape: the bottom tier is suppressed by policy.
+SUPPRESS_THE_BOTTOM: dict[str, Any] = {**EMAIL_EVERYTHING, "disqualified": {"action": "suppress"}}
+
+MINIMAL: dict[str, Any] = {
+    "tenant_id": "acme",
+    "name": "Acme Corp",
+    "icp_description": "B2B SaaS companies with 50-500 employees in North America.",
+    "routing_rules": SUPPRESS_THE_BOTTOM,
+}
+
+NEUTRAL: dict[str, float] = dict.fromkeys(DIMENSION_MAXIMA, 1.0)
+
+
+def make_config(**overrides: Any) -> TenantConfig:
+    """A valid config with only the named fields changed. Neutral weights, plan defaults."""
+    return TenantConfig.model_validate({**MINIMAL, **overrides})
+
+
+def scores(**values: int) -> DimensionScores:
+    return DimensionScores.model_validate({**dict.fromkeys(DIMENSION_MAXIMA, 0), **values})
+
+
+def scoring_to(total: int) -> DimensionScores:
+    """Dimension scores that sum to ``total``; under neutral weights that *is* the total."""
+    remaining = total
+    values: dict[str, int] = {}
+    for name, top in DIMENSION_MAXIMA.items():
+        values[name] = min(top, remaining)
+        remaining -= values[name]
+    assert remaining == 0, f"{total} is above the rubric's maximum"
+    return scores(**values)
+
+
+def make_assessment(**overrides: Any) -> LeadAssessment:
+    base: dict[str, Any] = {
+        "dimension_scores": scores(icp_fit=20, intent=15, authority=10, urgency=8, budget_signal=7),
+        "extracted": ExtractedFacts.model_validate(dict.fromkeys(ExtractedFacts.model_fields)),
+        "reasoning": "Director at a mid-size logistics firm naming a concrete use case.",
+        "confidence": 0.82,
+        "missing_information": [],
+        "suggested_first_question": None,
+        "spam_or_test_submission": False,
+    }
+    return LeadAssessment.model_validate({**base, **overrides})
+
+
+# ------------------------------------------------------------------- 1. spam suppresses
+
+
+def test_spam_is_suppressed_as_disqualified_with_no_escalation_reason() -> None:
+    decision = decide(make_assessment(spam_or_test_submission=True), make_config())
+    assert decision.tier is Tier.DISQUALIFIED
+    assert decision.action is Action.SUPPRESS
+    assert decision.escalation_reason is None
+    assert decision.escalated is False
+    assert decision.total_score == 0.0
+    assert decision.note == SPAM_NOTE
+
+
+def test_spam_beats_a_perfect_score() -> None:
+    decision = decide(
+        make_assessment(
+            spam_or_test_submission=True,
+            dimension_scores=scores(**dict(DIMENSION_MAXIMA)),
+            confidence=1.0,
+        ),
+        make_config(),
+    )
+    assert (decision.tier, decision.action) == (Tier.DISQUALIFIED, Action.SUPPRESS)
+
+
+def test_spam_beats_low_confidence_and_attaches_no_escalation_reason() -> None:
+    """The two top branches can fire on the same lead. Spam wins, and it must not carry an
+    escalation reason: ``RoutingDecision`` forbids escalating and suppressing at once."""
+    decision = decide(
+        make_assessment(spam_or_test_submission=True, confidence=0.0),
+        make_config(min_confidence=0.9),
+    )
+    assert decision.action is Action.SUPPRESS
+    assert decision.escalation_reason is None
+
+
+def test_spam_is_suppressed_even_where_the_tenant_routes_the_bottom_tier_to_sales() -> None:
+    """Suppression is the one product-level exception to invariant 3, not a tenant knob."""
+    decision = decide(
+        make_assessment(spam_or_test_submission=True),
+        make_config(routing_rules=EMAIL_EVERYTHING),
+    )
+    assert (decision.tier, decision.action) == (Tier.DISQUALIFIED, Action.SUPPRESS)
+
+
+# --------------------------------------------------------------- 2. the confidence gate
+
+
+def test_low_confidence_goes_to_sales_as_warm_and_says_why() -> None:
+    assessment = make_assessment(confidence=0.4, dimension_scores=scoring_to(12))
+    decision = decide(assessment, make_config(min_confidence=0.6))
+    assert decision.tier is Tier.WARM
+    assert decision.action is Action.EMAIL_SALES
+    assert decision.escalation_reason is EscalationReason.LOW_CONFIDENCE
+    assert decision.escalated is True
+    assert decision.note == LOW_CONFIDENCE_NOTE
+    assert decision.total_score == 12.0
+
+
+def test_low_confidence_never_disqualifies_however_bad_the_score() -> None:
+    """Uncertainty escalates. A lead the model could not read is not a bad lead."""
+    decision = decide(
+        make_assessment(confidence=0.0, dimension_scores=scores()),
+        make_config(min_confidence=0.6),
+    )
+    assert decision.tier is Tier.WARM
+    assert decision.action is not Action.SUPPRESS
+
+
+def test_low_confidence_also_overrides_a_hot_score() -> None:
+    decision = decide(
+        make_assessment(confidence=0.1, dimension_scores=scoring_to(95)),
+        make_config(min_confidence=0.6),
+    )
+    assert decision.tier is Tier.WARM
+    assert decision.total_score == 95.0
+
+
+def test_confidence_exactly_at_the_threshold_is_trusted() -> None:
+    """The gate is ``confidence < min_confidence``: equality routes on the score.
+
+    Stated as a test because it is the one place a half-open interval is a policy choice —
+    a tenant that sets 0.6 means "0.6 is good enough", not "better than 0.6".
+    """
+    cfg = make_config(min_confidence=0.6)
+    at = decide(make_assessment(confidence=0.6, dimension_scores=scoring_to(90)), cfg)
+    assert at.tier is Tier.HOT
+    assert at.escalation_reason is None
+
+    below = decide(make_assessment(confidence=0.59, dimension_scores=scoring_to(90)), cfg)
+    assert below.tier is Tier.WARM
+    assert below.escalation_reason is EscalationReason.LOW_CONFIDENCE
+
+
+def test_a_tenant_can_switch_the_confidence_gate_off() -> None:
+    decision = decide(
+        make_assessment(confidence=0.0, dimension_scores=scoring_to(90)),
+        make_config(min_confidence=0.0),
+    )
+    assert decision.tier is Tier.HOT
+    assert decision.escalation_reason is None
+
+
+# ------------------------------------------------------------------ 3. scored routing
+
+
+@pytest.mark.parametrize(
+    ("total", "expected"),
+    [
+        (100, Tier.HOT),
+        (81, Tier.HOT),
+        (80, Tier.HOT),
+        (79, Tier.WARM),
+        (56, Tier.WARM),
+        (55, Tier.WARM),
+        (54, Tier.COLD),
+        (31, Tier.COLD),
+        (30, Tier.COLD),
+        (29, Tier.DISQUALIFIED),
+        (0, Tier.DISQUALIFIED),
+    ],
+)
+def test_every_default_threshold_is_inclusive_from_both_sides(total: int, expected: Tier) -> None:
+    decision = decide(make_assessment(dimension_scores=scoring_to(total)), make_config())
+    assert decision.tier is expected
+    assert decision.total_score == float(total)
+
+
+def test_a_total_landing_exactly_on_a_fractional_threshold_tiers_deterministically() -> None:
+    """The rounded score is the score that tiers, so a tenant can set a threshold to a value
+    a lead can actually hit. Raw arithmetic here is 54.5454...; the reported score is 54.55,
+    and a threshold written as 54.55 must be met by it rather than missed by 1e-14."""
+    weights = {**dict.fromkeys(DIMENSION_MAXIMA, 0.0), "icp_fit": 1.0, "intent": 1.0}
+    cfg = make_config(
+        weights=weights,
+        thresholds={"hot": 54.55, "warm": 30.0, "cold": 10.0},
+    )
+    assessment = make_assessment(dimension_scores=scores(icp_fit=30, intent=0))
+    assert weighted_total(assessment.dimension_scores, cfg) == 54.55
+    assert decide(assessment, cfg).tier is Tier.HOT
+
+
+def test_the_action_comes_from_the_tenants_routing_table() -> None:
+    cfg = make_config(
+        routing_rules={
+            **EMAIL_EVERYTHING,
+            "cold": {"action": "escalate_human", "destination": "queue@acme.test"},
+        }
+    )
+    decision = decide(make_assessment(dimension_scores=scoring_to(40)), cfg)
+    assert decision.tier is Tier.COLD
+    assert decision.action is Action.ESCALATE_HUMAN
+    assert decision.escalation_reason is None
+
+
+def test_a_tenant_can_move_its_own_boundaries() -> None:
+    cfg = make_config(thresholds={"hot": 40.0, "warm": 20.0, "cold": 5.0})
+    assert decide(make_assessment(dimension_scores=scoring_to(45)), cfg).tier is Tier.HOT
+    assert decide(make_assessment(dimension_scores=scoring_to(21)), cfg).tier is Tier.WARM
+
+
+def test_a_scored_decision_reports_its_score_in_the_note() -> None:
+    decision = decide(make_assessment(dimension_scores=scoring_to(72)), make_config())
+    assert "72.00" in decision.note
+    assert Tier.WARM.value in decision.note
+
+
+def test_deciding_twice_gives_the_same_answer() -> None:
+    assessment = make_assessment(dimension_scores=scoring_to(63))
+    cfg = make_config()
+    assert decide(assessment, cfg) == decide(assessment, cfg)
+
+
+# ----------------------------------------------------- invariant 3, executably guaranteed
+
+
+def test_a_confidently_low_lead_is_suppressed_when_the_tenant_configured_that() -> None:
+    """The ``disqualified`` tier exists to be suppressible, and the table is the tenant's.
+
+    This is a judgement, not a doubt: the model was confident and the score is real, so
+    honouring ``action_for`` here is invariant 1, not a breach of invariant 3.
+    """
+    decision = decide(make_assessment(dimension_scores=scoring_to(4)), make_config())
+    assert decision.tier is Tier.DISQUALIFIED
+    assert decision.action is Action.SUPPRESS
+    assert decision.total_score == 4.0
+    assert decision.escalation_reason is None
+
+
+def test_a_tenant_can_ask_to_see_its_disqualified_leads_instead() -> None:
+    """Nothing about suppression is hardcoded: the same lead, a different table."""
+    decision = decide(
+        make_assessment(dimension_scores=scoring_to(4)),
+        make_config(routing_rules=EMAIL_EVERYTHING),
+    )
+    assert decision.tier is Tier.DISQUALIFIED
+    assert decision.action is Action.EMAIL_SALES
+
+
+def test_the_two_suppressions_are_told_apart_by_their_notes() -> None:
+    """Spam and a bad score are different answers to "why did we never contact this lead?",
+    and #21 has to be able to group on the difference."""
+    spam = decide(make_assessment(spam_or_test_submission=True), make_config())
+    scored = decide(make_assessment(dimension_scores=scoring_to(4)), make_config())
+
+    assert spam.action is scored.action is Action.SUPPRESS
+    assert spam.note == SPAM_NOTE
+    assert scored.note.startswith(LOW_SCORE_SUPPRESSION_NOTE)
+    assert "4.00" in scored.note
+    assert spam.note != scored.note
+
+
+PATHOLOGICAL: dict[str, Any] = {
+    "hot": {"action": "suppress"},
+    "warm": {"action": "suppress"},
+    "cold": {"action": "suppress"},
+    "disqualified": {"action": "suppress"},
+}
+
+CONFIGS: dict[str, TenantConfig] = {
+    "default_shape": make_config(),
+    "emails_everything": make_config(routing_rules=EMAIL_EVERYTHING),
+    "suppresses_every_tier": make_config(routing_rules=PATHOLOGICAL),
+    "generous_gate": make_config(min_confidence=0.99),
+    "no_gate": make_config(min_confidence=0.0),
+    "lopsided_weights": make_config(
+        weights={**dict.fromkeys(DIMENSION_MAXIMA, 0.01), "authority": 50.0}
+    ),
+    "narrow_bands": make_config(thresholds={"hot": 99.0, "warm": 98.0, "cold": 97.0}),
+    "wide_open": make_config(thresholds={"hot": 3.0, "warm": 2.0, "cold": 1.0}),
+}
+
+
+def _sample_assessments(seed: int, count: int) -> list[LeadAssessment]:
+    rng = random.Random(seed)
+    samples: list[LeadAssessment] = []
+    for _ in range(count):
+        samples.append(
+            make_assessment(
+                dimension_scores=scores(
+                    **{name: rng.randint(0, top) for name, top in DIMENSION_MAXIMA.items()}
+                ),
+                confidence=rng.choice([0.0, 0.59, 0.6, 0.61, 0.99, 1.0, rng.random()]),
+            )
+        )
+    return samples
+
+
+def test_suppression_has_exactly_two_doors_and_no_others() -> None:
+    """Invariant 3, as a property over the whole reachable input space.
+
+    Every tenant shape, every corner of the score space, every position around the
+    confidence gate. A decision may only suppress if the model called it spam, or if the
+    lead was confidently scored into a tier this tenant configured to suppress. Any third
+    route to ``SUPPRESS`` is a lead lost with no alert, no bounce and no complaint.
+    """
+    for cfg in CONFIGS.values():
+        for assessment in _sample_assessments(seed=20260902, count=250):
+            decision = decide(assessment, cfg)
+            assert 0.0 <= decision.total_score <= MAX_TOTAL_SCORE
+            if decision.action is not Action.SUPPRESS:
+                continue
+            spam = assessment.spam_or_test_submission
+            confidently_scored_into_a_suppressed_tier = (
+                assessment.confidence >= cfg.min_confidence
+                and cfg.action_for(cfg.tier_for(weighted_total(assessment.dimension_scores, cfg)))
+                is Action.SUPPRESS
+            )
+            assert spam or confidently_scored_into_a_suppressed_tier, (cfg.tenant_id, decision)
+            assert decision.escalation_reason is None, (cfg.tenant_id, decision)
+
+
+def test_both_doors_to_suppression_actually_open() -> None:
+    """The property above is only worth something if neither door is unreachable."""
+    spam = decide(make_assessment(spam_or_test_submission=True), make_config())
+    scored = decide(make_assessment(dimension_scores=scoring_to(4)), make_config())
+    assert spam.action is Action.SUPPRESS
+    assert scored.action is Action.SUPPRESS
+
+
+GATED = sorted(label for label, cfg in CONFIGS.items() if cfg.min_confidence > 0.0)
+
+
+@pytest.mark.parametrize("label", GATED)
+def test_the_confidence_gate_can_never_suppress_or_disqualify_at_any_score(label: str) -> None:
+    """Doubt is not a judgement. At every reachable total, under every tenant shape —
+    including one that asks for every single tier to be suppressed — a lead the model was
+    not confident about reaches a person."""
+    cfg = CONFIGS[label]
+    for total in range(int(MAX_TOTAL_SCORE) + 1):
+        decision = decide(make_assessment(confidence=0.0, dimension_scores=scoring_to(total)), cfg)
+        assert decision.action is not Action.SUPPRESS, (label, total, decision)
+        assert decision.tier is not Tier.DISQUALIFIED, (label, total, decision)
+        assert decision.action is Action.EMAIL_SALES
+        assert decision.escalation_reason is EscalationReason.LOW_CONFIDENCE
+
+
+@pytest.mark.parametrize("reason", list(EscalationReason))
+def test_no_system_failure_can_suppress_or_disqualify(reason: EscalationReason) -> None:
+    """The other escalation path, held to the same guarantee. A failure of ours must never
+    look like a judgement about the lead, and must never be a dead end."""
+    decision = system_failure(reason)
+    assert decision.action is not Action.SUPPRESS
+    assert decision.tier is not Tier.DISQUALIFIED
+    assert decision.tier.rank >= Tier.WARM.rank
+    assert decision.escalated is True
+
+
+def test_an_explicit_spam_flag_always_suppresses_whatever_else_is_true() -> None:
+    for cfg in CONFIGS.values():
+        for assessment in _sample_assessments(seed=7, count=50):
+            decision = decide(assessment.model_copy(update={"spam_or_test_submission": True}), cfg)
+            assert decision.action is Action.SUPPRESS
+            assert decision.tier is Tier.DISQUALIFIED
+
+
+# ------------------------------------------------------------------- 4. system failures
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        EscalationReason.MODEL_REFUSAL,
+        EscalationReason.PARSE_ERROR,
+        EscalationReason.API_ERROR,
+        EscalationReason.TIMEOUT,
+    ],
+)
+def test_a_system_failure_reaches_sales_unqualified_and_never_disqualified(
+    reason: EscalationReason,
+) -> None:
+    decision = system_failure(reason)
+    assert isinstance(decision, RoutingDecision)
+    assert decision.tier is Tier.WARM
+    assert decision.action is Action.EMAIL_SALES
+    assert decision.escalation_reason is reason
+    assert decision.escalated is True
+    assert decision.total_score == 0.0
+    assert decision.note.startswith(SYSTEM_FAILURE_BANNER)
+
+
+def test_a_system_failure_names_the_reason_in_words_a_person_can_act_on() -> None:
+    notes = {system_failure(reason).note for reason in EscalationReason}
+    assert len(notes) == len(EscalationReason), "each reason needs its own explanation"
+    assert all(note.startswith(SYSTEM_FAILURE_BANNER) for note in notes)
+
+
+def test_a_system_failure_can_carry_an_operator_detail() -> None:
+    decision = system_failure(EscalationReason.API_ERROR, detail="overloaded_error after 3 tries")
+    assert decision.note.startswith(SYSTEM_FAILURE_BANNER)
+    assert "overloaded_error after 3 tries" in decision.note
+
+
+def test_a_system_failure_detail_is_normalised_not_pasted() -> None:
+    """The note goes into an email. A stray newline from an exception message must not."""
+    decision = system_failure(EscalationReason.TIMEOUT, detail="  read timeout\n\nafter 30s  ")
+    assert "\n" not in decision.note
+    assert "read timeout after 30s" in decision.note
+
+
+def test_system_failures_are_deterministic() -> None:
+    assert system_failure(EscalationReason.TIMEOUT) == system_failure(EscalationReason.TIMEOUT)

--- a/tests/unit/test_scoring.py
+++ b/tests/unit/test_scoring.py
@@ -1,0 +1,210 @@
+"""Behaviour of the deterministic weighted score.
+
+The two properties that matter are stated as properties, not as examples: a maximal
+assessment lands on exactly ``MAX_TOTAL_SCORE`` under *any* valid weighting, and a total
+is always a value that can be shown to a human and tiered on without a second rounding.
+"""
+
+from __future__ import annotations
+
+import random
+from typing import Any
+
+import pytest
+
+from leadquali.domain.models import MAX_TOTAL_SCORE, DimensionScores
+from leadquali.domain.scoring import SCORE_DECIMAL_PLACES, round_score, weighted_total
+from leadquali.domain.tenant_config import DIMENSION_MAXIMA, TenantConfig
+
+MINIMAL: dict[str, Any] = {
+    "tenant_id": "acme",
+    "name": "Acme Corp",
+    "icp_description": "B2B SaaS companies with 50-500 employees in North America.",
+    "routing_rules": {
+        "hot": {"action": "email_sales", "destination": "hot@acme.test"},
+        "warm": {"action": "email_sales", "destination": "sales@acme.test"},
+        "cold": {"action": "email_sales", "destination": "nurture@acme.test"},
+        "disqualified": {"action": "suppress"},
+    },
+}
+
+NEUTRAL: dict[str, float] = dict.fromkeys(DIMENSION_MAXIMA, 1.0)
+
+#: Weightings a real tenant might plausibly ask for, plus the ones that break naive
+#: arithmetic: a single dimension carrying everything, weights that are not representable
+#: in binary, and weights eleven orders of magnitude apart.
+WEIGHTINGS: dict[str, dict[str, float]] = {
+    "neutral": NEUTRAL,
+    "authority_heavy": {**NEUTRAL, "authority": 6.0},
+    "icp_only": {**dict.fromkeys(DIMENSION_MAXIMA, 0.0), "icp_fit": 1.0},
+    "lopsided": {
+        "icp_fit": 10.0,
+        "intent": 0.01,
+        "authority": 0.01,
+        "urgency": 0.01,
+        "budget_signal": 0.01,
+    },
+    "inexact_binary": {
+        "icp_fit": 0.1,
+        "intent": 0.2,
+        "authority": 0.3,
+        "urgency": 0.4,
+        "budget_signal": 0.7,
+    },
+    "many_orders_of_magnitude": {
+        "icp_fit": 1e6,
+        "intent": 1e-5,
+        "authority": 1e-5,
+        "urgency": 1e-5,
+        "budget_signal": 1e-5,
+    },
+    "fractional": {
+        "icp_fit": 0.333,
+        "intent": 1.7,
+        "authority": 2.25,
+        "urgency": 0.05,
+        "budget_signal": 9.9,
+    },
+    "two_dimensions": {
+        **dict.fromkeys(DIMENSION_MAXIMA, 0.0),
+        "icp_fit": 1.0,
+        "intent": 1.0,
+    },
+}
+
+
+def make_config(**overrides: Any) -> TenantConfig:
+    """A valid config with only the named fields changed."""
+    return TenantConfig.model_validate({**MINIMAL, **overrides})
+
+
+def scores(**values: int) -> DimensionScores:
+    """Dimension scores, defaulting every dimension not named to zero."""
+    return DimensionScores.model_validate({**dict.fromkeys(DIMENSION_MAXIMA, 0), **values})
+
+
+ZERO = scores()
+MAXIMAL = scores(**dict(DIMENSION_MAXIMA))
+
+
+def plan_formula(cfg: TenantConfig, dimensions: DimensionScores) -> float:
+    """The unrounded formula from plan section 5, spelled out independently."""
+    dumped = dimensions.model_dump()
+    raw = sum(cfg.weights[name] * float(dumped[name]) for name in sorted(DIMENSION_MAXIMA))
+    return MAX_TOTAL_SCORE * raw / cfg.max_weighted_raw
+
+
+# ------------------------------------------------------------------- the two endpoints
+
+
+@pytest.mark.parametrize("label", sorted(WEIGHTINGS))
+def test_an_all_zero_assessment_scores_zero_under_every_weighting(label: str) -> None:
+    assert weighted_total(ZERO, make_config(weights=WEIGHTINGS[label])) == 0.0
+
+
+@pytest.mark.parametrize("label", sorted(WEIGHTINGS))
+def test_a_maximal_assessment_lands_on_exactly_100_under_every_weighting(label: str) -> None:
+    """The scale has to be exact at the top, or no lead could ever reach a hot threshold
+    set at 100 and the number shown to sales would be 99.99999999999999."""
+    total = weighted_total(MAXIMAL, make_config(weights=WEIGHTINGS[label]))
+    assert total == MAX_TOTAL_SCORE
+    assert isinstance(total, float)
+
+
+def test_neutral_weights_make_the_total_the_raw_sum() -> None:
+    """With every multiplier at one the rubric's own 30/25/15/15/15 emphasis is the scale,
+    so the total is simply the sum the model handed us."""
+    cfg = make_config(weights=NEUTRAL)
+    assert weighted_total(scores(icp_fit=20, intent=15, authority=10), cfg) == 45.0
+    assert weighted_total(scores(icp_fit=30, intent=25, authority=15), cfg) == 70.0
+
+
+# ------------------------------------------------------------------------- properties
+
+
+@pytest.mark.parametrize("label", sorted(WEIGHTINGS))
+def test_every_total_stays_on_the_scale_and_is_already_rounded(label: str) -> None:
+    """Fuzzed over the whole score space: the result is always something ``RoutingDecision``
+    accepts (0-100) and always equal to its own rounding, so tiering and display agree."""
+    cfg = make_config(weights=WEIGHTINGS[label])
+    rng = random.Random(20260902)
+    for _ in range(200):
+        sample = scores(**{name: rng.randint(0, top) for name, top in DIMENSION_MAXIMA.items()})
+        total = weighted_total(sample, cfg)
+        assert 0.0 <= total <= MAX_TOTAL_SCORE
+        assert total == round_score(total)
+        assert total == pytest.approx(plan_formula(cfg, sample), abs=0.005)
+
+
+def test_scaling_every_weight_by_the_same_factor_changes_nothing() -> None:
+    """Only the *relative* emphasis is policy. A tenant that writes 3/3/3/3/3 instead of
+    1/1/1/1/1 has said the same thing and must get the same score, to the last bit."""
+    sample = scores(icp_fit=21, intent=9, authority=4, urgency=11, budget_signal=2)
+    base = weighted_total(sample, make_config(weights=NEUTRAL))
+    for factor in (0.5, 3.0, 1000.0):
+        scaled = {name: weight * factor for name, weight in NEUTRAL.items()}
+        assert weighted_total(sample, make_config(weights=scaled)) == base
+
+
+def test_a_zero_weighted_dimension_cannot_move_the_total() -> None:
+    cfg = make_config(weights={**NEUTRAL, "budget_signal": 0.0})
+    baseline = weighted_total(scores(icp_fit=20, budget_signal=0), cfg)
+    assert weighted_total(scores(icp_fit=20, budget_signal=15), cfg) == baseline
+
+
+def test_a_dominant_weight_makes_one_dimension_carry_the_lead() -> None:
+    """A tenant selling to procurement can make authority nearly the whole score, and a
+    perfect lead on that one dimension must come out near the top of the scale."""
+    cfg = make_config(weights={**dict.fromkeys(DIMENSION_MAXIMA, 0.001), "authority": 100.0})
+    authority_only = weighted_total(scores(authority=15), cfg)
+    everything_else = weighted_total(
+        scores(icp_fit=30, intent=25, urgency=15, budget_signal=15), cfg
+    )
+    assert authority_only > 99.0
+    assert everything_else < 1.0
+
+
+@pytest.mark.parametrize("dimension", sorted(DIMENSION_MAXIMA))
+def test_raising_a_positively_weighted_dimension_never_lowers_the_total(dimension: str) -> None:
+    cfg = make_config(weights=WEIGHTINGS["fractional"])
+    previous = -1.0
+    for value in range(DIMENSION_MAXIMA[dimension] + 1):
+        total = weighted_total(scores(**{dimension: value}), cfg)
+        assert total > previous
+        previous = total
+
+
+def test_the_same_input_always_scores_the_same() -> None:
+    cfg = make_config(weights=WEIGHTINGS["inexact_binary"])
+    sample = scores(icp_fit=17, intent=6, authority=15, urgency=1, budget_signal=9)
+    assert len({weighted_total(sample, cfg) for _ in range(50)}) == 1
+
+
+# --------------------------------------------------------------------------- rounding
+
+
+def test_scores_are_rounded_to_two_decimals() -> None:
+    assert SCORE_DECIMAL_PLACES == 2
+    cfg = make_config(weights=WEIGHTINGS["icp_only"])
+    # 100 * 10/30 = 33.3333...
+    assert weighted_total(scores(icp_fit=10), cfg) == 33.33
+    # 100 * 20/30 = 66.6666...
+    assert weighted_total(scores(icp_fit=20), cfg) == 66.67
+
+
+def test_round_score_rounds_half_up_on_the_printed_value() -> None:
+    """Ties go up, and they go up on the number a person would read.
+
+    ``round(2.675, 2)`` is 2.67 because 2.675 is really 2.67499999...; a salesperson told
+    the lead scored 2.675 and then shown 2.67 has been told two different things.
+    """
+    assert round_score(2.675) == 2.68
+    assert round_score(54.545) == 54.55
+    assert round_score(0.125) == 0.13
+    assert round_score(0.0) == 0.0
+    assert round_score(99.999) == 100.0
+
+
+def test_round_score_leaves_an_already_rounded_value_alone() -> None:
+    for value in (0.0, 12.34, 55.0, 79.99, 100.0):
+        assert round_score(value) == value


### PR DESCRIPTION
Closes #9. Based on #49 (TenantConfig). Independent of #51 (rubric prompt) — different files, either order.

This is the code half of "the model assesses, code routes", and the enforcement point for "a lead is never silently dropped". Entirely offline: no network, no cost, no LLM.

## Public API

`leadquali.domain.scoring` — `weighted_total(scores, cfg) -> float`, `round_score(value)`, `SCORE_DECIMAL_PLACES`.
`leadquali.domain.routing` — `decide(assessment, cfg) -> RoutingDecision`, `system_failure(reason, detail="") -> RoutingDecision`, and the note constants (`SPAM_NOTE`, `LOW_CONFIDENCE_NOTE`, `LOW_SCORE_SUPPRESSION_NOTE`, `SYSTEM_FAILURE_BANNER`).

`system_failure()` is the constructor #11 and #14 need for the no-assessment cases — refusal, parse error, API error, timeout. It always returns WARM / EMAIL_SALES with the escalation reason attached, and can never return DISQUALIFIED or SUPPRESS.

## The invariant, stated correctly

An earlier draft of this PR forbade suppression outright. That was wrong, and it is worth saying why, because it looked safer: it made `decide()` override `cfg.action_for(tier)`, which breaks invariant 1 (routing rules are tenant configuration, not code) and makes the `disqualified` tier meaningless — **every** low-scoring lead would have reached a human, which is the flood this product exists to prevent.

The invariant is narrower than "never suppress". It is:

> **Suppression has exactly two doors:** an explicit `spam_or_test_submission`, or a *confident* assessment whose computed tier has a tenant-configured `SUPPRESS` action. Every escalation path — low confidence, and all five `EscalationReason` values — is structurally incapable of reaching it, because neither escalation path consults the routing table at all.

Enforced by four tests, not by a comment:
- a property test over 8 tenant shapes × 250 sampled assessments: if a decision suppresses, it came through one of the two doors and carries no escalation reason;
- the confidence gate, parametrized over every score 0–100 **and** a pathological tenant that suppresses all four tiers, never suppresses or disqualifies;
- every `EscalationReason` through `system_failure()`, likewise;
- and a test that both doors actually open, so the property cannot pass vacuously.

Mutation-checked: pointing `system_failure` at `DISQUALIFIED`, or making the confidence gate consult `cfg.action_for`, each turns these red.

**Neither suppression is silent.** Spam carries `SPAM_NOTE`; a scored suppression carries `"suppressed: scored below this tenant's qualification threshold (4.00/100)"`. #21 can group on the two prefixes — they mean completely different things when someone later asks "why did we never contact this lead?".

## Decisions worth confirming

1. **`weighted_total` returns `float`, not the `int` the issue sketched.** `total_score` is a float and tenant thresholds can be fractional; int totals make a threshold of `55.1` unexpressible. Rounded once, half-up, to 2dp — so the displayed score is the score that tiers, and a boundary value tiers deterministically rather than on floating-point luck.
2. **The confidence gate is strict `<`** — `confidence == min_confidence` routes on score.
3. **Spam wins over everything**, including low confidence, and forces `total_score = 0.0`.

## One thing for #14 and #19

A low-confidence lead routes WARM + EMAIL_SALES *regardless* of the tenant's warm rule. For a tenant that has configured `warm` to suppress, `cfg.destination_for(Tier.WARM)` is then `None` while the action says email. That tenant shape is pathological rather than expected, but **the dispatcher needs a fallback destination for escalations either way** — an escalation with nowhere to go is a dropped lead by another name.

## Verification

88 new tests (238 repo-wide), all four gates green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_