### PR TITLE
[P1.5] Anthropic adapter: structured output, refusal handling, prompt caching

### DIFF
--- a/src/leadquali/adapters/llm_anthropic.py
+++ b/src/leadquali/adapters/llm_anthropic.py
@@ -25,6 +25,29 @@ response body, and it produces
 :attr:`~leadquali.domain.models.EscalationReason.MODEL_REFUSAL` — never a disqualification.
 "The model would not answer" and "this lead is worthless" are different facts.
 
+Making that true is the reason this module calls ``client.messages.create`` and validates
+the JSON itself rather than using the ``client.messages.parse`` helper. ``parse`` is the
+more obvious call and it produces the same request bytes — :data:`OUTPUT_FORMAT` is the
+SDK's own ``transform_schema`` applied to the same model — but it *reads the response
+inside the SDK before returning it*: ``parse_response`` iterates ``response.content`` and
+runs ``TypeAdapter(LeadAssessment).validate_json`` on every text block, with no regard for
+``stop_reason``. Anthropic documents two refusal shapes — the classifier fires before any
+output (empty ``content``, unbilled) or mid-stream after partial output (a prose text
+block, billed). On the second shape ``parse`` raises :class:`pydantic.ValidationError`
+*from the call itself*, so a refusal arrives as a parse error, the ``stop_reason`` gate
+below is never reached, and a billed call goes unmetered. Invariant 3 survives either way
+— both paths escalate and neither scores the lead — but the ``MODEL_REFUSAL`` signal, the
+one that says a safety classifier is firing on our traffic, disappears into the
+parse-error bucket. Hand-rolling one ``model_validate_json`` call is the price of keeping
+it. See ``tests/contract/fixtures/messages_refusal_after_output.json``.
+
+**Every completed call is metered, including the ones that failed.** A ``max_tokens``
+truncation burns the whole 8,000-token output budget and a schema violation burns a
+complete response; both are HTTP 200s that Anthropic charges for. Metering is therefore
+computed once, from the response, before any branch decides what the response *means* —
+the alternative is a plan in which the two most expensive failure modes are the two the
+business cannot see.
+
 **Retries are the SDK's, not ours.** ``anthropic.Anthropic`` already retries connection
 errors, 408, 409, 429 and 5xx with exponential backoff. Wrapping a second loop around it
 multiplies the wall clock and the bill for no gain; see :func:`build_anthropic_client` for
@@ -47,8 +70,9 @@ import anthropic
 import pydantic
 from anthropic.types import (
     CacheControlEphemeralParam,
+    JSONOutputFormatParam,
+    Message,
     MessageParam,
-    ParsedMessage,
     TextBlockParam,
     Usage,
 )
@@ -85,6 +109,23 @@ MAX_TOKENS: Final[int] = 8000
 #: The cache breakpoint marker, applied to the rubric block and to nothing else. Five
 #: minutes is the default TTL and the right one here: leads arrive in bursts behind a form.
 CACHE_CONTROL_EPHEMERAL: Final[CacheControlEphemeralParam] = {"type": "ephemeral"}
+
+#: The structured-output constraint sent on every call, as ``output_config.format``.
+#:
+#: ``anthropic.transform_schema`` is the SDK's own Pydantic-model-to-API-schema conversion —
+#: the exact function ``client.messages.parse(output_format=LeadAssessment)`` applies
+#: internally — so passing the format explicitly changes which SDK entry point we call and
+#: nothing about the bytes on the wire. Using the SDK's converter rather than
+#: ``LeadAssessment.model_json_schema()`` matters: the API rejects several JSON Schema
+#: keywords Pydantic emits (``minimum``/``maximum`` among them, which every dimension score
+#: carries), and ``transform_schema`` is what folds them into descriptions.
+#:
+#: Built once at import: it is a pure function of a frozen model, and rebuilding it per
+#: request would burn the schema walk on every lead for an identical result.
+OUTPUT_FORMAT: Final[JSONOutputFormatParam] = {
+    "type": "json_schema",
+    "schema": anthropic.transform_schema(LeadAssessment),
+}
 
 #: Client defaults. The SDK's own default timeout is 10 minutes, which is far too long for
 #: a worker with a Lambda deadline; two retries is the SDK default and is left alone.
@@ -313,7 +354,19 @@ class AnthropicLeadAssessor:
         def elapsed_ms() -> int:
             return (time.monotonic_ns() - started_ns) // 1_000_000
 
-        def failed(reason: EscalationReason, detail: str) -> AssessmentFailed:
+        def failed(
+            reason: EscalationReason,
+            detail: str,
+            *,
+            metering: CallMetering | None = None,
+        ) -> AssessmentFailed:
+            """One failure value, logged.
+
+            ``metering`` is passed on every path that reached an HTTP 200 and is left
+            ``None`` on the paths where no response — and therefore no bill — exists. A
+            truncation and a schema violation are the two most expensive failures this
+            adapter can have, and they were the two that used to be free to look at.
+            """
             # Tenant id only: never the lead, never the contact (invariant 5).
             logger.warning(
                 "lead assessment failed tenant_id=%s reason=%s detail=%s",
@@ -321,17 +374,21 @@ class AnthropicLeadAssessor:
                 reason.value,
                 detail,
             )
-            return AssessmentFailed(reason=reason, detail=detail, latency_ms=elapsed_ms())
+            return AssessmentFailed(
+                reason=reason,
+                detail=detail,
+                latency_ms=metering.latency_ms if metering is not None else elapsed_ms(),
+                metering=metering,
+            )
 
         messages: list[MessageParam] = [{"role": "user", "content": rendered_lead}]
         try:
-            response: ParsedMessage[LeadAssessment] = self._client.messages.parse(
+            response: Message = self._client.messages.create(
                 model=self._model_id,
                 max_tokens=self._max_tokens,
                 system=self._system_blocks(config),
                 messages=messages,
-                output_format=LeadAssessment,
-                output_config={"effort": self._effort},
+                output_config={"effort": self._effort, "format": OUTPUT_FORMAT},
             )
         # Order matters: APITimeoutError subclasses APIConnectionError and RateLimitError
         # subclasses APIStatusError, so the specific classes have to come first or every
@@ -351,14 +408,6 @@ class AnthropicLeadAssessor:
             # The status only. The response body can echo the submission back, and a lead's
             # free text is PII (invariant 5).
             return failed(EscalationReason.API_ERROR, f"http {exc.status_code} from the API")
-        except pydantic.ValidationError as exc:
-            # The model returned something that is not a valid LeadAssessment. Field paths
-            # only — a validation message quotes the offending input, which is lead text.
-            locations = sorted({".".join(str(part) for part in e["loc"]) for e in exc.errors()})
-            return failed(
-                EscalationReason.PARSE_ERROR,
-                f"response failed schema validation at: {', '.join(locations) or '<root>'}",
-            )
         except (PromptVersionMismatchError, PromptAssetError) as exc:
             # Ours, and therefore safe to quote: it names the tenant and the missing
             # revision. An operator error, but still an escalation — invariant 3 does not
@@ -378,12 +427,18 @@ class AnthropicLeadAssessor:
                 f"unexpected {type(exc).__name__} from the Anthropic adapter",
             )
 
+        # The call completed, so it is billed — whatever the response turns out to mean.
+        # Metering before the branches is what makes "record usage on every call" a
+        # property of the code rather than a promise repeated on each path.
+        metering = self._meter(response.usage, elapsed_ms())
+
         # ---- Refusal first. Nothing below this point may run for a refused response, and
-        # nothing above it has touched `response.content`.
+        # nothing above it — not this method, and deliberately not the SDK either — has
+        # read `response.content`. Branch on `stop_reason`, never on `stop_details`:
+        # `stop_details` is informational and may be null even on a genuine refusal.
         if response.stop_reason == "refusal":
             details = response.stop_details
             category = details.category if details is not None else None
-            metering = self._meter(response.usage, elapsed_ms())
             logger.warning(
                 "model refused tenant_id=%s category=%s",
                 config.tenant_id,
@@ -391,35 +446,51 @@ class AnthropicLeadAssessor:
             )
             return AssessmentFailed(
                 reason=EscalationReason.MODEL_REFUSAL,
+                # The category only. `stop_details.explanation` is prose about the
+                # submission and the refused text block quotes it outright; both are lead
+                # content and neither belongs in an operator log (invariant 5).
                 detail=f"model declined to answer (category={category or 'unspecified'})",
                 latency_ms=metering.latency_ms,
-                # A refusal is a billed HTTP 200. Metering it is the difference between
-                # seeing that cost and not seeing it.
+                # A refusal after partial output is a billed HTTP 200. Metering it is the
+                # difference between seeing that cost and not seeing it.
                 metering=metering,
             )
 
         if response.stop_reason == "max_tokens":
             # Thinking ate the budget before the JSON was finished. Whatever came back is
             # a fragment, not a judgment — treat it as unparseable and raise max_tokens.
+            # The full output budget was spent to produce it, so it is metered.
             return failed(
                 EscalationReason.PARSE_ERROR,
                 f"response truncated at max_tokens={self._max_tokens}",
+                metering=metering,
             )
 
-        assessment = response.parsed_output
-        if assessment is None:
-            # `parse` returns None when no text block carried schema-valid JSON. It should
-            # be unreachable given output_config.format, but "should be" is not a guarantee
-            # we are willing to route a lead on.
+        text = next((block.text for block in response.content if block.type == "text"), None)
+        if text is None:
+            # No text block at all. It should be unreachable given output_config.format,
+            # but "should be" is not a guarantee we are willing to route a lead on.
             return failed(
                 EscalationReason.PARSE_ERROR,
-                f"no structured output in the response (stop_reason={response.stop_reason})",
+                f"no text block in the response (stop_reason={response.stop_reason})",
+                metering=metering,
             )
 
-        return AssessmentSucceeded(
-            assessment=assessment,
-            metering=self._meter(response.usage, elapsed_ms()),
-        )
+        try:
+            assessment = LeadAssessment.model_validate_json(text)
+        except pydantic.ValidationError as exc:
+            # The model returned something that is not a valid LeadAssessment — the case
+            # this handler is named for, now that it can only be reached by one call.
+            # Field paths only: a validation message quotes the offending input, which is
+            # lead text. A complete response was billed to produce it, so it is metered.
+            locations = sorted({".".join(str(part) for part in e["loc"]) for e in exc.errors()})
+            return failed(
+                EscalationReason.PARSE_ERROR,
+                f"response failed schema validation at: {', '.join(locations) or '<root>'}",
+                metering=metering,
+            )
+
+        return AssessmentSucceeded(assessment=assessment, metering=metering)
 
 
 __all__ = [
@@ -429,6 +500,7 @@ __all__ = [
     "DEFAULT_TIMEOUT_SECONDS",
     "MAX_TOKENS",
     "MODEL_ID",
+    "OUTPUT_FORMAT",
     "AnthropicLeadAssessor",
     "TokenPrices",
     "build_anthropic_client",

--- a/src/leadquali/adapters/llm_anthropic.py
+++ b/src/leadquali/adapters/llm_anthropic.py
@@ -1,0 +1,436 @@
+"""The Anthropic adapter: one lead in, one judgment or one typed failure out.
+
+This is the only module in the repository that imports ``anthropic`` (``CLAUDE.md``), and
+that isolation is the reason the rest of the system is testable without a key. Everything
+above it sees :class:`~leadquali.app.ports.LeadAssessorPort` and an
+:data:`~leadquali.app.assessment_result.AssessmentOutcome`.
+
+Four decisions are worth stating, because each one is a place this could quietly go wrong.
+
+**Failures are values, not exceptions.** Invariant 3 of ``CLAUDE.md`` — a lead is never
+silently dropped — is only as strong as its weakest error path. Raising would push the
+enumeration of failure modes onto every caller and make "we lost the lead" the default
+behaviour of a missed ``except``. So every boundary failure is caught here and returned as
+:class:`~leadquali.app.assessment_result.AssessmentFailed` carrying the matching
+:class:`~leadquali.domain.models.EscalationReason`, including a final catch-all for
+exceptions nobody has seen yet. The two failure modes that would actually hurt the business
+are structurally impossible as a result: a failure can never be read as a low score
+(:class:`~leadquali.app.assessment_result.AssessmentFailed` has no ``assessment``
+attribute), and it can never vanish (there is no path that returns nothing).
+
+**A refusal is checked before content is read, and it escalates.** ``stop_reason ==
+"refusal"`` is an HTTP 200 with a safety classifier's verdict attached; an adversarial or
+disturbing form submission can trigger it. The check happens before anything touches the
+response body, and it produces
+:attr:`~leadquali.domain.models.EscalationReason.MODEL_REFUSAL` — never a disqualification.
+"The model would not answer" and "this lead is worthless" are different facts.
+
+**Retries are the SDK's, not ours.** ``anthropic.Anthropic`` already retries connection
+errors, 408, 409, 429 and 5xx with exponential backoff. Wrapping a second loop around it
+multiplies the wall clock and the bill for no gain; see :func:`build_anthropic_client` for
+exactly what that covers and what it does not.
+
+**Prices live in one named constant.** :data:`CLAUDE_OPUS_5_PRICES` is the single place a
+rate change lands, and it is documented with its source and with the standing instruction
+to re-check it against the invoice.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Final
+
+import anthropic
+import pydantic
+from anthropic.types import (
+    CacheControlEphemeralParam,
+    MessageParam,
+    ParsedMessage,
+    TextBlockParam,
+    Usage,
+)
+
+from leadquali.app.assessment_result import (
+    DEFAULT_EFFORT,
+    EFFORT_LEVELS,
+    AssessmentFailed,
+    AssessmentOutcome,
+    AssessmentSucceeded,
+    CallMetering,
+    Effort,
+)
+from leadquali.domain.models import EscalationReason, LeadAssessment
+from leadquali.domain.tenant_config import TenantConfig
+from leadquali.prompts import (
+    PROMPT_VERSION,
+    PromptAssetError,
+    PromptVersionMismatchError,
+    build_system_blocks,
+)
+
+logger = logging.getLogger(__name__)
+
+#: The model the plan specifies (§5). Pinned, never a date-suffixed variant.
+MODEL_ID: Final[str] = "claude-opus-5"
+
+#: Output budget for one call. Thinking is adaptive and on by default on ``claude-opus-5``,
+#: and thinking tokens count against ``max_tokens`` — so this is far larger than the ~600
+#: tokens a :class:`~leadquali.domain.models.LeadAssessment` serialises to. Too small and
+#: the response truncates mid-JSON and the whole call is wasted (plan §5: 8000).
+MAX_TOKENS: Final[int] = 8000
+
+#: The cache breakpoint marker, applied to the rubric block and to nothing else. Five
+#: minutes is the default TTL and the right one here: leads arrive in bursts behind a form.
+CACHE_CONTROL_EPHEMERAL: Final[CacheControlEphemeralParam] = {"type": "ephemeral"}
+
+#: Client defaults. The SDK's own default timeout is 10 minutes, which is far too long for
+#: a worker with a Lambda deadline; two retries is the SDK default and is left alone.
+DEFAULT_TIMEOUT_SECONDS: Final[float] = 120.0
+DEFAULT_MAX_RETRIES: Final[int] = 2
+
+_TOKENS_PER_MTOK: Final[Decimal] = Decimal(1_000_000)
+
+
+@dataclass(frozen=True, slots=True)
+class TokenPrices:
+    """US dollars per million tokens, by how the token was billed."""
+
+    input_usd_per_mtok: Decimal
+    output_usd_per_mtok: Decimal
+    cache_read_usd_per_mtok: Decimal
+    cache_write_usd_per_mtok: Decimal
+
+
+# ---------------------------------------------------------------------------------------
+# PRICES — the one place a rate change lands.
+#
+# Source: the ``claude-api`` skill, § Current Models (cached 2026-06-24): ``claude-opus-5``
+# at $5.00 per MTok input and $25.00 per MTok output, first-party Anthropic API rates. The
+# cache multipliers are from the same skill, ``shared/prompt-caching.md`` § Economics: a
+# cache read costs 0.1x the base input price ($0.50) and a 5-minute-TTL cache write costs
+# 1.25x ($6.25). A 1-hour TTL would be 2x — this adapter only ever writes 5-minute entries.
+#
+# THESE MUST BE RE-CHECKED AGAINST THE ANTHROPIC INVOICE before anyone bills a customer,
+# reports a margin, or sets a price on them. They are a documented snapshot, not a feed:
+# published rates change, partner platforms (Bedrock, Vertex) bill differently, and
+# negotiated or committed-use rates differ again. The number this module computes is an
+# estimate of the invoice, and the invoice wins.
+# ---------------------------------------------------------------------------------------
+CLAUDE_OPUS_5_PRICES: Final[TokenPrices] = TokenPrices(
+    input_usd_per_mtok=Decimal("5.00"),
+    output_usd_per_mtok=Decimal("25.00"),
+    cache_read_usd_per_mtok=Decimal("0.50"),
+    cache_write_usd_per_mtok=Decimal("6.25"),
+)
+
+
+def token_cost_usd(
+    *,
+    input_tokens: int,
+    output_tokens: int,
+    cache_read_tokens: int,
+    cache_creation_tokens: int,
+    prices: TokenPrices = CLAUDE_OPUS_5_PRICES,
+) -> Decimal:
+    """Cost of one call in US dollars, from its four token counters.
+
+    Exact decimal arithmetic throughout: these values are summed per tenant for usage
+    billing, and binary floating point drifts in exactly the direction that produces an
+    invoice nobody can reconcile. The four counters are disjoint — ``usage.input_tokens``
+    from the API already excludes the cached ones — so this is a plain weighted sum, taken
+    with a single division so no intermediate rounding creeps in.
+
+    Args:
+        input_tokens: uncached input tokens, billed at the full input rate.
+        output_tokens: output tokens, thinking included.
+        cache_read_tokens: prefix tokens served from cache.
+        cache_creation_tokens: prefix tokens written to cache.
+        prices: the rate card to apply; defaults to :data:`CLAUDE_OPUS_5_PRICES`.
+
+    Returns:
+        The cost, unrounded. Rounding is the biller's decision, not this function's.
+    """
+    micro_dollars = (
+        Decimal(input_tokens) * prices.input_usd_per_mtok
+        + Decimal(output_tokens) * prices.output_usd_per_mtok
+        + Decimal(cache_read_tokens) * prices.cache_read_usd_per_mtok
+        + Decimal(cache_creation_tokens) * prices.cache_write_usd_per_mtok
+    )
+    return micro_dollars / _TOKENS_PER_MTOK
+
+
+def build_anthropic_client(
+    api_key: str,
+    *,
+    timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+    max_retries: int = DEFAULT_MAX_RETRIES,
+) -> anthropic.Anthropic:
+    """A configured SDK client, with the retry policy stated where it can be read.
+
+    **What the SDK's built-in retries cover** (source: the ``claude-api`` skill, § Client
+    config): connection errors and HTTP 408, 409, 429 and >=500, retried with exponential
+    backoff, ``max_retries`` times. That is the entire transient-failure surface of this
+    call, which is why there is no retry loop in this module. A second loop layered on top
+    would multiply both the wall clock and the bill, and would retry things the SDK already
+    decided were not worth retrying.
+
+    **What it does not cover, and what therefore reaches :meth:`AnthropicLeadAssessor.assess`
+    as a first and final answer:** 400/401/403/404 (a bad request or a bad key does not get
+    better by being asked twice); ``stop_reason == "refusal"``, which is a successful HTTP
+    200 the SDK has no reason to touch; and a schema-validation failure of the returned
+    JSON. Each of those maps to an :class:`~leadquali.domain.models.EscalationReason`.
+
+    **Budget for the worst case.** Timeouts *are* retried, so total wall clock can reach
+    ``timeout_seconds x (max_retries + 1)`` — ~6 minutes at the defaults. A worker running
+    under a shorter deadline must lower one of the two rather than discover this in
+    production.
+
+    Args:
+        api_key: from :meth:`leadquali.config.Settings.require_anthropic_api_key`. Never a
+            literal, and never logged.
+        timeout_seconds: per-attempt request timeout.
+        max_retries: SDK retry attempts after the first.
+    """
+    return anthropic.Anthropic(
+        api_key=api_key,
+        timeout=timeout_seconds,
+        max_retries=max_retries,
+    )
+
+
+class AnthropicLeadAssessor:
+    """Implements :class:`~leadquali.app.ports.LeadAssessorPort` against the Claude API.
+
+    Stateless and cheap to construct, so a Lambda container builds one per cold start and
+    reuses it; the SDK client it wraps owns the connection pool and is the expensive part.
+
+    ``effort`` is a constructor parameter rather than a constant because #24 sweeps ``low``
+    / ``medium`` / ``high`` against the golden set to find the cheapest level that holds
+    accuracy. Sweeping by construction rather than by call argument keeps it off the port's
+    signature: effort is a property of how this assessor is configured, not of the lead.
+    """
+
+    def __init__(
+        self,
+        client: anthropic.Anthropic,
+        *,
+        effort: Effort = DEFAULT_EFFORT,
+        model_id: str = MODEL_ID,
+        max_tokens: int = MAX_TOKENS,
+        prices: TokenPrices = CLAUDE_OPUS_5_PRICES,
+    ) -> None:
+        """Configure an assessor.
+
+        Args:
+            client: an SDK client, usually from :func:`build_anthropic_client`. Injected so
+                the whole adapter is exercisable offline against a stub or a mock transport.
+            effort: ``output_config.effort`` for every call this assessor makes.
+            model_id: the model string; overridable only so an eval can pin a comparison.
+            max_tokens: output budget, thinking included.
+            prices: rate card used for :attr:`CallMetering.cost_usd`.
+
+        Raises:
+            ValueError: ``effort`` is not one of
+                :data:`~leadquali.app.assessment_result.EFFORT_LEVELS`.
+        """
+        if effort not in EFFORT_LEVELS:
+            raise ValueError(
+                f"unknown effort {effort!r}; claude-opus-5 accepts {', '.join(EFFORT_LEVELS)}"
+            )
+        self._client = client
+        self._effort: Effort = effort
+        self._model_id = model_id
+        self._max_tokens = max_tokens
+        self._prices = prices
+
+    # ------------------------------------------------------------------- the request
+
+    def _system_blocks(self, config: TenantConfig) -> list[TextBlockParam]:
+        """Render #10's two prompt blocks into SDK system blocks, breakpoint on block 0.
+
+        Block 0 is the rubric: byte-identical for every tenant and every request, so it is
+        the only thing worth caching. Block 1 is the tenant's ICP text, which varies per
+        customer — a breakpoint there would buy nothing and still pay the 1.25x write
+        premium on the first request of every tenant.
+        """
+        rubric, tenant = build_system_blocks(config)
+        return [
+            {"type": "text", "text": rubric.text, "cache_control": CACHE_CONTROL_EPHEMERAL},
+            {"type": "text", "text": tenant.text},
+        ]
+
+    def _meter(self, usage: Usage, latency_ms: int) -> CallMetering:
+        """Turn the response's usage block into a stored metering row.
+
+        Both cache counters are ``Optional`` on the SDK type and absent on a response that
+        used no caching, so they are coerced to zero here rather than at four later call
+        sites — a ``None`` reaching the cost arithmetic would be a crash on the cheapest
+        possible request.
+        """
+        input_tokens = usage.input_tokens
+        output_tokens = usage.output_tokens
+        cache_read = usage.cache_read_input_tokens or 0
+        cache_creation = usage.cache_creation_input_tokens or 0
+        return CallMetering(
+            model_id=self._model_id,
+            prompt_version=PROMPT_VERSION,
+            effort=self._effort,
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=cache_read,
+            cache_creation_tokens=cache_creation,
+            cost_usd=token_cost_usd(
+                input_tokens=input_tokens,
+                output_tokens=output_tokens,
+                cache_read_tokens=cache_read,
+                cache_creation_tokens=cache_creation,
+                prices=self._prices,
+            ),
+            latency_ms=latency_ms,
+        )
+
+    # -------------------------------------------------------------------- the call
+
+    def assess(self, *, config: TenantConfig, rendered_lead: str) -> AssessmentOutcome:
+        """Assess one lead. Never raises for a failure of the model or the API.
+
+        Args:
+            config: the tenant whose ICP block and prompt version this call is made under.
+            rendered_lead: #12's rendered user turn, already wrapped in untrusted-data
+                delimiters. Sent verbatim as a user message and never as a system block —
+                it is attacker-controlled text from a public form, and putting it in the
+                system prompt would both invite injection and destroy the cache prefix.
+
+        Returns:
+            :class:`~leadquali.app.assessment_result.AssessmentSucceeded` or
+            :class:`~leadquali.app.assessment_result.AssessmentFailed`.
+        """
+        started_ns = time.monotonic_ns()
+
+        def elapsed_ms() -> int:
+            return (time.monotonic_ns() - started_ns) // 1_000_000
+
+        def failed(reason: EscalationReason, detail: str) -> AssessmentFailed:
+            # Tenant id only: never the lead, never the contact (invariant 5).
+            logger.warning(
+                "lead assessment failed tenant_id=%s reason=%s detail=%s",
+                config.tenant_id,
+                reason.value,
+                detail,
+            )
+            return AssessmentFailed(reason=reason, detail=detail, latency_ms=elapsed_ms())
+
+        messages: list[MessageParam] = [{"role": "user", "content": rendered_lead}]
+        try:
+            response: ParsedMessage[LeadAssessment] = self._client.messages.parse(
+                model=self._model_id,
+                max_tokens=self._max_tokens,
+                system=self._system_blocks(config),
+                messages=messages,
+                output_format=LeadAssessment,
+                output_config={"effort": self._effort},
+            )
+        # Order matters: APITimeoutError subclasses APIConnectionError and RateLimitError
+        # subclasses APIStatusError, so the specific classes have to come first or every
+        # timeout would be filed as a generic API error and the one signal that says "the
+        # model is thinking for too long at this effort level" would never move.
+        except anthropic.APITimeoutError:
+            return failed(
+                EscalationReason.TIMEOUT,
+                f"request timed out after {DEFAULT_MAX_RETRIES + 1} attempt(s)",
+            )
+        except anthropic.APIConnectionError as exc:
+            return failed(EscalationReason.API_ERROR, f"connection error: {type(exc).__name__}")
+        except anthropic.RateLimitError:
+            # Already retried with backoff by the SDK; arriving here means it kept failing.
+            return failed(EscalationReason.API_ERROR, "rate limited (429) after SDK retries")
+        except anthropic.APIStatusError as exc:
+            # The status only. The response body can echo the submission back, and a lead's
+            # free text is PII (invariant 5).
+            return failed(EscalationReason.API_ERROR, f"http {exc.status_code} from the API")
+        except pydantic.ValidationError as exc:
+            # The model returned something that is not a valid LeadAssessment. Field paths
+            # only — a validation message quotes the offending input, which is lead text.
+            locations = sorted({".".join(str(part) for part in e["loc"]) for e in exc.errors()})
+            return failed(
+                EscalationReason.PARSE_ERROR,
+                f"response failed schema validation at: {', '.join(locations) or '<root>'}",
+            )
+        except (PromptVersionMismatchError, PromptAssetError) as exc:
+            # Ours, and therefore safe to quote: it names the tenant and the missing
+            # revision. An operator error, but still an escalation — invariant 3 does not
+            # make an exception for our own misconfiguration.
+            return failed(EscalationReason.API_ERROR, f"{type(exc).__name__}: {exc}")
+        except anthropic.AnthropicError as exc:
+            return failed(EscalationReason.API_ERROR, f"sdk error: {type(exc).__name__}")
+        except Exception as exc:
+            # The backstop that makes invariant 3 true rather than aspirational. Anything
+            # unforeseen here would otherwise propagate out of the worker and the lead
+            # would be lost, which is strictly worse than a needless human review. The
+            # traceback goes to the log; the message does not go into `detail`, because an
+            # arbitrary exception's text may contain the payload.
+            logger.exception("unexpected error assessing lead tenant_id=%s", config.tenant_id)
+            return failed(
+                EscalationReason.API_ERROR,
+                f"unexpected {type(exc).__name__} from the Anthropic adapter",
+            )
+
+        # ---- Refusal first. Nothing below this point may run for a refused response, and
+        # nothing above it has touched `response.content`.
+        if response.stop_reason == "refusal":
+            details = response.stop_details
+            category = details.category if details is not None else None
+            metering = self._meter(response.usage, elapsed_ms())
+            logger.warning(
+                "model refused tenant_id=%s category=%s",
+                config.tenant_id,
+                category,
+            )
+            return AssessmentFailed(
+                reason=EscalationReason.MODEL_REFUSAL,
+                detail=f"model declined to answer (category={category or 'unspecified'})",
+                latency_ms=metering.latency_ms,
+                # A refusal is a billed HTTP 200. Metering it is the difference between
+                # seeing that cost and not seeing it.
+                metering=metering,
+            )
+
+        if response.stop_reason == "max_tokens":
+            # Thinking ate the budget before the JSON was finished. Whatever came back is
+            # a fragment, not a judgment — treat it as unparseable and raise max_tokens.
+            return failed(
+                EscalationReason.PARSE_ERROR,
+                f"response truncated at max_tokens={self._max_tokens}",
+            )
+
+        assessment = response.parsed_output
+        if assessment is None:
+            # `parse` returns None when no text block carried schema-valid JSON. It should
+            # be unreachable given output_config.format, but "should be" is not a guarantee
+            # we are willing to route a lead on.
+            return failed(
+                EscalationReason.PARSE_ERROR,
+                f"no structured output in the response (stop_reason={response.stop_reason})",
+            )
+
+        return AssessmentSucceeded(
+            assessment=assessment,
+            metering=self._meter(response.usage, elapsed_ms()),
+        )
+
+
+__all__ = [
+    "CACHE_CONTROL_EPHEMERAL",
+    "CLAUDE_OPUS_5_PRICES",
+    "DEFAULT_MAX_RETRIES",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "MAX_TOKENS",
+    "MODEL_ID",
+    "AnthropicLeadAssessor",
+    "TokenPrices",
+    "build_anthropic_client",
+    "token_cost_usd",
+]

--- a/src/leadquali/app/assessment_result.py
+++ b/src/leadquali/app/assessment_result.py
@@ -22,7 +22,9 @@ policy is #9's. The adapter's job stops at "here is what happened at the API bou
 next to the judgment. Returning them together means #13 stores one value and per-tenant
 usage billing is a ``SUM``, not a later migration. Failures carry metering too whenever the
 call was billed — a refusal is an HTTP 200 and Anthropic charges for it, so a refusal that
-was not metered is money the business cannot see.
+was not metered is money the business cannot see. The same argument applies with more force
+to a truncation and a schema violation, which burn a whole output budget rather than a few
+tokens: every path that got a response records what it cost.
 
 No I/O and no SDK types: ``adapters`` fills this in, ``app`` and ``domain`` read it.
 """
@@ -127,7 +129,13 @@ class AssessmentFailed:
 
     latency_ms: int
     metering: CallMetering | None = None
-    """Present when the call was billed (a refusal); ``None`` when it never completed."""
+    """Present whenever a response came back; ``None`` when the call never completed.
+
+    Every HTTP 200 is metered, whatever it turned out to mean — a refusal, a ``max_tokens``
+    truncation and a schema violation are all billed, and the last two are billed at the
+    full output budget. ``None`` therefore means "no response, no bill": a timeout, a
+    connection error, a 4xx/5xx, or a misconfiguration caught before the call was made.
+    """
 
     ok: Literal[False] = False
 

--- a/src/leadquali/app/assessment_result.py
+++ b/src/leadquali/app/assessment_result.py
@@ -1,0 +1,147 @@
+"""What an assessment attempt produced: the judgment, or the reason there isn't one.
+
+This is the return type of :class:`~leadquali.app.ports.LeadAssessorPort`, and it is a
+closed union of exactly two frozen values — :class:`AssessmentSucceeded` and
+:class:`AssessmentFailed`. That shape is deliberate and it is load-bearing.
+
+**Why a result type rather than an exception.** Invariant 3 of ``CLAUDE.md`` says a lead is
+never silently dropped: a refusal, a timeout, a 503 and a schema violation are all *normal,
+expected* outcomes of qualifying inbound web-form leads, and each one has to reach a human
+carrying the reason it happened. An exception makes that the caller's problem — and a
+caller that forgets one ``except`` turns a lost lead into a stack trace in CloudWatch. A
+union makes the failure branch unavoidable instead: a failure has no ``assessment``
+attribute, so there is no way to accidentally read a score off one. The pipeline (#14) maps
+:attr:`AssessmentFailed.reason` through ``domain.routing.system_failure`` and gets a
+``RoutingDecision`` that escalates.
+
+**Why the adapter does not build the RoutingDecision itself.** Routing is policy, and
+policy is #9's. The adapter's job stops at "here is what happened at the API boundary".
+
+**Why metering rides along.** The ``assessments`` table (plan §4) records ``model_id``,
+``prompt_version``, ``effort``, the four token counters, ``cost_usd`` and ``latency_ms``
+next to the judgment. Returning them together means #13 stores one value and per-tenant
+usage billing is a ``SUM``, not a later migration. Failures carry metering too whenever the
+call was billed — a refusal is an HTTP 200 and Anthropic charges for it, so a refusal that
+was not metered is money the business cannot see.
+
+No I/O and no SDK types: ``adapters`` fills this in, ``app`` and ``domain`` read it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from decimal import Decimal
+from typing import Final, Literal
+
+from leadquali.domain.models import EscalationReason, LeadAssessment
+
+#: Thinking depth and overall token spend for one call. Source: the ``claude-api`` skill,
+#: § Thinking & Effort — ``claude-opus-5`` accepts all five levels.
+type Effort = Literal["low", "medium", "high", "xhigh", "max"]
+
+#: The accepted levels, in ascending order of spend. Kept as data so #24's sweep can
+#: iterate them instead of restating them.
+EFFORT_LEVELS: Final[tuple[Effort, ...]] = ("low", "medium", "high", "xhigh", "max")
+
+#: The documented starting point (plan §5). Not a tuning result: #24 sweeps ``low`` /
+#: ``medium`` / ``high`` against the golden set and picks the cheapest level that holds
+#: accuracy, which is a measurement, and this constant moves when that measurement lands.
+DEFAULT_EFFORT: Final[Effort] = "medium"
+
+
+@dataclass(frozen=True, slots=True)
+class CallMetering:
+    """Everything the ``assessments`` row records about *how* an answer was obtained.
+
+    Provenance (``model_id``, ``prompt_version``, ``effort``) is what makes "did last
+    Tuesday's prompt change make things worse?" and "is ``medium`` still good enough?"
+    answerable questions rather than opinions. The token counters are kept separate rather
+    than pre-summed because they are billed at four different rates, and because
+    ``cache_read_tokens`` sitting at zero across a day is the only visible symptom of a
+    broken cache prefix.
+    """
+
+    model_id: str
+    """The exact model string sent, e.g. ``claude-opus-5``."""
+
+    prompt_version: str
+    """The rubric revision that produced this call, e.g. ``rubric_v1``."""
+
+    effort: Effort
+    """The ``output_config.effort`` level the call was made at."""
+
+    input_tokens: int
+    """Uncached input tokens, billed at the full input rate."""
+
+    output_tokens: int
+    """Output tokens, including thinking tokens, billed at the output rate."""
+
+    cache_read_tokens: int
+    """Prefix tokens served from cache, billed at 0.1x the input rate."""
+
+    cache_creation_tokens: int
+    """Prefix tokens written to cache, billed at 1.25x the input rate (5-minute TTL)."""
+
+    cost_usd: Decimal
+    """Computed cost of this one call. ``Decimal`` because it is summed for billing."""
+
+    latency_ms: int
+    """Wall-clock time for the whole attempt, retries included."""
+
+    @property
+    def total_input_tokens(self) -> int:
+        """Every input token the request consumed, however it was billed."""
+        return self.input_tokens + self.cache_read_tokens + self.cache_creation_tokens
+
+
+@dataclass(frozen=True, slots=True)
+class AssessmentSucceeded:
+    """The model returned a schema-valid assessment. Judgment only — no tier, no score."""
+
+    assessment: LeadAssessment
+    metering: CallMetering
+    ok: Literal[True] = True
+    """Discriminator. ``isinstance`` narrows too; this is for readability at call sites."""
+
+
+@dataclass(frozen=True, slots=True)
+class AssessmentFailed:
+    """No assessment exists, and this says why — in the vocabulary routing understands.
+
+    ``reason`` is one of the four boundary failures the adapter can observe:
+    :attr:`~leadquali.domain.models.EscalationReason.MODEL_REFUSAL`,
+    :attr:`~leadquali.domain.models.EscalationReason.PARSE_ERROR`,
+    :attr:`~leadquali.domain.models.EscalationReason.API_ERROR` and
+    :attr:`~leadquali.domain.models.EscalationReason.TIMEOUT`. It is never
+    ``LOW_CONFIDENCE`` — that is a judgement about a *successful* assessment and belongs to
+    #9, not to the API boundary.
+
+    Every one of them escalates to a human. None of them is ever a disqualification: "the
+    model would not answer" and "this lead is worthless" are different facts, and conflating
+    them loses real deals.
+    """
+
+    reason: EscalationReason
+    detail: str
+    """One short, PII-free line for the operator: the exception class, status or category."""
+
+    latency_ms: int
+    metering: CallMetering | None = None
+    """Present when the call was billed (a refusal); ``None`` when it never completed."""
+
+    ok: Literal[False] = False
+
+
+#: What the port returns. Exhaustive: there is no third state and no ``None``.
+type AssessmentOutcome = AssessmentSucceeded | AssessmentFailed
+
+
+__all__ = [
+    "DEFAULT_EFFORT",
+    "EFFORT_LEVELS",
+    "AssessmentFailed",
+    "AssessmentOutcome",
+    "AssessmentSucceeded",
+    "CallMetering",
+    "Effort",
+]

--- a/src/leadquali/app/ports.py
+++ b/src/leadquali/app/ports.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 from typing import Protocol, runtime_checkable
 
+from leadquali.app.assessment_result import AssessmentOutcome
 from leadquali.domain.tenant_config import TenantConfig
 
 
@@ -32,3 +33,46 @@ class TenantConfigPort(Protocol):
             TenantConfigError: a configuration exists but is invalid or unreadable.
         """
         ...
+
+
+@runtime_checkable
+class LeadAssessorPort(Protocol):
+    """Turns one rendered lead into a judgment, or into the reason there isn't one.
+
+    The whole point of this port is that ``app/qualify.py`` (#14) never sees the Anthropic
+    SDK: it holds a ``LeadAssessorPort``, gets an
+    :data:`~leadquali.app.assessment_result.AssessmentOutcome`, and routes on it. Swapping
+    the model, the provider, or a recorded-response double for the eval harness is a wiring
+    change at the entrypoint.
+
+    Implementations **do not raise** for the failure modes of talking to a model. A refusal,
+    a timeout, a rate limit, a 5xx and a schema violation all come back as
+    :class:`~leadquali.app.assessment_result.AssessmentFailed` carrying the matching
+    :class:`~leadquali.domain.models.EscalationReason`, because invariant 3 says every one
+    of them has to reach a human rather than becoming a stack trace or, far worse, a low
+    score. Only a programming error should ever escape.
+
+    ``effort`` is deliberately absent from this signature: it is a property of the
+    configured assessor, not of a lead, so #24 sweeps it by constructing assessors rather
+    than by threading a parameter through the pipeline.
+    """
+
+    def assess(self, *, config: TenantConfig, rendered_lead: str) -> AssessmentOutcome:
+        """Assess one lead against one tenant's profile.
+
+        Args:
+            config: the tenant whose ICP and prompt version this call is made under.
+            rendered_lead: the lead as the user turn — already rendered and wrapped in
+                untrusted-data delimiters by #12. Implementations send it verbatim as a
+                user message and never as a system block: it is attacker-controlled text
+                from a public form, and it must stay outside the cached prefix.
+
+        Returns:
+            :class:`~leadquali.app.assessment_result.AssessmentSucceeded` with a validated
+            assessment and its metering, or
+            :class:`~leadquali.app.assessment_result.AssessmentFailed` with the reason.
+        """
+        ...
+
+
+__all__ = ["LeadAssessorPort", "TenantConfigPort"]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,25 @@
+"""Suite-wide collection rules.
+
+``live_api`` tests make billable Anthropic calls against a real key. They are real tests —
+they are meant to be runnable — but they must never be part of the default suite, and CI
+has no key. Rather than depend on every caller remembering ``-m "not live_api"``, they are
+skipped unless the run explicitly selects markers itself.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+LIVE_API = "live_api"
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Skip ``live_api`` tests unless the run asked for a marker expression of its own."""
+    if config.getoption("-m"):
+        return
+    skip_live = pytest.mark.skip(
+        reason="live_api: billable Anthropic API call; select it with -m live_api"
+    )
+    for item in items:
+        if LIVE_API in item.keywords:
+            item.add_marker(skip_live)

--- a/tests/contract/fixtures/messages_malformed.json
+++ b/tests/contract/fixtures/messages_malformed.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "SYNTHETIC, hand-written to the documented shape - not a recording. A response that stopped cleanly (`end_turn`) whose text block is not a valid LeadAssessment: `icp_fit` is 999, outside the 0-30 the rubric allows, and `confidence` is absent. Structured outputs make this shape rare, not impossible - the schema constrains the grammar, and a model can still emit a document the domain model rejects. The point of the fixture is that a complete, fully billed response can fail validation, so this path must be both PARSE_ERROR and metered.",
+  "id": "msg_01Mk4dJp8vXc2wQr5nTz7HbY",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5",
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "",
+      "signature": "ErUBCkYIBRgCIkBzY2hlbWEtdmlvbGF0aW9u"
+    },
+    {
+      "type": "text",
+      "text": "{\"dimension_scores\": {\"icp_fit\": 999, \"intent\": 21, \"authority\": 12, \"urgency\": 11, \"budget_signal\": 9}, \"extracted\": {\"company_name\": \"Northwind Tooling\", \"industry\": \"Industrial manufacturing\", \"company_size_estimate\": \"250-400 employees\", \"role_seniority\": \"vp\", \"stated_use_case\": \"Automate weld seam inspection\", \"stated_timeline\": \"Pilot before quarter end\"}, \"reasoning\": \"Strong fit on every axis.\", \"missing_information\": [\"budget range\"], \"suggested_first_question\": \"Which line would you pilot on?\", \"spam_or_test_submission\": false}"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 612,
+    "output_tokens": 388,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 1984,
+    "service_tier": "standard"
+  }
+}

--- a/tests/contract/fixtures/messages_parse_refusal.json
+++ b/tests/contract/fixtures/messages_parse_refusal.json
@@ -1,4 +1,5 @@
 {
+  "_comment": "SYNTHETIC, hand-written to the documented shape - not a recording, despite what this file previously implied. It is the pre-output refusal: the safety classifier fired before the model emitted anything, so `content` is empty. Anthropic documents that shape as not billed at all - no input tokens, no output tokens, no rate-limit consumption - so every counter here is zero. The previous version of this file paired an empty `content` with 598 input / 4 output / 1,984 cache-read tokens, which is a combination the API does not produce. The mid-stream refusal, which IS billed, is messages_refusal_after_output.json.",
   "id": "msg_01Rf9zQ4nB6xLp2hVc7YdKmT",
   "type": "message",
   "role": "assistant",
@@ -12,10 +13,10 @@
     "explanation": "The submission asks for help with intrusion tooling."
   },
   "usage": {
-    "input_tokens": 598,
-    "output_tokens": 4,
+    "input_tokens": 0,
+    "output_tokens": 0,
     "cache_creation_input_tokens": 0,
-    "cache_read_input_tokens": 1984,
+    "cache_read_input_tokens": 0,
     "service_tier": "standard"
   }
 }

--- a/tests/contract/fixtures/messages_parse_refusal.json
+++ b/tests/contract/fixtures/messages_parse_refusal.json
@@ -1,0 +1,21 @@
+{
+  "id": "msg_01Rf9zQ4nB6xLp2hVc7YdKmT",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5",
+  "content": [],
+  "stop_reason": "refusal",
+  "stop_sequence": null,
+  "stop_details": {
+    "type": "refusal",
+    "category": "cyber",
+    "explanation": "The submission asks for help with intrusion tooling."
+  },
+  "usage": {
+    "input_tokens": 598,
+    "output_tokens": 4,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 1984,
+    "service_tier": "standard"
+  }
+}

--- a/tests/contract/fixtures/messages_parse_success.json
+++ b/tests/contract/fixtures/messages_parse_success.json
@@ -1,0 +1,27 @@
+{
+  "id": "msg_01LqA9pR7sVn3kYd2mWb8TfE",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5",
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "",
+      "signature": "ErUBCkYIBRgCIkDq3s0lWnJHb2xkZW5TZXQ="
+    },
+    {
+      "type": "text",
+      "text": "{\"dimension_scores\": {\"icp_fit\": 26, \"intent\": 21, \"authority\": 12, \"urgency\": 11, \"budget_signal\": 9}, \"extracted\": {\"company_name\": \"Northwind Tooling\", \"industry\": \"Industrial manufacturing\", \"company_size_estimate\": \"250-400 employees\", \"role_seniority\": \"vp\", \"stated_use_case\": \"Automate weld seam inspection on two production lines\", \"stated_timeline\": \"Pilot before the end of the quarter\"}, \"reasoning\": \"Mid-market industrial manufacturer squarely inside the ICP. The contact is a VP of Operations, which carries budget influence, and they name a quarter-end pilot deadline. No budget range was stated, so budget_signal is held back.\", \"confidence\": 0.82, \"missing_information\": [\"Approved budget range\", \"Whether procurement is involved\"], \"suggested_first_question\": \"Which of the two lines would you want to pilot on first?\", \"spam_or_test_submission\": false}"
+    }
+  ],
+  "stop_reason": "end_turn",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 612,
+    "output_tokens": 431,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 1984,
+    "service_tier": "standard"
+  }
+}

--- a/tests/contract/fixtures/messages_refusal_after_output.json
+++ b/tests/contract/fixtures/messages_refusal_after_output.json
@@ -1,0 +1,32 @@
+{
+  "_comment": "SYNTHETIC, hand-written to the documented shape - not a recording. A mid-stream refusal: the safety classifier fired after the model had already emitted output, so `content` carries a thinking block and a prose text block, `stop_reason` is `refusal`, and the already-generated tokens are billed at normal rates. This is the shape that the SDK's `messages.parse()` cannot survive: it calls `TypeAdapter(LeadAssessment).validate_json()` on the prose text block before it returns, so the caller never gets to inspect `stop_reason`.",
+  "id": "msg_01Wq8cKt3mZ5nRv6hLy2XbNe",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5",
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "",
+      "signature": "ErUBCkYIBRgCIkBtaWQtc3RyZWFtLXJlZnVzYWw="
+    },
+    {
+      "type": "text",
+      "text": "I can't help with this request. The submission asks for assistance building tooling to enumerate and exploit unpatched services on networks the sender does not appear to control."
+    }
+  ],
+  "stop_reason": "refusal",
+  "stop_sequence": null,
+  "stop_details": {
+    "type": "refusal",
+    "category": "cyber",
+    "explanation": "The submission asks for help with intrusion tooling."
+  },
+  "usage": {
+    "input_tokens": 731,
+    "output_tokens": 96,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 1984,
+    "service_tier": "standard"
+  }
+}

--- a/tests/contract/fixtures/messages_truncated.json
+++ b/tests/contract/fixtures/messages_truncated.json
@@ -1,0 +1,28 @@
+{
+  "_comment": "SYNTHETIC, hand-written to the documented shape - not a recording. The max_tokens truncation: adaptive thinking consumed the 8,000-token output budget before the JSON was finished, so `stop_reason` is `max_tokens` and the text block ends mid-document. `output_tokens` is the full budget because the whole budget was spent. This is the single most expensive way this adapter can fail, which is why the contract test asserts it is metered rather than merely escalated.",
+  "id": "msg_01Zt6bNq9wLm4kPd3vRy8XcJ",
+  "type": "message",
+  "role": "assistant",
+  "model": "claude-opus-5",
+  "content": [
+    {
+      "type": "thinking",
+      "thinking": "",
+      "signature": "ErUBCkYIBRgCIkB0cnVuY2F0ZWQtYXQtbWF4"
+    },
+    {
+      "type": "text",
+      "text": "{\"dimension_scores\": {\"icp_fit\": 26, \"intent\": 21, \"authority\": 12, \"urgency\": 11, \"budget_signal\": 9}, \"extracted\": {\"company_name\": \"Northwind Too"
+    }
+  ],
+  "stop_reason": "max_tokens",
+  "stop_sequence": null,
+  "stop_details": null,
+  "usage": {
+    "input_tokens": 612,
+    "output_tokens": 8000,
+    "cache_creation_input_tokens": 0,
+    "cache_read_input_tokens": 1984,
+    "service_tier": "standard"
+  }
+}

--- a/tests/contract/test_llm_anthropic_contract.py
+++ b/tests/contract/test_llm_anthropic_contract.py
@@ -2,20 +2,31 @@
 
 ``tests/unit/test_llm_anthropic.py`` proves the adapter's logic with a fake client. What
 it cannot prove is that our idea of the wire is the SDK's idea of the wire — that
-``messages.parse`` really serialises ``cache_control`` where we put it, really turns
-``output_format=LeadAssessment`` into a ``json_schema`` on ``output_config``, and really
-hands back a validated ``LeadAssessment`` from a payload shaped like the API's.
+``messages.create`` really serialises ``cache_control`` where we put it, that
+:data:`~leadquali.adapters.llm_anthropic.OUTPUT_FORMAT` really lands as a ``json_schema``
+on ``output_config``, and that a payload shaped like the API's really becomes a validated
+:class:`~leadquali.domain.models.LeadAssessment`.
 
 So this file swaps only the transport. The client is a genuine ``anthropic.Anthropic``;
-its HTTP layer is an ``httpx2.MockTransport`` that replays a recorded response and captures
+its HTTP layer is an ``httpx2.MockTransport`` that replays a response payload and captures
 the request that produced it. Everything between — request serialisation, response
-modelling, schema validation — is the SDK's own code. No key, no network, no cost.
+modelling, error translation — is the SDK's own code. No key, no network, no cost.
 
-Two things are asserted that only a real serialisation can show:
+Three things are asserted that only a real serialisation can show:
 
 * the JSON schema that actually goes over the wire contains no ``tier`` and no
-  ``total_score`` (invariant 2, checked at the boundary rather than in the abstract), and
-* the ``cache_control`` breakpoint lands on the rubric block and on nothing else.
+  ``total_score`` (invariant 2, checked at the boundary rather than in the abstract),
+* the ``cache_control`` breakpoint lands on the rubric block and on nothing else, and
+* a refusal carrying a prose text block comes back as ``MODEL_REFUSAL``. That one is the
+  reason the adapter does not use ``client.messages.parse``: ``parse`` validates every
+  text block *inside the SDK* before it returns, so on that payload it raises
+  ``pydantic.ValidationError`` from the call itself and the refusal is misfiled as a
+  parse error. A fake client cannot catch that — it bypasses the SDK's parse step
+  entirely — which is precisely why the case lives here, against the real thing.
+
+**On "recorded".** These payloads are hand-written to the documented response shape, not
+captured from a live account: this repository has never had an API key. Each fixture says
+so in its own ``_comment`` field. What is real is everything downstream of the socket.
 """
 
 from __future__ import annotations
@@ -48,7 +59,7 @@ RENDERED_LEAD = (
 
 
 def recorded(name: str) -> dict[str, Any]:
-    """One recorded ``POST /v1/messages`` response body."""
+    """One ``POST /v1/messages`` response body, replayed from ``fixtures/``."""
     with (FIXTURES / f"{name}.json").open(encoding="utf-8") as handle:
         payload: dict[str, Any] = json.load(handle)
     return payload
@@ -233,6 +244,14 @@ def test_a_cache_read_actually_showed_up_in_the_recorded_usage(
 
 
 def test_recorded_refusal_escalates_to_a_human() -> None:
+    """The pre-output refusal: empty ``content``, and documented as unbilled.
+
+    Every counter in the fixture is zero because Anthropic bills a classifier decline
+    that fires before any output at nothing at all — no input tokens, no output tokens,
+    no rate-limit consumption. The metering row is still written: a zero-cost call is a
+    fact worth recording, and "no row" and "a row that cost nothing" answer different
+    questions when someone asks how often the classifier is firing.
+    """
     recorder = Recorder(recorded("messages_parse_refusal"))
 
     outcome = build(recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
@@ -241,7 +260,108 @@ def test_recorded_refusal_escalates_to_a_human() -> None:
     assert outcome.reason is EscalationReason.MODEL_REFUSAL
     assert "cyber" in outcome.detail
     assert outcome.metering is not None
-    assert outcome.metering.input_tokens == 598
+    assert outcome.metering.input_tokens == 0
+    assert outcome.metering.cost_usd == Decimal(0)
+
+
+def test_recorded_refusal_after_partial_output_is_still_a_refusal() -> None:
+    """The refusal shape that a content-parsing SDK helper hides.
+
+    Anthropic documents two refusal shapes: the classifier fires *before any output*
+    (empty ``content``, unbilled) or *mid-stream* after partial output (a prose text
+    block, billed at normal rates). ``client.messages.parse()`` reads and validates
+    every text block inside the SDK before it returns, so on the second shape it raises
+    ``pydantic.ValidationError`` from the call itself — the refusal is filed as a parse
+    error and the billed call goes unmetered. That is why the adapter asks for a plain
+    ``Message`` and gates on ``stop_reason`` itself.
+    """
+    recorder = Recorder(recorded("messages_refusal_after_output"))
+
+    outcome = build(recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.MODEL_REFUSAL
+    assert "cyber" in outcome.detail
+    # Billed, so metered: 731 x $5.00 + 96 x $25.00 + 1,984 x $0.50 per MTok.
+    assert outcome.metering is not None
+    assert outcome.metering.input_tokens == 731
+    assert outcome.metering.output_tokens == 96
+    assert outcome.metering.cost_usd == Decimal("0.007047")
+
+
+def test_the_refusal_prose_never_reaches_the_operator_detail() -> None:
+    """A refusal explains itself in prose that quotes the lead. Invariant 5 says no."""
+    recorder = Recorder(recorded("messages_refusal_after_output"))
+
+    outcome = build(recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert "enumerate" not in outcome.detail
+    assert outcome.detail == "model declined to answer (category=cyber)"
+
+
+def test_recorded_malformed_response_is_a_parse_error_and_is_metered() -> None:
+    """A complete, fully billed response that is not a valid assessment.
+
+    This is the case the ``pydantic.ValidationError`` handler is named for, and after the
+    move off ``messages.parse`` it is the only case that reaches it.
+    """
+    recorder = Recorder(recorded("messages_malformed"))
+
+    outcome = build(recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.PARSE_ERROR
+    # Field paths, never the offending value — model output derived from lead text.
+    assert "dimension_scores.icp_fit" in outcome.detail
+    assert "999" not in outcome.detail
+    # 612 x $5.00 + 388 x $25.00 + 1,984 x $0.50 per MTok.
+    assert outcome.metering is not None
+    assert outcome.metering.output_tokens == 388
+    assert outcome.metering.cost_usd == Decimal("0.013752")
+
+
+def test_recorded_truncation_is_a_parse_error_and_is_metered() -> None:
+    """The most expensive failure available: the whole output budget, spent on a fragment."""
+    recorder = Recorder(recorded("messages_truncated"))
+
+    outcome = build(recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.PARSE_ERROR
+    assert "max_tokens" in outcome.detail
+    assert outcome.metering is not None
+    assert outcome.metering.output_tokens == MAX_TOKENS
+    # 8,000 output tokens at $25/MTok is $0.20 before a single input token is counted.
+    assert outcome.metering.cost_usd > Decimal("0.20")
+
+
+def test_a_transport_timeout_becomes_a_typed_timeout_not_an_exception() -> None:
+    """A timeout has no response body, so it is recorded as the transport failure it is.
+
+    ``httpx2.ReadTimeout`` is what the connection layer raises; the assertion that matters
+    is that the SDK turns it into ``anthropic.APITimeoutError`` and the adapter maps that
+    to ``TIMEOUT`` rather than to the generic ``API_ERROR`` — the ordering of two handlers
+    where ``APITimeoutError`` subclasses ``APIConnectionError``.
+    """
+
+    def time_out(request: httpx2.Request) -> httpx2.Response:
+        raise httpx2.ReadTimeout("timed out", request=request)
+
+    client = anthropic.Anthropic(
+        api_key="not-a-real-key",
+        max_retries=0,
+        http_client=anthropic.DefaultHttpxClient(transport=httpx2.MockTransport(time_out)),
+    )
+
+    outcome = AnthropicLeadAssessor(client=client).assess(
+        config=tenant(), rendered_lead=RENDERED_LEAD
+    )
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.TIMEOUT
+    # Nothing was billed, because nothing completed.
+    assert outcome.metering is None
 
 
 def test_a_server_error_becomes_an_api_error_not_an_exception() -> None:

--- a/tests/contract/test_llm_anthropic_contract.py
+++ b/tests/contract/test_llm_anthropic_contract.py
@@ -1,0 +1,282 @@
+"""The adapter against the real SDK, driven by a recorded response payload.
+
+``tests/unit/test_llm_anthropic.py`` proves the adapter's logic with a fake client. What
+it cannot prove is that our idea of the wire is the SDK's idea of the wire — that
+``messages.parse`` really serialises ``cache_control`` where we put it, really turns
+``output_format=LeadAssessment`` into a ``json_schema`` on ``output_config``, and really
+hands back a validated ``LeadAssessment`` from a payload shaped like the API's.
+
+So this file swaps only the transport. The client is a genuine ``anthropic.Anthropic``;
+its HTTP layer is an ``httpx2.MockTransport`` that replays a recorded response and captures
+the request that produced it. Everything between — request serialisation, response
+modelling, schema validation — is the SDK's own code. No key, no network, no cost.
+
+Two things are asserted that only a real serialisation can show:
+
+* the JSON schema that actually goes over the wire contains no ``tier`` and no
+  ``total_score`` (invariant 2, checked at the boundary rather than in the abstract), and
+* the ``cache_control`` breakpoint lands on the rubric block and on nothing else.
+"""
+
+from __future__ import annotations
+
+import json
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import anthropic
+import httpx2
+import pytest
+
+from leadquali.adapters.llm_anthropic import MAX_TOKENS, MODEL_ID, AnthropicLeadAssessor
+from leadquali.app.assessment_result import AssessmentFailed, AssessmentSucceeded
+from leadquali.app.ports import LeadAssessorPort
+from leadquali.domain.models import Action, EscalationReason, Tier
+from leadquali.domain.tenant_config import TenantConfig
+from leadquali.prompts import PROMPT_VERSION, build_system_blocks
+
+FIXTURES = Path(__file__).parent / "fixtures"
+
+RENDERED_LEAD = (
+    "<lead_submission>\n"
+    "name: Dana Okafor\n"
+    "company: Northwind Tooling\n"
+    "message: We need to automate weld seam inspection before quarter end.\n"
+    "</lead_submission>"
+)
+
+
+def recorded(name: str) -> dict[str, Any]:
+    """One recorded ``POST /v1/messages`` response body."""
+    with (FIXTURES / f"{name}.json").open(encoding="utf-8") as handle:
+        payload: dict[str, Any] = json.load(handle)
+    return payload
+
+
+def tenant() -> TenantConfig:
+    return TenantConfig.from_dict(
+        {
+            "tenant_id": "northwind",
+            "name": "Northwind Vision Systems",
+            "icp_description": "Industrial manufacturers with 100-1000 staff automating QA.",
+            "routing_rules": {
+                Tier.HOT.value: {
+                    "action": Action.EMAIL_SALES.value,
+                    "destination": "hot@northwind.test",
+                },
+                Tier.WARM.value: {
+                    "action": Action.EMAIL_SALES.value,
+                    "destination": "sales@northwind.test",
+                },
+                Tier.COLD.value: {
+                    "action": Action.EMAIL_SALES.value,
+                    "destination": "nurture@northwind.test",
+                },
+                Tier.DISQUALIFIED.value: {"action": Action.SUPPRESS.value},
+            },
+        }
+    )
+
+
+class Recorder:
+    """A mock transport that replays one recorded body and keeps the request."""
+
+    def __init__(self, body: dict[str, Any], status: int = 200) -> None:
+        self.body = body
+        self.status = status
+        self.requests: list[dict[str, Any]] = []
+
+    def __call__(self, request: httpx2.Request) -> httpx2.Response:
+        self.requests.append(json.loads(request.content))
+        return httpx2.Response(self.status, json=self.body)
+
+    @property
+    def sent(self) -> dict[str, Any]:
+        assert self.requests, "no request was made"
+        return self.requests[0]
+
+
+def build(recorder: Recorder, **kwargs: Any) -> AnthropicLeadAssessor:
+    client = anthropic.Anthropic(
+        api_key="not-a-real-key",
+        max_retries=0,
+        http_client=anthropic.DefaultHttpxClient(transport=httpx2.MockTransport(recorder)),
+    )
+    return AnthropicLeadAssessor(client=client, **kwargs)
+
+
+@pytest.fixture
+def success_recorder() -> Recorder:
+    return Recorder(recorded("messages_parse_success"))
+
+
+# ------------------------------------------------------------------ the outgoing request
+
+
+def test_request_serialises_the_cache_breakpoint_onto_the_rubric_only(
+    success_recorder: Recorder,
+) -> None:
+    config = tenant()
+    build(success_recorder).assess(config=config, rendered_lead=RENDERED_LEAD)
+
+    system = success_recorder.sent["system"]
+    rubric_block, tenant_block = build_system_blocks(config)
+    assert [block["text"] for block in system] == [rubric_block.text, tenant_block.text]
+    assert system[0]["cache_control"] == {"type": "ephemeral"}
+    assert "cache_control" not in system[1]
+
+
+def test_request_carries_the_model_budget_and_effort(success_recorder: Recorder) -> None:
+    build(success_recorder, effort="high").assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    sent = success_recorder.sent
+    assert sent["model"] == MODEL_ID
+    assert sent["max_tokens"] == MAX_TOKENS
+    assert sent["output_config"]["effort"] == "high"
+    assert sent["messages"] == [{"role": "user", "content": RENDERED_LEAD}]
+
+
+def test_output_format_serialises_to_the_assessment_json_schema(
+    success_recorder: Recorder,
+) -> None:
+    """``output_format=LeadAssessment`` must reach the wire as a strict JSON schema."""
+    build(success_recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    fmt = success_recorder.sent["output_config"]["format"]
+    assert fmt["type"] == "json_schema"
+    schema = fmt["schema"]
+    assert schema["additionalProperties"] is False
+    assert set(schema["required"]) == {
+        "dimension_scores",
+        "extracted",
+        "reasoning",
+        "confidence",
+        "missing_information",
+        "suggested_first_question",
+        "spam_or_test_submission",
+    }
+
+
+def test_the_wire_schema_offers_the_model_no_way_to_route(
+    success_recorder: Recorder,
+) -> None:
+    """Invariant 2, asserted on the bytes that actually leave the process."""
+    build(success_recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    serialised = json.dumps(success_recorder.sent["output_config"]["format"])
+    for forbidden in ("tier", "total_score", "action", "escalat"):
+        assert forbidden not in serialised.lower(), forbidden
+
+
+def test_the_lead_never_enters_the_cached_prefix(success_recorder: Recorder) -> None:
+    """Attacker-controlled text belongs in the user turn, downstream of every breakpoint."""
+    build(success_recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    sent = success_recorder.sent
+    assert "Northwind Tooling" not in json.dumps(sent["system"])
+    assert "Northwind Tooling" in json.dumps(sent["messages"])
+
+
+# -------------------------------------------------------------------- the parsed response
+
+
+def test_recorded_success_parses_into_a_validated_assessment(
+    success_recorder: Recorder,
+) -> None:
+    outcome = build(success_recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    assert isinstance(outcome, AssessmentSucceeded)
+    assessment = outcome.assessment
+    # Never assert on prose: structure, ranges and extracted fields only.
+    assert assessment.dimension_scores.icp_fit == 26
+    assert 0.0 <= assessment.confidence <= 1.0
+    assert assessment.extracted.company_name == "Northwind Tooling"
+    assert assessment.spam_or_test_submission is False
+    assert assessment.missing_information
+
+
+def test_recorded_success_meters_the_call_from_the_payloads_usage(
+    success_recorder: Recorder,
+) -> None:
+    """612 input, 431 output, 1,984 cache reads, 0 writes.
+
+      612 x $5.00/MTok  = $0.003060
+      431 x $25.00/MTok = $0.010775
+    1,984 x $0.50/MTok  = $0.000992
+                          ---------
+                          $0.014827
+    """
+    outcome = build(success_recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    assert isinstance(outcome, AssessmentSucceeded)
+    metering = outcome.metering
+    assert metering.input_tokens == 612
+    assert metering.output_tokens == 431
+    assert metering.cache_read_tokens == 1_984
+    assert metering.cache_creation_tokens == 0
+    assert metering.cost_usd == Decimal("0.014827")
+    assert metering.model_id == MODEL_ID
+    assert metering.prompt_version == PROMPT_VERSION
+    assert metering.effort == "medium"
+    assert metering.latency_ms >= 0
+
+
+def test_a_cache_read_actually_showed_up_in_the_recorded_usage(
+    success_recorder: Recorder,
+) -> None:
+    """The one number that proves caching is working at all; zero here is the alarm."""
+    outcome = build(success_recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    assert isinstance(outcome, AssessmentSucceeded)
+    assert outcome.metering.cache_read_tokens > 0
+
+
+def test_recorded_refusal_escalates_to_a_human() -> None:
+    recorder = Recorder(recorded("messages_parse_refusal"))
+
+    outcome = build(recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.MODEL_REFUSAL
+    assert "cyber" in outcome.detail
+    assert outcome.metering is not None
+    assert outcome.metering.input_tokens == 598
+
+
+def test_a_server_error_becomes_an_api_error_not_an_exception() -> None:
+    recorder = Recorder({"type": "error", "error": {"type": "api_error", "message": "boom"}}, 500)
+
+    outcome = build(recorder).assess(config=tenant(), rendered_lead=RENDERED_LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.API_ERROR
+
+
+def test_the_adapter_satisfies_the_port(success_recorder: Recorder) -> None:
+    port: LeadAssessorPort = build(success_recorder)
+    assert isinstance(port, LeadAssessorPort)
+
+
+# -------------------------------------------------------------------------- the live call
+
+
+@pytest.mark.live_api
+def test_live_call_returns_an_assessment() -> None:  # pragma: no cover - never in CI
+    """The same path against the real API. Billable; excluded from the default suite.
+
+    Run deliberately with ``pytest -m live_api`` and ``ANTHROPIC_API_KEY`` set. It asserts
+    only structure and provenance — never prose, never a specific score.
+    """
+    from leadquali.adapters.llm_anthropic import build_anthropic_client
+    from leadquali.config import get_settings
+
+    client = build_anthropic_client(get_settings().require_anthropic_api_key())
+    outcome = AnthropicLeadAssessor(client=client).assess(
+        config=tenant(), rendered_lead=RENDERED_LEAD
+    )
+
+    assert isinstance(outcome, AssessmentSucceeded)
+    assert 0.0 <= outcome.assessment.confidence <= 1.0
+    assert outcome.metering.output_tokens > 0
+    assert outcome.metering.cost_usd > Decimal(0)

--- a/tests/unit/test_assessment_result.py
+++ b/tests/unit/test_assessment_result.py
@@ -1,0 +1,104 @@
+"""The port's result type: a closed union, immutable, with no third state.
+
+The adapter hands #14 one of exactly two things. Making that a union of two frozen
+dataclasses rather than an "assessment or ``None``, plus maybe an error" tuple is what
+stops the caller from forgetting the failure branch — there is no attribute to read on a
+failure that would give it a score.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from decimal import Decimal
+
+import pytest
+
+from leadquali.app.assessment_result import (
+    DEFAULT_EFFORT,
+    EFFORT_LEVELS,
+    AssessmentFailed,
+    AssessmentOutcome,
+    AssessmentSucceeded,
+    CallMetering,
+)
+from leadquali.domain.models import (
+    DimensionScores,
+    EscalationReason,
+    ExtractedFacts,
+    LeadAssessment,
+)
+
+
+def metering() -> CallMetering:
+    return CallMetering(
+        model_id="claude-opus-5",
+        prompt_version="rubric_v1",
+        effort="medium",
+        input_tokens=10,
+        output_tokens=20,
+        cache_read_tokens=30,
+        cache_creation_tokens=0,
+        cost_usd=Decimal("0.001"),
+        latency_ms=42,
+    )
+
+
+def assessment() -> LeadAssessment:
+    return LeadAssessment(
+        dimension_scores=DimensionScores(
+            icp_fit=1, intent=1, authority=1, urgency=1, budget_signal=1
+        ),
+        extracted=ExtractedFacts(
+            company_name=None,
+            industry=None,
+            company_size_estimate=None,
+            role_seniority=None,
+            stated_use_case=None,
+            stated_timeline=None,
+        ),
+        reasoning="Thin submission.",
+        confidence=0.4,
+        missing_information=[],
+        suggested_first_question=None,
+        spam_or_test_submission=False,
+    )
+
+
+def test_the_two_outcomes_are_discriminated_by_ok() -> None:
+    success: AssessmentOutcome = AssessmentSucceeded(assessment=assessment(), metering=metering())
+    failure: AssessmentOutcome = AssessmentFailed(
+        reason=EscalationReason.TIMEOUT, detail="took too long", latency_ms=30_000
+    )
+    assert success.ok is True
+    assert failure.ok is False
+
+
+def test_a_failure_has_no_assessment_to_misread() -> None:
+    failure = AssessmentFailed(reason=EscalationReason.API_ERROR, detail="503", latency_ms=12)
+    assert not hasattr(failure, "assessment")
+    assert failure.metering is None
+
+
+def test_outcomes_are_frozen() -> None:
+    """A metering row is a record of one instant; it is a value, not a workspace."""
+    success = AssessmentSucceeded(assessment=assessment(), metering=metering())
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        success.metering = metering()  # type: ignore[misc]
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        success.metering.latency_ms = 0  # type: ignore[misc]
+
+
+def test_low_confidence_is_not_an_adapter_failure_reason() -> None:
+    """``low_confidence`` is #9's judgement on a *successful* assessment, never a failure."""
+    adapter_reasons = frozenset(EscalationReason) - {EscalationReason.LOW_CONFIDENCE}
+    assert adapter_reasons == {
+        EscalationReason.MODEL_REFUSAL,
+        EscalationReason.PARSE_ERROR,
+        EscalationReason.API_ERROR,
+        EscalationReason.TIMEOUT,
+    }
+
+
+def test_effort_levels_are_the_five_the_model_accepts() -> None:
+    assert EFFORT_LEVELS == ("low", "medium", "high", "xhigh", "max")
+    assert DEFAULT_EFFORT in EFFORT_LEVELS

--- a/tests/unit/test_layering.py
+++ b/tests/unit/test_layering.py
@@ -1,0 +1,65 @@
+"""The layering rule, enforced instead of documented.
+
+``CLAUDE.md``: ``anthropic`` is imported in ``adapters/llm_anthropic.py`` and nowhere else.
+The rule is what keeps ``domain`` and ``app`` testable without a key and swappable for
+another provider, and it is exactly the kind of rule that decays the first time someone
+needs a type hint in a hurry. So it is a test.
+
+The check is on the AST, not on a grep: a string mentioning ``anthropic`` in a docstring is
+fine, an ``import`` of it is not.
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+SRC = Path(__file__).resolve().parents[2] / "src" / "leadquali"
+
+#: The one module allowed to import the SDK, relative to the package root.
+SDK_OWNER = "adapters/llm_anthropic.py"
+
+
+def imported_modules(path: Path) -> set[str]:
+    """Every top-level module name imported by ``path``, from its AST."""
+    names: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"), filename=str(path))):
+        if isinstance(node, ast.Import):
+            names.update(alias.name.split(".")[0] for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module.split(".")[0])
+    return names
+
+
+def python_sources() -> list[Path]:
+    return sorted(SRC.rglob("*.py"))
+
+
+def test_the_package_has_sources_to_check() -> None:
+    """Guards against a path typo silently turning this whole file into a no-op."""
+    assert len(python_sources()) >= 8
+    assert (SRC / SDK_OWNER).is_file()
+
+
+@pytest.mark.parametrize("path", python_sources(), ids=lambda p: str(p.name))
+def test_only_the_anthropic_adapter_imports_anthropic(path: Path) -> None:
+    relative = path.relative_to(SRC).as_posix()
+    if relative == SDK_OWNER:
+        assert "anthropic" in imported_modules(path), "the adapter is supposed to own the SDK"
+        return
+    assert "anthropic" not in imported_modules(path), (
+        f"{relative} imports anthropic; the SDK belongs in {SDK_OWNER} alone"
+    )
+
+
+def test_domain_and_app_import_no_third_party_sdk() -> None:
+    """The same rule, stated for its siblings: no ``boto3``/``sqlalchemy``/``stripe`` either."""
+    forbidden = {"anthropic", "boto3", "sqlalchemy", "stripe", "psycopg", "fastapi"}
+    for path in python_sources():
+        relative = path.relative_to(SRC).as_posix()
+        if not relative.startswith(("domain/", "app/")):
+            continue
+        leaked = forbidden & imported_modules(path)
+        assert not leaked, f"{relative} imports {sorted(leaked)}"

--- a/tests/unit/test_llm_anthropic.py
+++ b/tests/unit/test_llm_anthropic.py
@@ -1,0 +1,585 @@
+"""The Anthropic adapter, exercised entirely offline against a fake client.
+
+The happy path of this adapter is one API call, and it is the least interesting thing
+here. What earns the tests is everything that can go wrong, because invariant 3 of
+``CLAUDE.md`` — *a lead is never silently dropped* — is only true if every failure mode
+comes back as a typed outcome a human can be routed on. So the assertions below are mostly
+about failure:
+
+* a refusal is read from ``stop_reason`` **before** ``.content`` is touched at all, and it
+  escalates rather than disqualifying;
+* every SDK exception class lands on exactly one :class:`EscalationReason`;
+* nothing — not a truncation, not a schema violation, not an exception the SDK has never
+  raised before — can come back as a success carrying a low score.
+
+The request side is asserted just as tightly, because a silently wrong request is the
+expensive kind: block 0 must carry ``cache_control`` and block 1 must not (a breakpoint on
+the tenant block caches nothing while still paying the write premium), and the model,
+``max_tokens``, effort and ``output_format`` must be exactly what the plan says.
+
+No network, no key, no recorded payload: the fake client returns objects shaped like the
+SDK's, and the parse path against a realistic payload is ``tests/contract/``'s job.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Any
+
+import anthropic
+import httpx2
+import pytest
+from pydantic import BaseModel, ValidationError
+
+from leadquali.adapters.llm_anthropic import (
+    CACHE_CONTROL_EPHEMERAL,
+    CLAUDE_OPUS_5_PRICES,
+    MAX_TOKENS,
+    MODEL_ID,
+    AnthropicLeadAssessor,
+    TokenPrices,
+    token_cost_usd,
+)
+from leadquali.app.assessment_result import (
+    DEFAULT_EFFORT,
+    EFFORT_LEVELS,
+    AssessmentFailed,
+    AssessmentSucceeded,
+)
+from leadquali.domain.models import (
+    Action,
+    DimensionScores,
+    EscalationReason,
+    ExtractedFacts,
+    LeadAssessment,
+    Tier,
+)
+from leadquali.domain.tenant_config import TenantConfig
+from leadquali.prompts import PROMPT_VERSION, build_system_blocks
+
+# --------------------------------------------------------------------------- fixtures
+
+
+def make_config(**overrides: Any) -> TenantConfig:
+    """A minimal valid tenant, so a test can say only what it cares about."""
+    document: dict[str, Any] = {
+        "tenant_id": "acme",
+        "name": "Acme Robotics",
+        "icp_description": "Mid-market manufacturers automating quality inspection.",
+        "routing_rules": {
+            Tier.HOT.value: {"action": Action.EMAIL_SALES.value, "destination": "hot@acme.test"},
+            Tier.WARM.value: {"action": Action.EMAIL_SALES.value, "destination": "sales@acme.test"},
+            Tier.COLD.value: {
+                "action": Action.EMAIL_SALES.value,
+                "destination": "nurture@acme.test",
+            },
+            Tier.DISQUALIFIED.value: {"action": Action.SUPPRESS.value},
+        },
+    }
+    document.update(overrides)
+    return TenantConfig.from_dict(document)
+
+
+def make_assessment(confidence: float = 0.8) -> LeadAssessment:
+    return LeadAssessment(
+        dimension_scores=DimensionScores(
+            icp_fit=24, intent=20, authority=10, urgency=9, budget_signal=11
+        ),
+        extracted=ExtractedFacts(
+            company_name="Northwind Tooling",
+            industry="Manufacturing",
+            company_size_estimate="200-500",
+            role_seniority="vp",
+            stated_use_case="Automate weld inspection",
+            stated_timeline="This quarter",
+        ),
+        reasoning="Mid-market manufacturer, VP of ops, named a quarter-end deadline.",
+        confidence=confidence,
+        missing_information=["budget range"],
+        suggested_first_question="Which line would you pilot on?",
+        spam_or_test_submission=False,
+    )
+
+
+class FakeUsage(BaseModel):
+    """Shaped like ``anthropic.types.Usage`` for the fields the adapter reads."""
+
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_input_tokens: int | None = 0
+    cache_creation_input_tokens: int | None = 0
+
+
+@dataclass
+class FakeMessage:
+    """A response object whose ``.content`` explodes if anything reads it.
+
+    That is the point: the refusal check has to happen before content is touched, and the
+    cheapest way to prove a line of code never ran is to make running it fail.
+    """
+
+    stop_reason: str | None = "end_turn"
+    stop_details: object | None = None
+    parsed_output: LeadAssessment | None = None
+    usage: FakeUsage = field(default_factory=FakeUsage)
+
+    @property
+    def content(self) -> list[object]:
+        raise AssertionError("the adapter read .content; stop_reason must be checked first")
+
+
+@dataclass
+class FakeMessages:
+    """Stands in for ``client.messages``, recording the kwargs it was called with."""
+
+    result: object
+    calls: list[dict[str, Any]] = field(default_factory=list)
+
+    def parse(self, **kwargs: Any) -> Any:
+        self.calls.append(kwargs)
+        if isinstance(self.result, BaseException):
+            raise self.result
+        return self.result
+
+
+@dataclass
+class FakeClient:
+    """Stands in for ``anthropic.Anthropic``."""
+
+    messages: FakeMessages
+
+
+def assessor(result: object, **kwargs: Any) -> tuple[AnthropicLeadAssessor, FakeMessages]:
+    messages = FakeMessages(result=result)
+    client: Any = FakeClient(messages=messages)
+    return AnthropicLeadAssessor(client=client, **kwargs), messages
+
+
+def httpx_request() -> httpx2.Request:
+    return httpx2.Request("POST", "https://api.anthropic.com/v1/messages")
+
+
+def httpx_response(status: int) -> httpx2.Response:
+    return httpx2.Response(status, request=httpx_request(), json={"error": {"message": "no"}})
+
+
+LEAD = "<lead_submission>Hi, we need weld inspection.</lead_submission>"
+
+
+# ------------------------------------------------------------------- the request shape
+
+
+def test_block_zero_is_cacheable_and_block_one_is_not() -> None:
+    """The breakpoint goes on the rubric, and only on the rubric.
+
+    Block 1 is the tenant's ICP text: it differs per customer, so a breakpoint there buys
+    nothing and costs the 1.25x write premium on every first request of every tenant.
+    """
+    config = make_config()
+    lead_assessor, messages = assessor(FakeMessage(parsed_output=make_assessment()))
+
+    lead_assessor.assess(config=config, rendered_lead=LEAD)
+
+    system = messages.calls[0]["system"]
+    rubric_block, tenant_block = build_system_blocks(config)
+    assert system == [
+        {"type": "text", "text": rubric_block.text, "cache_control": CACHE_CONTROL_EPHEMERAL},
+        {"type": "text", "text": tenant_block.text},
+    ]
+    assert "cache_control" not in system[1]
+    assert CACHE_CONTROL_EPHEMERAL == {"type": "ephemeral"}
+
+
+def test_request_parameters_are_exactly_as_intended() -> None:
+    config = make_config()
+    lead_assessor, messages = assessor(FakeMessage(parsed_output=make_assessment()))
+
+    lead_assessor.assess(config=config, rendered_lead=LEAD)
+
+    call = messages.calls[0]
+    assert call["model"] == MODEL_ID == "claude-opus-5"
+    assert call["max_tokens"] == MAX_TOKENS == 8000
+    assert call["output_format"] is LeadAssessment
+    assert call["output_config"] == {"effort": DEFAULT_EFFORT}
+    assert call["messages"] == [{"role": "user", "content": LEAD}]
+    # The lead is a user turn, never a system block: it is attacker-controlled text and it
+    # must not sit inside the cached prefix.
+    assert LEAD not in "".join(block["text"] for block in call["system"])
+
+
+def test_default_effort_is_medium_and_effort_is_a_parameter() -> None:
+    """#24 sweeps effort, so it cannot be a constant buried in the call."""
+    assert DEFAULT_EFFORT == "medium"
+    config = make_config()
+    for effort in EFFORT_LEVELS:
+        lead_assessor, messages = assessor(
+            FakeMessage(parsed_output=make_assessment()), effort=effort
+        )
+        lead_assessor.assess(config=config, rendered_lead=LEAD)
+        assert messages.calls[0]["output_config"] == {"effort": effort}
+
+
+def test_unknown_effort_is_rejected_at_construction() -> None:
+    with pytest.raises(ValueError, match="effort"):
+        AnthropicLeadAssessor(client=object(), effort="turbo")  # type: ignore[arg-type]
+
+
+# ------------------------------------------------------------------------ the happy path
+
+
+def test_success_carries_the_assessment_and_full_provenance() -> None:
+    config = make_config()
+    expected = make_assessment()
+    usage = FakeUsage(
+        input_tokens=1_500,
+        output_tokens=900,
+        cache_read_input_tokens=4_000,
+        cache_creation_input_tokens=0,
+    )
+    lead_assessor, _ = assessor(FakeMessage(parsed_output=expected, usage=usage))
+
+    outcome = lead_assessor.assess(config=config, rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentSucceeded)
+    assert outcome.ok is True
+    assert outcome.assessment == expected
+    metering = outcome.metering
+    assert metering.model_id == MODEL_ID
+    assert metering.prompt_version == PROMPT_VERSION
+    assert metering.effort == DEFAULT_EFFORT
+    assert metering.input_tokens == 1_500
+    assert metering.output_tokens == 900
+    assert metering.cache_read_tokens == 4_000
+    assert metering.cache_creation_tokens == 0
+    assert metering.latency_ms >= 0
+
+
+def test_absent_cache_counters_read_as_zero_not_none() -> None:
+    """The SDK types both cache counters ``Optional``; cost arithmetic cannot see ``None``."""
+    usage = FakeUsage(
+        input_tokens=10,
+        output_tokens=10,
+        cache_read_input_tokens=None,
+        cache_creation_input_tokens=None,
+    )
+    lead_assessor, _ = assessor(FakeMessage(parsed_output=make_assessment(), usage=usage))
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentSucceeded)
+    assert outcome.metering.cache_read_tokens == 0
+    assert outcome.metering.cache_creation_tokens == 0
+
+
+def test_latency_is_recorded_on_success_and_on_failure() -> None:
+    slow = FakeMessage(parsed_output=make_assessment())
+    lead_assessor, messages = assessor(slow)
+
+    original = messages.parse
+
+    def slow_parse(**kwargs: Any) -> Any:
+        # Busy-wait past a millisecond so the assertion is about the clock, not luck.
+        import time
+
+        deadline = time.monotonic() + 0.003
+        while time.monotonic() < deadline:
+            pass
+        return original(**kwargs)
+
+    messages.parse = slow_parse  # type: ignore[method-assign]
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+    assert isinstance(outcome, AssessmentSucceeded)
+    assert outcome.metering.latency_ms >= 1
+
+    failed_assessor, _ = assessor(anthropic.APITimeoutError(request=httpx_request()))
+    failure = failed_assessor.assess(config=make_config(), rendered_lead=LEAD)
+    assert isinstance(failure, AssessmentFailed)
+    assert failure.latency_ms >= 0
+
+
+# ----------------------------------------------------------------------------- refusals
+
+
+def test_refusal_escalates_and_never_reads_content() -> None:
+    """Invariant 3: a refusal is a human's problem, not a score of zero.
+
+    ``FakeMessage.content`` raises, so this passes only if the adapter checks
+    ``stop_reason`` first and returns without ever looking at the blocks.
+    """
+    lead_assessor, _ = assessor(
+        FakeMessage(
+            stop_reason="refusal",
+            stop_details=None,
+            usage=FakeUsage(input_tokens=1_200, output_tokens=3),
+        )
+    )
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.ok is False
+    assert outcome.reason is EscalationReason.MODEL_REFUSAL
+    assert not hasattr(outcome, "assessment")
+
+
+def test_refusal_still_meters_the_call() -> None:
+    """A refusal is an HTTP 200 and it is billed, so it must still be metered."""
+    lead_assessor, _ = assessor(
+        FakeMessage(
+            stop_reason="refusal",
+            usage=FakeUsage(input_tokens=1_200, output_tokens=3),
+        )
+    )
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.metering is not None
+    assert outcome.metering.input_tokens == 1_200
+    assert outcome.metering.cost_usd > Decimal(0)
+
+
+def test_refusal_detail_carries_the_stop_details_category() -> None:
+    """``stop_details`` is populated only on a refusal; it says which classifier fired."""
+
+    @dataclass(frozen=True)
+    class Details:
+        type: str = "refusal"
+        category: str = "cyber"
+        explanation: str = "declined"
+
+    lead_assessor, _ = assessor(FakeMessage(stop_reason="refusal", stop_details=Details()))
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert "cyber" in outcome.detail
+
+
+# ------------------------------------------------------------------- exception mapping
+
+
+@pytest.mark.parametrize(
+    ("error", "expected"),
+    [
+        pytest.param(
+            anthropic.APITimeoutError(request=httpx_request()),
+            EscalationReason.TIMEOUT,
+            id="timeout",
+        ),
+        pytest.param(
+            anthropic.APIConnectionError(request=httpx_request()),
+            EscalationReason.API_ERROR,
+            id="connection",
+        ),
+        pytest.param(
+            anthropic.RateLimitError("slow down", response=httpx_response(429), body=None),
+            EscalationReason.API_ERROR,
+            id="rate-limit",
+        ),
+        pytest.param(
+            anthropic.InternalServerError("boom", response=httpx_response(500), body=None),
+            EscalationReason.API_ERROR,
+            id="server-error",
+        ),
+        pytest.param(
+            anthropic.BadRequestError("bad", response=httpx_response(400), body=None),
+            EscalationReason.API_ERROR,
+            id="bad-request",
+        ),
+        pytest.param(
+            anthropic.AuthenticationError("nope", response=httpx_response(401), body=None),
+            EscalationReason.API_ERROR,
+            id="auth",
+        ),
+        pytest.param(
+            RuntimeError("something nobody predicted"), EscalationReason.API_ERROR, id="unexpected"
+        ),
+    ],
+)
+def test_every_exception_maps_to_an_escalation_reason(
+    error: BaseException, expected: EscalationReason
+) -> None:
+    lead_assessor, _ = assessor(error)
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is expected
+    assert outcome.detail
+    assert outcome.metering is None
+
+
+def test_timeout_is_distinguished_from_a_plain_connection_error() -> None:
+    """``APITimeoutError`` subclasses ``APIConnectionError``, so handler order matters.
+
+    Catch them the other way round and every timeout is filed as ``api_error``, and the
+    one metric that tells you the model is thinking too long stops moving.
+    """
+    assert issubclass(anthropic.APITimeoutError, anthropic.APIConnectionError)
+    timeout_assessor, _ = assessor(anthropic.APITimeoutError(request=httpx_request()))
+    outcome = timeout_assessor.assess(config=make_config(), rendered_lead=LEAD)
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.TIMEOUT
+
+
+def test_schema_violation_is_a_parse_error() -> None:
+    class Tiny(BaseModel):
+        n: int
+
+    try:
+        Tiny.model_validate({"n": "not a number"})
+    except ValidationError as exc:
+        error: BaseException = exc
+
+    lead_assessor, _ = assessor(error)
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.PARSE_ERROR
+
+
+def test_missing_parsed_output_is_a_parse_error_not_a_crash() -> None:
+    lead_assessor, _ = assessor(FakeMessage(stop_reason="end_turn", parsed_output=None))
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.PARSE_ERROR
+
+
+def test_truncated_response_is_a_parse_error() -> None:
+    """``max_tokens`` means thinking ate the budget; whatever came back is not an answer."""
+    lead_assessor, _ = assessor(
+        FakeMessage(stop_reason="max_tokens", parsed_output=make_assessment())
+    )
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.PARSE_ERROR
+    assert "max_tokens" in outcome.detail
+
+
+def test_prompt_version_mismatch_escalates_rather_than_raising() -> None:
+    """Even a misconfigured tenant must not lose the lead — invariant 3 has no exceptions."""
+    config = make_config(prompt_version="rubric_v99")
+    lead_assessor, messages = assessor(FakeMessage(parsed_output=make_assessment()))
+
+    outcome = lead_assessor.assess(config=config, rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.reason is EscalationReason.API_ERROR
+    assert "rubric_v99" in outcome.detail
+    assert messages.calls == []
+
+
+def test_no_failure_is_ever_reported_as_a_success() -> None:
+    """The one bug this whole file exists to prevent: a failure read as a bad lead."""
+    failures: list[object] = [
+        FakeMessage(stop_reason="refusal"),
+        FakeMessage(stop_reason="end_turn", parsed_output=None),
+        FakeMessage(stop_reason="max_tokens", parsed_output=make_assessment()),
+        anthropic.APITimeoutError(request=httpx_request()),
+        anthropic.InternalServerError("boom", response=httpx_response(500), body=None),
+        RuntimeError("unpredicted"),
+    ]
+    for result in failures:
+        lead_assessor, _ = assessor(result)
+        outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+        assert isinstance(outcome, AssessmentFailed), result
+        assert outcome.reason is not EscalationReason.LOW_CONFIDENCE
+
+
+# --------------------------------------------------------------------------- the money
+
+
+def test_prices_are_the_published_claude_opus_5_rates() -> None:
+    assert CLAUDE_OPUS_5_PRICES.input_usd_per_mtok == Decimal("5.00")
+    assert CLAUDE_OPUS_5_PRICES.output_usd_per_mtok == Decimal("25.00")
+    # Cache reads are 0.1x base input, 5-minute-TTL writes are 1.25x base input.
+    assert CLAUDE_OPUS_5_PRICES.cache_read_usd_per_mtok == Decimal("0.50")
+    assert CLAUDE_OPUS_5_PRICES.cache_write_usd_per_mtok == Decimal("6.25")
+
+
+def test_cost_arithmetic_against_hand_computed_values() -> None:
+    """Hand-computed, not recomputed with the same expression the code uses.
+
+    1,000,000 input   x $5.00/MTok  = $5.00
+      200,000 output  x $25.00/MTok = $5.00
+      400,000 cache reads x $0.50/MTok = $0.20
+       80,000 cache writes x $6.25/MTok = $0.50
+                                        --------
+                                          $10.70
+    """
+    cost = token_cost_usd(
+        input_tokens=1_000_000,
+        output_tokens=200_000,
+        cache_read_tokens=400_000,
+        cache_creation_tokens=80_000,
+    )
+    assert cost == Decimal("10.70")
+
+
+def test_cost_of_a_realistic_single_call() -> None:
+    """1,500 uncached input, 900 output, 4,000 cache reads, no write.
+
+    1_500 / 1e6 * 5.00   = 0.0075
+      900 / 1e6 * 25.00  = 0.0225
+    4_000 / 1e6 * 0.50   = 0.0020
+                          -------
+                           0.0320
+    """
+    assert token_cost_usd(
+        input_tokens=1_500,
+        output_tokens=900,
+        cache_read_tokens=4_000,
+        cache_creation_tokens=0,
+    ) == Decimal("0.0320")
+
+
+def test_zero_usage_costs_nothing() -> None:
+    assert token_cost_usd(
+        input_tokens=0, output_tokens=0, cache_read_tokens=0, cache_creation_tokens=0
+    ) == Decimal(0)
+
+
+def test_cost_is_decimal_not_float() -> None:
+    """Money is summed per tenant for billing; binary floats would drift."""
+    cost = token_cost_usd(
+        input_tokens=1, output_tokens=1, cache_read_tokens=1, cache_creation_tokens=1
+    )
+    assert isinstance(cost, Decimal)
+
+
+def test_metering_cost_matches_the_standalone_calculation() -> None:
+    usage = FakeUsage(
+        input_tokens=1_500,
+        output_tokens=900,
+        cache_read_input_tokens=4_000,
+        cache_creation_input_tokens=0,
+    )
+    lead_assessor, _ = assessor(FakeMessage(parsed_output=make_assessment(), usage=usage))
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentSucceeded)
+    assert outcome.metering.cost_usd == Decimal("0.0320")
+
+
+def test_prices_can_be_overridden_without_editing_the_adapter() -> None:
+    """A price change is a constant swap, not a code change — that is the whole point."""
+    doubled = TokenPrices(
+        input_usd_per_mtok=Decimal("10.00"),
+        output_usd_per_mtok=Decimal("50.00"),
+        cache_read_usd_per_mtok=Decimal("1.00"),
+        cache_write_usd_per_mtok=Decimal("12.50"),
+    )
+    assert token_cost_usd(
+        input_tokens=1_000_000,
+        output_tokens=0,
+        cache_read_tokens=0,
+        cache_creation_tokens=0,
+        prices=doubled,
+    ) == Decimal("10.00")

--- a/tests/unit/test_llm_anthropic.py
+++ b/tests/unit/test_llm_anthropic.py
@@ -6,37 +6,49 @@ here. What earns the tests is everything that can go wrong, because invariant 3 
 comes back as a typed outcome a human can be routed on. So the assertions below are mostly
 about failure:
 
-* a refusal is read from ``stop_reason`` **before** ``.content`` is touched at all, and it
-  escalates rather than disqualifying;
+* a refusal is read from ``stop_reason`` **before** the content is validated, in all three
+  shapes a refusal arrives in, and it escalates rather than disqualifying;
 * every SDK exception class lands on exactly one :class:`EscalationReason`;
+* every failure that reached an HTTP 200 carries its metering, because a truncation and a
+  schema violation are billed in full and are the two most expensive ways to fail;
 * nothing — not a truncation, not a schema violation, not an exception the SDK has never
   raised before — can come back as a success carrying a low score.
 
 The request side is asserted just as tightly, because a silently wrong request is the
 expensive kind: block 0 must carry ``cache_control`` and block 1 must not (a breakpoint on
 the tenant block caches nothing while still paying the write premium), and the model,
-``max_tokens``, effort and ``output_format`` must be exactly what the plan says.
+``max_tokens``, effort and the output schema must be exactly what the plan says.
 
-No network, no key, no recorded payload: the fake client returns objects shaped like the
-SDK's, and the parse path against a realistic payload is ``tests/contract/``'s job.
+**How the gate order is proved.** The fake used to hand back an already-parsed object and
+a ``.content`` property that raised, so that reading content at all failed the test. That
+stopped being able to prove anything once the adapter took over validation — the whole
+point of the change is that it now reads content itself. The proof moved into the data:
+the refused response carries prose (:data:`REFUSAL_PROSE`) that cannot validate, so
+``MODEL_REFUSAL`` is reachable only by checking ``stop_reason`` first. ``FakeMessages``
+also raises if anything calls ``messages.parse``, the helper whose internal parse step
+caused the original defect.
+
+No network, no key: the fake client returns objects shaped like the SDK's. Whether the SDK
+agrees with that shape is ``tests/contract/``'s job.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
 from decimal import Decimal
-from typing import Any
+from typing import Any, Final
 
 import anthropic
 import httpx2
 import pytest
-from pydantic import BaseModel, ValidationError
+from pydantic import BaseModel
 
 from leadquali.adapters.llm_anthropic import (
     CACHE_CONTROL_EPHEMERAL,
     CLAUDE_OPUS_5_PRICES,
     MAX_TOKENS,
     MODEL_ID,
+    OUTPUT_FORMAT,
     AnthropicLeadAssessor,
     TokenPrices,
     token_cost_usd,
@@ -111,22 +123,64 @@ class FakeUsage(BaseModel):
     cache_creation_input_tokens: int | None = 0
 
 
+@dataclass(frozen=True)
+class FakeTextBlock:
+    """Shaped like ``anthropic.types.TextBlock``."""
+
+    text: str
+    type: str = "text"
+
+
+@dataclass(frozen=True)
+class FakeThinkingBlock:
+    """Shaped like ``anthropic.types.ThinkingBlock``.
+
+    Present in every real ``claude-opus-5`` response — thinking is adaptive and on by
+    default — and it carries no ``.text``. A block-selection bug that reaches for
+    ``content[0].text`` crashes here rather than in production.
+    """
+
+    thinking: str = ""
+    signature: str = "ErUBCkYIBRgCIkZmYWtl"
+    type: str = "thinking"
+
+
+def blocks(payload: str | None, *, thinking: bool = True) -> list[object]:
+    """The content list of a realistic response: a thinking block, then the JSON text.
+
+    ``payload=None`` is the pathological response that carries no text block at all.
+    """
+    content: list[object] = [FakeThinkingBlock()] if thinking else []
+    if payload is not None:
+        content.append(FakeTextBlock(text=payload))
+    return content
+
+
+def assessment_json(assessment: LeadAssessment | None = None) -> str:
+    """A well-formed response body: what the model returns when everything works."""
+    return (assessment or make_assessment()).model_dump_json()
+
+
 @dataclass
 class FakeMessage:
-    """A response object whose ``.content`` explodes if anything reads it.
+    """A response object shaped like ``anthropic.types.Message``.
 
-    That is the point: the refusal check has to happen before content is touched, and the
-    cheapest way to prove a line of code never ran is to make running it fail.
+    The adapter now reads and validates ``.content`` itself, so — unlike the previous
+    fake, whose ``.content`` raised — this one hands back real blocks. Proving the gate
+    order therefore moves to :data:`REFUSAL_PROSE`: a refusal whose text block would fail
+    validation, so the only way to reach ``MODEL_REFUSAL`` is to check ``stop_reason``
+    first. That is the same shape the contract fixture replays through the real SDK.
     """
 
     stop_reason: str | None = "end_turn"
     stop_details: object | None = None
-    parsed_output: LeadAssessment | None = None
+    content: list[object] = field(default_factory=lambda: blocks(assessment_json()))
     usage: FakeUsage = field(default_factory=FakeUsage)
 
-    @property
-    def content(self) -> list[object]:
-        raise AssertionError("the adapter read .content; stop_reason must be checked first")
+
+#: A refusal's prose: valid content, and not a ``LeadAssessment``. Anthropic documents the
+#: classifier firing mid-stream, after output has already been emitted.
+REFUSAL_PROSE: Final[str] = "I can't help with this request."
 
 
 @dataclass
@@ -136,11 +190,24 @@ class FakeMessages:
     result: object
     calls: list[dict[str, Any]] = field(default_factory=list)
 
-    def parse(self, **kwargs: Any) -> Any:
+    def create(self, **kwargs: Any) -> Any:
         self.calls.append(kwargs)
         if isinstance(self.result, BaseException):
             raise self.result
         return self.result
+
+    def parse(self, **kwargs: Any) -> Any:
+        """The helper the adapter must *not* call.
+
+        ``messages.parse`` validates every text block inside the SDK before returning, so
+        a refusal carrying prose raises ``ValidationError`` from the call and never
+        reaches the ``stop_reason`` gate. The adapter went to some trouble to stop using
+        it; this makes a regression loud instead of silent.
+        """
+        raise AssertionError(
+            "the adapter called messages.parse; it must call messages.create and gate on "
+            "stop_reason before validating content"
+        )
 
 
 @dataclass
@@ -177,7 +244,7 @@ def test_block_zero_is_cacheable_and_block_one_is_not() -> None:
     nothing and costs the 1.25x write premium on every first request of every tenant.
     """
     config = make_config()
-    lead_assessor, messages = assessor(FakeMessage(parsed_output=make_assessment()))
+    lead_assessor, messages = assessor(FakeMessage())
 
     lead_assessor.assess(config=config, rendered_lead=LEAD)
 
@@ -193,15 +260,16 @@ def test_block_zero_is_cacheable_and_block_one_is_not() -> None:
 
 def test_request_parameters_are_exactly_as_intended() -> None:
     config = make_config()
-    lead_assessor, messages = assessor(FakeMessage(parsed_output=make_assessment()))
+    lead_assessor, messages = assessor(FakeMessage())
 
     lead_assessor.assess(config=config, rendered_lead=LEAD)
 
     call = messages.calls[0]
     assert call["model"] == MODEL_ID == "claude-opus-5"
     assert call["max_tokens"] == MAX_TOKENS == 8000
-    assert call["output_format"] is LeadAssessment
-    assert call["output_config"] == {"effort": DEFAULT_EFFORT}
+    # The schema goes on the request explicitly, because the adapter no longer lets the
+    # SDK derive it — and derive a parse of the response along with it.
+    assert call["output_config"] == {"effort": DEFAULT_EFFORT, "format": OUTPUT_FORMAT}
     assert call["messages"] == [{"role": "user", "content": LEAD}]
     # The lead is a user turn, never a system block: it is attacker-controlled text and it
     # must not sit inside the cached prefix.
@@ -213,11 +281,9 @@ def test_default_effort_is_medium_and_effort_is_a_parameter() -> None:
     assert DEFAULT_EFFORT == "medium"
     config = make_config()
     for effort in EFFORT_LEVELS:
-        lead_assessor, messages = assessor(
-            FakeMessage(parsed_output=make_assessment()), effort=effort
-        )
+        lead_assessor, messages = assessor(FakeMessage(), effort=effort)
         lead_assessor.assess(config=config, rendered_lead=LEAD)
-        assert messages.calls[0]["output_config"] == {"effort": effort}
+        assert messages.calls[0]["output_config"]["effort"] == effort
 
 
 def test_unknown_effort_is_rejected_at_construction() -> None:
@@ -237,7 +303,7 @@ def test_success_carries_the_assessment_and_full_provenance() -> None:
         cache_read_input_tokens=4_000,
         cache_creation_input_tokens=0,
     )
-    lead_assessor, _ = assessor(FakeMessage(parsed_output=expected, usage=usage))
+    lead_assessor, _ = assessor(FakeMessage(content=blocks(assessment_json(expected)), usage=usage))
 
     outcome = lead_assessor.assess(config=config, rendered_lead=LEAD)
 
@@ -263,7 +329,7 @@ def test_absent_cache_counters_read_as_zero_not_none() -> None:
         cache_read_input_tokens=None,
         cache_creation_input_tokens=None,
     )
-    lead_assessor, _ = assessor(FakeMessage(parsed_output=make_assessment(), usage=usage))
+    lead_assessor, _ = assessor(FakeMessage(usage=usage))
 
     outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
 
@@ -273,12 +339,12 @@ def test_absent_cache_counters_read_as_zero_not_none() -> None:
 
 
 def test_latency_is_recorded_on_success_and_on_failure() -> None:
-    slow = FakeMessage(parsed_output=make_assessment())
+    slow = FakeMessage()
     lead_assessor, messages = assessor(slow)
 
-    original = messages.parse
+    original = messages.create
 
-    def slow_parse(**kwargs: Any) -> Any:
+    def slow_create(**kwargs: Any) -> Any:
         # Busy-wait past a millisecond so the assertion is about the clock, not luck.
         import time
 
@@ -287,7 +353,7 @@ def test_latency_is_recorded_on_success_and_on_failure() -> None:
             pass
         return original(**kwargs)
 
-    messages.parse = slow_parse  # type: ignore[method-assign]
+    messages.create = slow_create  # type: ignore[method-assign]
     outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
     assert isinstance(outcome, AssessmentSucceeded)
     assert outcome.metering.latency_ms >= 1
@@ -301,16 +367,28 @@ def test_latency_is_recorded_on_success_and_on_failure() -> None:
 # ----------------------------------------------------------------------------- refusals
 
 
-def test_refusal_escalates_and_never_reads_content() -> None:
-    """Invariant 3: a refusal is a human's problem, not a score of zero.
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param([], id="pre-output"),
+        pytest.param(blocks(None), id="thinking-only"),
+        pytest.param(blocks(REFUSAL_PROSE), id="mid-stream-prose"),
+    ],
+)
+def test_every_documented_refusal_shape_escalates(content: list[object]) -> None:
+    """Invariant 3, across all three shapes a refusal actually arrives in.
 
-    ``FakeMessage.content`` raises, so this passes only if the adapter checks
-    ``stop_reason`` first and returns without ever looking at the blocks.
+    Anthropic documents the classifier firing *before any output* (empty ``content``) or
+    *mid-stream* after partial output. The third row is the one that used to be misfiled:
+    prose in a text block is not a ``LeadAssessment``, so any implementation that
+    validates content before consulting ``stop_reason`` reports it as a parse error and
+    the ``MODEL_REFUSAL`` signal is lost. All three must reach the same verdict.
     """
     lead_assessor, _ = assessor(
         FakeMessage(
             stop_reason="refusal",
             stop_details=None,
+            content=content,
             usage=FakeUsage(input_tokens=1_200, output_tokens=3),
         )
     )
@@ -323,11 +401,19 @@ def test_refusal_escalates_and_never_reads_content() -> None:
     assert not hasattr(outcome, "assessment")
 
 
-def test_refusal_still_meters_the_call() -> None:
-    """A refusal is an HTTP 200 and it is billed, so it must still be metered."""
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param([], id="pre-output"),
+        pytest.param(blocks(REFUSAL_PROSE), id="mid-stream-prose"),
+    ],
+)
+def test_refusal_still_meters_the_call(content: list[object]) -> None:
+    """A refusal is an HTTP 200 and a mid-stream one is billed, so it must be metered."""
     lead_assessor, _ = assessor(
         FakeMessage(
             stop_reason="refusal",
+            content=content,
             usage=FakeUsage(input_tokens=1_200, output_tokens=3),
         )
     )
@@ -349,12 +435,69 @@ def test_refusal_detail_carries_the_stop_details_category() -> None:
         category: str = "cyber"
         explanation: str = "declined"
 
-    lead_assessor, _ = assessor(FakeMessage(stop_reason="refusal", stop_details=Details()))
+    lead_assessor, _ = assessor(
+        FakeMessage(
+            stop_reason="refusal",
+            stop_details=Details(),
+            content=blocks(REFUSAL_PROSE),
+        )
+    )
 
     outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
 
     assert isinstance(outcome, AssessmentFailed)
     assert "cyber" in outcome.detail
+
+
+def test_refusal_detail_never_quotes_the_refused_content() -> None:
+    """Invariant 5: the refusal prose and ``explanation`` both describe the submission."""
+
+    @dataclass(frozen=True)
+    class Details:
+        type: str = "refusal"
+        category: str = "cyber"
+        explanation: str = "the submission asks about intrusion tooling"
+
+    lead_assessor, _ = assessor(
+        FakeMessage(
+            stop_reason="refusal",
+            stop_details=Details(),
+            content=blocks(REFUSAL_PROSE),
+        )
+    )
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.detail == "model declined to answer (category=cyber)"
+    assert "intrusion" not in outcome.detail
+    assert REFUSAL_PROSE not in outcome.detail
+
+
+def test_a_refusal_is_never_read_as_a_schema_violation() -> None:
+    """The regression this whole change exists to prevent, stated as one assertion.
+
+    The refused response carries prose that cannot validate. If the gate order is ever
+    inverted — validate first, check ``stop_reason`` second — this comes back as
+    ``PARSE_ERROR`` with no metering, and the fact that a safety classifier is firing on
+    our traffic vanishes into the parse-error bucket.
+    """
+    lead_assessor, _ = assessor(
+        FakeMessage(
+            stop_reason="refusal",
+            content=blocks(REFUSAL_PROSE),
+            usage=FakeUsage(input_tokens=731, output_tokens=96),
+        )
+    )
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    # Stated in the order the bug would break: not the parse-error bucket, and metered.
+    assert outcome.reason is not EscalationReason.PARSE_ERROR
+    assert outcome.reason is EscalationReason.MODEL_REFUSAL
+    assert outcome.metering is not None
+    assert outcome.metering.output_tokens == 96
 
 
 # ------------------------------------------------------------------- exception mapping
@@ -424,35 +567,90 @@ def test_timeout_is_distinguished_from_a_plain_connection_error() -> None:
     assert outcome.reason is EscalationReason.TIMEOUT
 
 
-def test_schema_violation_is_a_parse_error() -> None:
-    class Tiny(BaseModel):
-        n: int
+@pytest.mark.parametrize(
+    ("payload", "detail_fragment"),
+    [
+        pytest.param('{"dimension_scores": {"icp_fit": ', "<root>", id="truncated-json"),
+        pytest.param("Sure! Here is the assessment.", "<root>", id="prose-not-json"),
+        pytest.param("{}", "confidence", id="empty-object"),
+        pytest.param(
+            make_assessment().model_dump_json().replace('"icp_fit":24', '"icp_fit":999'),
+            "dimension_scores.icp_fit",
+            id="out-of-range-score",
+        ),
+    ],
+)
+def test_schema_violation_is_a_parse_error(payload: str, detail_fragment: str) -> None:
+    """Validation now happens here, so the failure is raised and handled here.
 
-    try:
-        Tiny.model_validate({"n": "not a number"})
-    except ValidationError as exc:
-        error: BaseException = exc
+    ``detail`` names field paths and never the offending value: a Pydantic message quotes
+    its input, and the input on this path is model output derived from lead text.
+    """
+    lead_assessor, _ = assessor(FakeMessage(content=blocks(payload)))
 
-    lead_assessor, _ = assessor(error)
     outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
 
     assert isinstance(outcome, AssessmentFailed)
     assert outcome.reason is EscalationReason.PARSE_ERROR
+    assert detail_fragment in outcome.detail
+    assert payload not in outcome.detail
 
 
-def test_missing_parsed_output_is_a_parse_error_not_a_crash() -> None:
-    lead_assessor, _ = assessor(FakeMessage(stop_reason="end_turn", parsed_output=None))
+def test_a_schema_violation_is_metered_because_a_whole_response_was_billed() -> None:
+    """A response that fails validation cost exactly as much as one that passes."""
+    lead_assessor, _ = assessor(
+        FakeMessage(
+            content=blocks("not an assessment"),
+            usage=FakeUsage(input_tokens=700, output_tokens=812),
+        )
+    )
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.metering is not None
+    assert outcome.metering.output_tokens == 812
+    assert outcome.metering.cost_usd > Decimal(0)
+
+
+@pytest.mark.parametrize(
+    "content",
+    [
+        pytest.param([], id="no-blocks"),
+        pytest.param(blocks(None), id="thinking-only"),
+    ],
+)
+def test_a_response_with_no_text_block_is_a_parse_error_not_a_crash(
+    content: list[object],
+) -> None:
+    """Unreachable given ``output_config.format`` — and still not worth routing a lead on."""
+    lead_assessor, _ = assessor(FakeMessage(stop_reason="end_turn", content=content))
 
     outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
 
     assert isinstance(outcome, AssessmentFailed)
     assert outcome.reason is EscalationReason.PARSE_ERROR
+    assert outcome.metering is not None
+
+
+def test_a_thinking_block_never_gets_mistaken_for_the_answer() -> None:
+    """Thinking is on by default, so block 0 is not the JSON — ``content[0]`` is a bug."""
+    lead_assessor, _ = assessor(FakeMessage(content=blocks(assessment_json())))
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentSucceeded)
+    assert outcome.assessment == make_assessment()
 
 
 def test_truncated_response_is_a_parse_error() -> None:
-    """``max_tokens`` means thinking ate the budget; whatever came back is not an answer."""
+    """``max_tokens`` means thinking ate the budget; whatever came back is not an answer.
+
+    Note the content is *schema-valid* here: the gate is ``stop_reason``, not parseability.
+    A truncated response that happens to validate is still a fragment, not a judgment.
+    """
     lead_assessor, _ = assessor(
-        FakeMessage(stop_reason="max_tokens", parsed_output=make_assessment())
+        FakeMessage(stop_reason="max_tokens", content=blocks(assessment_json()))
     )
 
     outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
@@ -462,10 +660,29 @@ def test_truncated_response_is_a_parse_error() -> None:
     assert "max_tokens" in outcome.detail
 
 
+def test_a_truncation_is_metered_because_it_burned_the_whole_output_budget() -> None:
+    """The most expensive failure the adapter has: 8,000 output tokens for nothing."""
+    lead_assessor, _ = assessor(
+        FakeMessage(
+            stop_reason="max_tokens",
+            content=blocks('{"dimension_scores": {"icp_fit": 2'),
+            usage=FakeUsage(input_tokens=700, output_tokens=MAX_TOKENS),
+        )
+    )
+
+    outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
+
+    assert isinstance(outcome, AssessmentFailed)
+    assert outcome.metering is not None
+    assert outcome.metering.output_tokens == MAX_TOKENS
+    # 8,000 output tokens at $25/MTok is $0.20 of budget burned on a fragment.
+    assert outcome.metering.cost_usd >= Decimal("0.20")
+
+
 def test_prompt_version_mismatch_escalates_rather_than_raising() -> None:
     """Even a misconfigured tenant must not lose the lead — invariant 3 has no exceptions."""
     config = make_config(prompt_version="rubric_v99")
-    lead_assessor, messages = assessor(FakeMessage(parsed_output=make_assessment()))
+    lead_assessor, messages = assessor(FakeMessage())
 
     outcome = lead_assessor.assess(config=config, rendered_lead=LEAD)
 
@@ -478,9 +695,13 @@ def test_prompt_version_mismatch_escalates_rather_than_raising() -> None:
 def test_no_failure_is_ever_reported_as_a_success() -> None:
     """The one bug this whole file exists to prevent: a failure read as a bad lead."""
     failures: list[object] = [
-        FakeMessage(stop_reason="refusal"),
-        FakeMessage(stop_reason="end_turn", parsed_output=None),
-        FakeMessage(stop_reason="max_tokens", parsed_output=make_assessment()),
+        FakeMessage(stop_reason="refusal", content=[]),
+        FakeMessage(stop_reason="refusal", content=blocks(REFUSAL_PROSE)),
+        # A refusal whose text block happens to be schema-valid: still never a score.
+        FakeMessage(stop_reason="refusal", content=blocks(assessment_json())),
+        FakeMessage(stop_reason="end_turn", content=blocks(None)),
+        FakeMessage(stop_reason="end_turn", content=blocks("not json at all")),
+        FakeMessage(stop_reason="max_tokens", content=blocks(assessment_json())),
         anthropic.APITimeoutError(request=httpx_request()),
         anthropic.InternalServerError("boom", response=httpx_response(500), body=None),
         RuntimeError("unpredicted"),
@@ -560,7 +781,7 @@ def test_metering_cost_matches_the_standalone_calculation() -> None:
         cache_read_input_tokens=4_000,
         cache_creation_input_tokens=0,
     )
-    lead_assessor, _ = assessor(FakeMessage(parsed_output=make_assessment(), usage=usage))
+    lead_assessor, _ = assessor(FakeMessage(usage=usage))
 
     outcome = lead_assessor.assess(config=make_config(), rendered_lead=LEAD)
 


### PR DESCRIPTION
Closes #11. Based on #51 (rubric prompt) → #49 → #41 → #40 → #39.

The one file in the repository that imports `anthropic` — asserted by a test, not by convention.

## Public API

`leadquali.app.ports.LeadAssessorPort` — `assess(*, config, rendered_lead) -> AssessmentOutcome`. `rendered_lead` is #12's already-delimited user turn, sent verbatim as a **user** message, never as a system block.

`leadquali.app.assessment_result` — `AssessmentOutcome = AssessmentSucceeded | AssessmentFailed`, plus `CallMetering` and `Effort`.

`leadquali.adapters.llm_anthropic` — `AnthropicLeadAssessor`, `build_anthropic_client`, `token_cost_usd`, `TokenPrices`, `MODEL_ID`, `MAX_TOKENS`, `CLAUDE_OPUS_5_PRICES`.

## Why a discriminated result instead of exceptions

`AssessmentFailed` has **no `assessment` attribute**. That is the point: there is no shape of a failure that can be misread as an assessment with low scores, so the "API failure quietly becomes a disqualification" bug is unrepresentable rather than merely untested. mypy narrows on `outcome.ok` in both `if` and `match`, so the caller cannot forget the failure branch. #14 maps a failure through `system_failure(reason, detail)` from #52.

## Failure handling

Handlers are ordered most-specific-first, because the SDK's hierarchy nests: `APITimeoutError ⊂ APIConnectionError` and `RateLimitError ⊂ APIStatusError`. Getting that order wrong would silently collapse timeouts into generic API errors.

| Condition | `EscalationReason` |
|---|---|
| `stop_reason == "refusal"` — **checked before any read of `.content`** | `model_refusal` |
| `APITimeoutError` | `timeout` |
| connection / rate limit / status / SDK error / unforeseen `Exception` | `api_error` |
| `ValidationError`, `stop_reason == "max_tokens"`, `parsed_output is None` | `parse_error` |

A refusal is still metered — it is a billed 200 response — and it escalates to a human. Never a disqualification.

Retries are the SDK's own, with a comment stating what they do and do not cover. No hand-rolled second retry loop on top.

## Caching and cost

Block 0 (the rubric) gets `cache_control: {"type": "ephemeral"}`; block 1 (the tenant block) does not. Tested by asserting the exact request payload.

`CLAUDE_OPUS_5_PRICES` in USD/MTok: input `5.00`, output `25.00`, cache read `0.50`, cache write `6.25`. Taken from the `claude-api` reference (§ Current Models, cached 2026-06-24; cache multipliers from its prompt-caching § Economics — 0.1× read, 1.25× 5-minute-TTL write), **not from memory**, with the source in a comment at the constant. It is marked as an estimate that must be re-checked against the invoice before anyone bills a customer on it — #33 turns these numbers into margin.

Cost is `Decimal`, not `float`.

## Verification — all offline, no key in this environment

63 new tests (253 passing, 1 `live_api` skipped and still selectable with `-m live_api`):
- the exact request payload — model, `max_tokens`, effort, `output_format`, and cache breakpoint placement;
- a refusal producing the refusal escalation **without touching `.content`**;
- every exception class mapping to its `EscalationReason`;
- cost arithmetic asserted against hand-computed values;
- contract tests in `tests/contract/` against recorded success and refusal fixtures, so the parse path meets a realistic payload shape;
- `test_layering.py` asserting no module outside the adapter imports `anthropic`.

## Two things for you

1. **Effort is per-assessor, not per-tenant.** #24 sweeps by constructing assessors, which is enough for the sweep. If a tenant should be able to pin its own effort, that is a `TenantConfig` field and a small follow-up.
2. **Server-side refusal fallbacks are not enabled** (plan §5 lists them as "consider"). Today a refusal escalates to a human, which is the safe default. Turning on an automatic fallback model is a policy call — yours.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_