### PR TITLE
[P2.3] Postgres store adapter: tenant-scoped repositories and idempotent writes

### DIFF
--- a/src/leadquali/adapters/store_postgres.py
+++ b/src/leadquali/adapters/store_postgres.py
@@ -1,0 +1,677 @@
+"""Postgres implementations of the store and tenant-config ports.
+
+Two adapters live here, both over the same tables and the same session factory:
+:class:`PostgresLeadStore` (:class:`~leadquali.app.ports.LeadStorePort`) and
+:class:`PostgresTenantConfigSource` (:class:`~leadquali.app.ports.TenantConfigPort`). The
+schema itself is :mod:`leadquali.adapters.db_schema` and is not touched here — this module
+is only the behaviour, which is why the migration environment can import the tables without
+importing connection handling.
+
+What the whole module is organised around
+-----------------------------------------
+
+**Invariant 4: every method takes a tenant and every statement filters on it.** Not one
+query in this file can be executed without a tenant predicate — including the "obviously
+unambiguous" ones where ``lead_id`` is a UUID and could not collide. That is not
+defensiveness about collisions, it is the property #32's isolation suite exists to attack:
+an adapter that filters on the tenant *cannot* serve tenant B's row to tenant A even when
+a caller is confused, and the way to keep that true a year from now is for there to be no
+code path in which it is optional. The upsert goes further and repeats the tenant in the
+``ON CONFLICT ... WHERE`` clause, so the predicate is in the SQL even where the unique
+index already implies it.
+
+**Idempotency is the database's job, not the worker's.** SQS is at-least-once, so
+:meth:`PostgresLeadStore.upsert_lead` is one ``INSERT ... ON CONFLICT DO UPDATE ...
+RETURNING`` against ``uq_leads_tenant_id_submission_id``. A ``SELECT`` followed by an
+``INSERT`` would be correct in a test and wrong in production: two workers handling the
+same redelivered message interleave between the two statements, one of them raises a
+uniqueness error, and the lead that was already stored looks like a crash. ``DO UPDATE``
+rather than ``DO NOTHING`` because ``DO NOTHING`` returns no row for the loser of that race
+— and the follow-up ``SELECT`` may not see the winner's row until it commits — whereas
+``DO UPDATE`` waits for the concurrent transaction, then returns the surviving row. The
+"update" writes the submission id back onto itself: it changes nothing, and it is what
+makes ``RETURNING`` produce a row in both branches.
+
+``is_new`` then comes from ``RETURNING id, (xmax = 0)``: on a row this statement inserted
+the system column ``xmax`` is zero, and on one it updated it holds the current transaction
+id. It is the standard Postgres idiom for "did my ``ON CONFLICT`` insert or update", and it
+is the only way to answer it in a single round trip.
+
+**No SQL is assembled from strings.** Every statement is built from SQLAlchemy Core
+constructs over the mapped tables, so tenant ids, submission ids and lead payloads travel
+as bound parameters. The single literal fragment in the file is the constant
+``(xmax = 0)``, which contains no input of any kind.
+
+Connection handling, and how it meets #27
+-----------------------------------------
+
+There is **no engine at import time**. :func:`engine_for` is memoised per URL and builds
+the engine on first use, so importing this module — which the Lambda bundle does at cold
+start, before any configuration may have been resolved — neither opens a socket nor fails
+in a place where the traceback has no request to attach itself to. The first call inside
+the container creates it; every later invocation on that warm container reuses it. That is
+the "one connection per container" shape a Lambda wants:
+
+* ``pool_size=1`` with ``max_overflow=0`` — a Lambda container serves one invocation at a
+  time, so a second pooled connection would sit idle holding a backend slot. It also makes
+  the arithmetic in #27 trivial: **reserved concurrency is the connection budget.** N
+  concurrent workers hold at most N server connections, and the number to reason about is
+  the one already written in the function's configuration.
+* ``pool_pre_ping=True`` and a ``pool_recycle`` below any proxy or server idle timeout. A
+  warm container can sit unused for minutes; RDS Proxy (or the server, or a NAT idle
+  timer) may have dropped the connection in the meantime, and the pre-ping turns what would
+  be a failed invocation into a transparent reconnect.
+* Prepared statements are disabled on the psycopg connection (``prepare_threshold=None``).
+  Server-side prepared statements are session state, and session state is what makes RDS
+  Proxy *pin* a client to a backend connection — pinning defeats the multiplexing that is
+  the reason for putting the proxy in front of Lambda at all. Giving that up costs a plan
+  per statement; keeping it would cost the proxy's whole purpose.
+* Every method opens a session, does its work and commits. There are no long-lived
+  transactions and nothing is held across an invocation — another pinning trigger, and the
+  reason a worker that dies mid-run leaves no locks behind for the redelivery to wait on.
+
+The store takes its ``sessionmaker`` as a constructor argument rather than reaching for a
+global, so the entrypoint decides (#26 wires one per container, the integration tests bind
+one to a transaction they roll back), and :meth:`PostgresLeadStore.from_env` is the
+convenience that reads ``DATABASE_URL`` through :class:`~leadquali.config.Settings`.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import re
+import uuid
+from datetime import datetime
+from decimal import Decimal
+from functools import lru_cache
+from typing import Any, Final
+
+from sqlalchemy import (
+    Boolean,
+    Engine,
+    create_engine,
+    insert,
+    literal_column,
+    null,
+    or_,
+    select,
+    update,
+)
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.orm import Session, sessionmaker
+
+from leadquali.adapters.db_schema import Assessment, Lead, RoutingEvent, Tenant
+from leadquali.adapters.seed import tenant_id_for
+from leadquali.app.assessment_result import AssessmentOutcome, CallMetering
+from leadquali.app.ports import RoutingOutcome, StoredLead
+from leadquali.config import Settings, get_settings
+from leadquali.domain.models import Action, RoutingDecision
+from leadquali.domain.tenant_config import (
+    TENANT_ID_PATTERN,
+    TenantConfig,
+    TenantConfigError,
+    TenantNotFoundError,
+)
+from leadquali.prompts.lead import LeadSubmission
+
+__all__ = [
+    "LEAD_IDEMPOTENCY_CONSTRAINT",
+    "UNKNOWN_MODEL_ID",
+    "UNKNOWN_PROMPT_VERSION",
+    "PostgresLeadStore",
+    "PostgresTenantConfigSource",
+    "assessment_values",
+    "contact_email_hash",
+    "engine_for",
+    "lead_uuid",
+    "session_factory",
+    "tenant_uuid",
+]
+
+LOGGER = logging.getLogger(__name__)
+
+#: The unique constraint ``upsert_lead`` resolves its conflict against. Named rather than
+#: inferred from columns so that a rename in #15's schema breaks loudly here.
+LEAD_IDEMPOTENCY_CONSTRAINT: Final[str] = "uq_leads_tenant_id_submission_id"
+
+#: Recorded as the model provenance of an attempt that never reached the model — a
+#: connection error or a timeout has no ``model_id`` to report, and the columns are NOT
+#: NULL because every *billed* row must have them. A sentinel is honest and greppable;
+#: guessing the configured model would put a lie in the billing table.
+UNKNOWN_MODEL_ID: Final[str] = "unknown"
+UNKNOWN_PROMPT_VERSION: Final[str] = "unknown"
+
+#: ``assessments.status`` values. Mirrors ``db_schema.ASSESSMENT_STATUSES``.
+ASSESSMENT_STATUS_OK: Final[str] = "ok"
+ASSESSMENT_STATUS_FAILED: Final[str] = "failed"
+
+#: ``leads.status`` values this adapter writes. Mirrors ``db_schema.LEAD_STATUSES``:
+#: ingest leaves a lead ``received``, an assessment moves it to ``qualified`` or
+#: ``failed``, and a final routing event moves it to ``routed``.
+LEAD_STATUS_QUALIFIED: Final[str] = "qualified"
+LEAD_STATUS_FAILED: Final[str] = "failed"
+LEAD_STATUS_ROUTED: Final[str] = "routed"
+
+#: Engine defaults; see the module docstring for why each one is what it is.
+DEFAULT_POOL_SIZE: Final[int] = 1
+DEFAULT_MAX_OVERFLOW: Final[int] = 0
+DEFAULT_POOL_RECYCLE_SECONDS: Final[int] = 300
+DEFAULT_CONNECT_TIMEOUT_SECONDS: Final[int] = 5
+
+_TENANT_SLUG_RE: Final[re.Pattern[str]] = re.compile(TENANT_ID_PATTERN)
+
+#: Scales of the two ``Numeric`` columns this adapter writes floats into.
+_SCORE_QUANTUM: Final[Decimal] = Decimal("0.01")
+_CONFIDENCE_QUANTUM: Final[Decimal] = Decimal("0.001")
+_COST_QUANTUM: Final[Decimal] = Decimal("0.000001")
+
+
+# --------------------------------------------------------------------------- identities
+
+
+def tenant_uuid(tenant_id: str) -> uuid.UUID:
+    """Resolve a port-level tenant id to the ``tenants.id`` primary key.
+
+    The ports speak in ``str`` tenant ids and the database keys on UUIDs, and the mapping
+    between them already exists: ``scripts/seed.py`` derives a tenant's row id from its
+    slug with UUID5 (:func:`leadquali.adapters.seed.tenant_id_for`), which is what makes
+    seeding idempotent and gives the default tenant the same id in every environment. This
+    function is that same mapping and imports it rather than restating it — two spellings
+    of "which row is this tenant" is how a lead ends up filed under a tenant that does not
+    exist.
+
+    A value that is already a UUID is taken as the row id itself, so a caller holding an id
+    read out of the database does not have to know about slugs.
+
+    Raises:
+        ValueError: the id is neither a UUID nor a valid tenant slug. Refused here rather
+            than passed to the query, because tenant ids arrive from queue messages and
+            request payloads.
+    """
+    try:
+        return uuid.UUID(tenant_id)
+    except ValueError:
+        pass
+    if not _TENANT_SLUG_RE.match(tenant_id):
+        raise ValueError(
+            f"tenant id {tenant_id!r} is neither a UUID nor a valid slug "
+            f"(expected {TENANT_ID_PATTERN})"
+        )
+    return tenant_id_for(tenant_id)
+
+
+def lead_uuid(lead_id: str) -> uuid.UUID:
+    """Parse a port-level lead id into the UUID the tables key on.
+
+    Raises:
+        ValueError: not a UUID. A lead id is only ever obtained from
+            :meth:`PostgresLeadStore.upsert_lead`, so anything else is a bug in the caller
+            and is worth a clear message rather than an empty result set.
+    """
+    try:
+        return uuid.UUID(lead_id)
+    except ValueError:
+        raise ValueError(f"lead id {lead_id!r} is not a UUID") from None
+
+
+def contact_email_hash(email: str | None) -> str | None:
+    """SHA-256 of the normalised contact address, or ``None`` when there is no address.
+
+    Invariant 5: this is what a log line or a metric carries so one person's leads can be
+    correlated without their address ever leaving ``leads.raw_payload``. Normalised —
+    stripped and lowercased — so that ``Ada@Example.com`` and ``ada@example.com`` correlate
+    to the same person, which is the entire point of storing it.
+
+    Not a secret and not reversible-proof: an email address has little entropy, so this
+    defends against casual disclosure in logs, not against a determined attacker with the
+    hash. It is never returned to a caller and never logged next to the address.
+    """
+    if email is None:
+        return None
+    normalised = email.strip().lower()
+    if not normalised:
+        return None
+    return hashlib.sha256(normalised.encode("utf-8")).hexdigest()
+
+
+# ------------------------------------------------------------------- engine & sessions
+
+
+@lru_cache(maxsize=8)
+def engine_for(url: str) -> Engine:
+    """The process-wide engine for one database URL, created on first use.
+
+    Memoised rather than module-level so that importing this module opens nothing: see the
+    module docstring on cold starts. Keyed by URL, so a test pointing at a throwaway
+    database does not share a pool with the process's real one.
+    """
+    return create_engine(
+        url,
+        pool_size=DEFAULT_POOL_SIZE,
+        max_overflow=DEFAULT_MAX_OVERFLOW,
+        pool_pre_ping=True,
+        pool_recycle=DEFAULT_POOL_RECYCLE_SECONDS,
+        connect_args={
+            "connect_timeout": DEFAULT_CONNECT_TIMEOUT_SECONDS,
+            # Session state pins an RDS Proxy client to a backend connection; see the
+            # module docstring.
+            "prepare_threshold": None,
+        },
+    )
+
+
+@lru_cache(maxsize=8)
+def session_factory(url: str) -> sessionmaker[Session]:
+    """The process-wide session factory for one database URL.
+
+    ``expire_on_commit=False`` because every method here commits and then returns plain
+    values: re-fetching a row after the transaction it belongs to has ended is a round trip
+    bought for nothing.
+    """
+    return sessionmaker(bind=engine_for(url), expire_on_commit=False)
+
+
+def session_factory_from_env(settings: Settings | None = None) -> sessionmaker[Session]:
+    """The session factory for the configured ``DATABASE_URL``.
+
+    Raises:
+        RuntimeError: ``DATABASE_URL`` was never set. Loud at wiring time rather than at
+            the first lead.
+    """
+    resolved = settings if settings is not None else get_settings()
+    return session_factory(resolved.require_database_url())
+
+
+# ------------------------------------------------------------------------- value mapping
+
+
+def assessment_values(*, outcome: AssessmentOutcome, decision: RoutingDecision) -> dict[str, Any]:
+    """The ``assessments`` columns for one attempt — successful or not.
+
+    Split out as a pure function because the interesting half of this mapping is a shape
+    rule enforced by a CHECK constraint (``output_present_iff_ok``), and a pure function is
+    testable without a database: a successful run carries every model-output column plus
+    the verdict code derived from them, and a failed run carries none of them and must say
+    why. Getting that wrong is not a silent bug — the insert is rejected — but finding out
+    at 3am against live traffic is worse than finding out in a unit test.
+
+    Metering is written whenever it is present, on success **or** failure: a refusal is an
+    HTTP 200 that Anthropic bills for, and a ``max_tokens`` truncation is billed too, so a
+    failure that was charged for has to appear in the same ``SUM`` as a success. When it is
+    absent — the call never completed — the NOT NULL provenance columns take
+    :data:`UNKNOWN_MODEL_ID` / :data:`UNKNOWN_PROMPT_VERSION`, the counters stay zero, and
+    ``latency_ms`` still records how long the failing attempt took.
+    """
+    values: dict[str, Any]
+    if outcome.ok:
+        assessment = outcome.assessment
+        values = {
+            "status": ASSESSMENT_STATUS_OK,
+            # Set on a *successful* assessment too, when the confidence gate rejected it.
+            "escalation_reason": _reason_value(decision),
+            "tier": decision.tier.value,
+            "total_score": _quantise(decision.total_score, _SCORE_QUANTUM),
+            "dimension_scores": assessment.dimension_scores.model_dump(mode="json"),
+            "extracted": assessment.extracted.model_dump(mode="json"),
+            "reasoning": assessment.reasoning,
+            "confidence": _quantise(assessment.confidence, _CONFIDENCE_QUANTUM),
+            "missing_information": list(assessment.missing_information),
+        }
+    else:
+        values = {
+            "status": ASSESSMENT_STATUS_FAILED,
+            # NOT NULL for a failure under the CHECK, and taken from the outcome rather
+            # than the decision: the outcome is the observation, the decision is what
+            # policy made of it, and only the first is guaranteed to carry a reason.
+            "escalation_reason": outcome.reason.value,
+            "tier": None,
+            "total_score": None,
+            # ``null()``, not ``None``. A Python ``None`` bound to a JSONB column is sent
+            # as the JSON value ``null``, which is a perfectly good *value*: it satisfies
+            # ``dimension_scores IS NOT NULL`` and so a failed assessment written that way
+            # is rejected by ``output_present_iff_ok``, which is the constraint that keeps
+            # a half-written row from masquerading as a real assessment. The two columns
+            # below are the only JSONB ones this branch nulls; the rest are ordinary types
+            # where ``None`` already means SQL NULL.
+            "dimension_scores": null(),
+            "extracted": null(),
+            "reasoning": None,
+            "confidence": None,
+            # Not part of the all-or-nothing group: "nothing was reported missing" is as
+            # true of a failed run as of a clean one.
+            "missing_information": [],
+        }
+
+    metering: CallMetering | None = outcome.metering
+    if metering is not None:
+        values |= {
+            "model_id": metering.model_id,
+            "prompt_version": metering.prompt_version,
+            "effort": metering.effort,
+            "input_tokens": metering.input_tokens,
+            "output_tokens": metering.output_tokens,
+            "cache_read_tokens": metering.cache_read_tokens,
+            "cache_creation_tokens": metering.cache_creation_tokens,
+            "cost_usd": metering.cost_usd.quantize(_COST_QUANTUM),
+            "latency_ms": metering.latency_ms,
+        }
+    else:
+        values |= {
+            "model_id": UNKNOWN_MODEL_ID,
+            "prompt_version": UNKNOWN_PROMPT_VERSION,
+            "effort": None,
+            "input_tokens": 0,
+            "output_tokens": 0,
+            "cache_read_tokens": 0,
+            "cache_creation_tokens": 0,
+            "cost_usd": Decimal(0),
+            # Narrowed rather than assumed: a success always carries metering, so the
+            # only outcome that reaches this branch is a failure, which knows how long
+            # it took before it gave up.
+            "latency_ms": 0 if outcome.ok else outcome.latency_ms,
+        }
+    return values
+
+
+def _reason_value(decision: RoutingDecision) -> str | None:
+    return decision.escalation_reason.value if decision.escalation_reason is not None else None
+
+
+def _quantise(value: float, quantum: Decimal) -> Decimal:
+    """A float onto the scale of its ``Numeric`` column, via ``str`` to avoid binary dust.
+
+    ``Decimal(0.1)`` is 0.1000000000000000055511151231257827; ``Decimal("0.1")`` is 0.1.
+    The column is ``Numeric`` precisely so sums over it stay exact, and going through the
+    binary value would put the imprecision back.
+    """
+    return Decimal(str(value)).quantize(quantum)
+
+
+# ------------------------------------------------------------------------------- stores
+
+
+class PostgresLeadStore:
+    """:class:`~leadquali.app.ports.LeadStorePort` over the Postgres schema of #15.
+
+    Substitutable for ``tests.fakes.InMemoryLeadStore``: both are exercised by the same
+    contract suite (``tests/contract/lead_store_contract.py``), because a double that has
+    drifted from the adapter it stands in for is worse than no double at all.
+
+    Every method opens its own short transaction and commits before returning. Failures are
+    raised, never swallowed: a store that cannot write is not a degraded mode, it is a
+    reason to leave the message on the queue.
+    """
+
+    def __init__(self, sessions: sessionmaker[Session]) -> None:
+        """Take the session factory to use. See :func:`session_factory`."""
+        self._sessions = sessions
+
+    @classmethod
+    def from_url(cls, url: str) -> PostgresLeadStore:
+        """A store over the memoised engine for ``url``."""
+        return cls(session_factory(url))
+
+    @classmethod
+    def from_env(cls, settings: Settings | None = None) -> PostgresLeadStore:
+        """A store over the configured ``DATABASE_URL``."""
+        return cls(session_factory_from_env(settings))
+
+    # ----------------------------------------------------------------------- leads
+
+    def upsert_lead(
+        self,
+        *,
+        tenant_id: str,
+        submission_id: str,
+        submission: LeadSubmission,
+        source: str,
+        received_at: datetime,
+    ) -> StoredLead:
+        """Insert this lead, or return the existing one for the same submission id.
+
+        One statement, and it is the whole idempotency guarantee: see the module docstring
+        for why it is ``ON CONFLICT DO UPDATE ... RETURNING (xmax = 0)`` and not a
+        ``SELECT`` followed by an ``INSERT``.
+
+        A redelivery deliberately does **not** overwrite the stored payload, source or
+        ``received_at``: the first delivery is the record of what arrived and when, and a
+        retry that rewrote it would quietly erase the queue latency the columns exist to
+        measure.
+        """
+        tenant = tenant_uuid(tenant_id)
+        if not submission_id:
+            # ``ck_leads_submission_id_not_blank`` would reject this anyway; saying so here
+            # names the offending argument instead of quoting a constraint.
+            raise ValueError("submission_id must not be blank; it is the idempotency key")
+
+        insertion = pg_insert(Lead).values(
+            tenant_id=tenant,
+            submission_id=submission_id,
+            raw_payload=submission.model_dump(mode="json"),
+            source=source,
+            received_at=received_at,
+            contact_email_hash=contact_email_hash(submission.email),
+        )
+        statement = insertion.on_conflict_do_update(
+            constraint=LEAD_IDEMPOTENCY_CONSTRAINT,
+            # A no-op write of the conflicting column onto itself. DO UPDATE is what makes
+            # RETURNING produce the surviving row under a concurrent redelivery; there is
+            # nothing about the lead we want to change.
+            set_={"submission_id": insertion.excluded.submission_id},
+            # Redundant against the conflict target, which already contains tenant_id, and
+            # kept because invariant 4 is "every statement filters on the tenant" with no
+            # exceptions for the ones that are provably safe.
+            where=Lead.tenant_id == tenant,
+        ).returning(Lead.id, literal_column("(xmax = 0)", Boolean))
+
+        with self._sessions.begin() as session:
+            row = session.execute(statement).one()
+        return StoredLead(lead_id=str(row[0]), is_new=bool(row[1]))
+
+    def already_routed(self, *, tenant_id: str, lead_id: str) -> bool:
+        """Whether this lead has a *final* routing event — dispatched or suppressed.
+
+        #15's ``routing_events`` has no ``outcome`` column, so finality is read off the two
+        columns that carry it: a dispatch stamps ``dispatched_at``, and a suppression is
+        the ``suppress`` action (a suppression involves no external call, so it cannot
+        fail). A failed send leaves ``dispatched_at`` NULL under a dispatching action and
+        is therefore not final — which is the point: one SES outage must not convert a
+        retryable failure into a permanently lost lead.
+        """
+        tenant = tenant_uuid(tenant_id)
+        lead = lead_uuid(lead_id)
+        statement = (
+            select(RoutingEvent.id)
+            .where(
+                RoutingEvent.tenant_id == tenant,
+                RoutingEvent.lead_id == lead,
+                or_(
+                    RoutingEvent.dispatched_at.is_not(None),
+                    RoutingEvent.action == Action.SUPPRESS.value,
+                ),
+            )
+            .limit(1)
+        )
+        with self._sessions.begin() as session:
+            return session.execute(statement).first() is not None
+
+    # ----------------------------------------------------------------- assessments
+
+    def record_assessment(
+        self,
+        *,
+        tenant_id: str,
+        lead_id: str,
+        outcome: AssessmentOutcome,
+        decision: RoutingDecision,
+        recorded_at: datetime,
+    ) -> None:
+        """Record what the model said and what policy concluded from it.
+
+        A failed attempt is a row like any other — see :func:`assessment_values` — and the
+        lead's status follows it: ``qualified`` when there is an assessment, ``failed``
+        when there is not. The two writes share one transaction, so a lead is never left
+        claiming a state its assessment history does not support.
+
+        ``recorded_at`` is written to ``created_at`` rather than left to the server's
+        ``now()``: the pipeline reads its clock through a port so tests are deterministic
+        and a replay can re-run a lead with the timestamps it originally had, and a row
+        stamped by the server would quietly opt out of that.
+        """
+        tenant = tenant_uuid(tenant_id)
+        lead = lead_uuid(lead_id)
+        statement = insert(Assessment).values(
+            tenant_id=tenant,
+            lead_id=lead,
+            created_at=recorded_at,
+            **assessment_values(outcome=outcome, decision=decision),
+        )
+        status = LEAD_STATUS_QUALIFIED if outcome.ok else LEAD_STATUS_FAILED
+        with self._sessions.begin() as session:
+            session.execute(statement)
+            self._set_lead_status(session, tenant=tenant, lead=lead, status=status)
+
+    # --------------------------------------------------------------- routing events
+
+    def record_routing_event(
+        self,
+        *,
+        tenant_id: str,
+        lead_id: str,
+        action: Action,
+        destination: str | None,
+        outcome: RoutingOutcome,
+        provider_message_id: str | None,
+        occurred_at: datetime,
+        detail: str,
+    ) -> None:
+        """Record where the lead went, or why it did not go anywhere.
+
+        The outcome is encoded in the columns #15's table has rather than stored as a word:
+        ``DISPATCHED`` stamps ``dispatched_at``, ``SUPPRESSED`` is the ``suppress`` action
+        with ``dispatched_at`` left NULL (nothing was dispatched), and ``FAILED`` is a
+        dispatching action that never got its stamp. :meth:`already_routed` reads finality
+        back out of exactly those two columns.
+
+        ``detail`` has no column to go in, so it is logged rather than dropped: it is one
+        short PII-free line by contract (invariant 5), and squeezing it into
+        ``provider_message_id`` — the one field an operator traces a delivery complaint
+        with — would corrupt the column that has a job. Giving it a column of its own is a
+        migration, and this issue does not own the schema; it is flagged in the report.
+
+        Raises:
+            ValueError: ``action`` and ``outcome`` disagree about suppression. Since
+                suppression is encoded *as* the action, a ``SUPPRESSED`` outcome under
+                another action would be invisible to :meth:`already_routed` and the lead
+                would be processed again, and a ``FAILED`` suppression would be read as
+                final though nothing happened. Neither combination is meaningful, and both
+                are better refused than silently mis-recorded.
+        """
+        suppressing = action is Action.SUPPRESS
+        if suppressing is not (outcome is RoutingOutcome.SUPPRESSED):
+            raise ValueError(
+                f"action {action.value!r} and outcome {outcome.value!r} disagree: "
+                "a suppression is recorded as the 'suppress' action and nothing else is"
+            )
+
+        tenant = tenant_uuid(tenant_id)
+        lead = lead_uuid(lead_id)
+        final = outcome is not RoutingOutcome.FAILED
+        statement = insert(RoutingEvent).values(
+            tenant_id=tenant,
+            lead_id=lead,
+            action=action.value,
+            destination=destination,
+            dispatched_at=occurred_at if outcome is RoutingOutcome.DISPATCHED else None,
+            provider_message_id=provider_message_id,
+            created_at=occurred_at,
+        )
+        with self._sessions.begin() as session:
+            session.execute(statement)
+            if final:
+                self._set_lead_status(session, tenant=tenant, lead=lead, status=LEAD_STATUS_ROUTED)
+        # PII-free by the port's contract: the decision's note or a failure's class, never
+        # lead content and never an address.
+        LOGGER.info(
+            "routing event recorded tenant=%s lead=%s action=%s outcome=%s detail=%s",
+            tenant,
+            lead,
+            action.value,
+            outcome.value,
+            detail,
+        )
+
+    # ---------------------------------------------------------------------- helpers
+
+    @staticmethod
+    def _set_lead_status(
+        session: Session, *, tenant: uuid.UUID, lead: uuid.UUID, status: str
+    ) -> None:
+        """Move one lead's lifecycle status, tenant-scoped like everything else."""
+        session.execute(
+            update(Lead).where(Lead.tenant_id == tenant, Lead.id == lead).values(status=status)
+        )
+
+
+class PostgresTenantConfigSource:
+    """:class:`~leadquali.app.ports.TenantConfigPort` over ``tenants.icp_config``.
+
+    The Phase 1 file loader (``adapters/tenant_config_json.py``) and this class are
+    interchangeable at the entrypoint: both hand back a fully validated
+    :class:`~leadquali.domain.tenant_config.TenantConfig` or raise, because a tenant whose
+    policy cannot be loaded must never have its leads routed by someone else's policy.
+    ``scripts/seed.py`` stores the config document verbatim, so the column is handed
+    straight to the model rather than reassembled from parts.
+
+    Reads are uncached, exactly as the file loader's are: the document is a few hundred
+    bytes, and picking up an operator's edit without a redeploy is worth far more than the
+    round trip. Caching it per container would also mean the tenant that changed its
+    routing table waits for a cold start to see the change.
+    """
+
+    def __init__(self, sessions: sessionmaker[Session]) -> None:
+        """Take the session factory to use. See :func:`session_factory`."""
+        self._sessions = sessions
+
+    @classmethod
+    def from_url(cls, url: str) -> PostgresTenantConfigSource:
+        """A config source over the memoised engine for ``url``."""
+        return cls(session_factory(url))
+
+    @classmethod
+    def from_env(cls, settings: Settings | None = None) -> PostgresTenantConfigSource:
+        """A config source over the configured ``DATABASE_URL``."""
+        return cls(session_factory_from_env(settings))
+
+    def get(self, tenant_id: str) -> TenantConfig:
+        """Return the validated configuration for ``tenant_id``.
+
+        Raises:
+            TenantNotFoundError: no such tenant row.
+            TenantConfigError: the row exists and its ``icp_config`` is not a valid
+                configuration — including the case where it declares a different tenant
+                than the one asked for, which means the seed and the caller disagree about
+                identity and is not something to guess about.
+        """
+        try:
+            tenant = tenant_uuid(tenant_id)
+        except ValueError as exc:
+            raise TenantConfigError(f"tenant '{tenant_id}': {exc}") from exc
+
+        statement = select(Tenant.icp_config).where(Tenant.id == tenant)
+        with self._sessions.begin() as session:
+            document = session.execute(statement).scalar_one_or_none()
+
+        if document is None:
+            raise TenantNotFoundError(
+                f"tenant '{tenant_id}': no row in tenants (id {tenant}); seed it first"
+            )
+
+        config = TenantConfig.from_dict(document)
+        if tenant_id != str(tenant) and config.tenant_id != tenant_id:
+            raise TenantConfigError(
+                f"tenant '{tenant_id}': icp_config declares tenant_id "
+                f"'{config.tenant_id}'; the row and its config must agree"
+            )
+        return config

--- a/tests/contract/lead_store_contract.py
+++ b/tests/contract/lead_store_contract.py
@@ -1,0 +1,417 @@
+"""The behaviour every ``LeadStorePort`` implementation has to share.
+
+This module holds no tests of its own — it is a mixin, imported by
+``tests/unit/test_lead_store_inmemory.py`` (against ``tests.fakes.InMemoryLeadStore``) and
+by ``tests/integration/test_store_postgres.py`` (against real Postgres). One suite, two
+implementations, because the fake is what every other issue's tests run against: any
+behaviour the double and the adapter do not share is a bug that can only be discovered in
+production, where the fake is not the thing running.
+
+The contract is deliberately about *observable* behaviour — what ``upsert_lead`` returns
+on a redelivery, what ``already_routed`` says after each kind of routing event, that a
+tenant cannot see another tenant's history. Columns, SQL and rows are the Postgres
+adapter's own business and are asserted in its own module.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import pytest
+
+from leadquali.app.assessment_result import (
+    AssessmentFailed,
+    AssessmentSucceeded,
+    CallMetering,
+    Effort,
+)
+from leadquali.app.ports import LeadStorePort, RoutingOutcome
+from leadquali.domain.models import (
+    Action,
+    DimensionScores,
+    EscalationReason,
+    ExtractedFacts,
+    LeadAssessment,
+    RoutingDecision,
+    Tier,
+)
+from leadquali.prompts.lead import LeadSubmission
+
+NOW = datetime(2026, 9, 2, 12, 0, tzinfo=UTC)
+
+
+def make_submission(
+    *,
+    email: str | None = "Ada@Example.com",
+    message: str = "We get about 200 web-form leads a month and nobody triages them.",
+) -> LeadSubmission:
+    """A plausible inbound submission. ``email`` is mixed-case on purpose: the hash is
+    computed over the normalised address, and a test that only ever passes lowercase text
+    cannot tell whether normalisation happens."""
+    return LeadSubmission(
+        full_name="Ada Lovelace",
+        email=email,
+        company="Analytical Engines",
+        role="VP Sales",
+        message=message,
+    )
+
+
+def make_assessment(*, confidence: float = 0.82, spam: bool = False) -> LeadAssessment:
+    """A schema-valid model output."""
+    return LeadAssessment(
+        dimension_scores=DimensionScores(
+            icp_fit=24, intent=20, authority=12, urgency=9, budget_signal=10
+        ),
+        extracted=ExtractedFacts(
+            company_name="Analytical Engines",
+            industry="B2B software",
+            company_size_estimate="50-100",
+            role_seniority="vp",
+            stated_use_case="triage inbound leads",
+            stated_timeline="this quarter",
+        ),
+        reasoning="Inbound volume and a named owner are both stated.",
+        confidence=confidence,
+        missing_information=["budget"],
+        suggested_first_question="How is the queue triaged today?",
+        spam_or_test_submission=spam,
+    )
+
+
+def make_metering(
+    *,
+    model_id: str = "claude-opus-5",
+    prompt_version: str = "rubric_v1",
+    effort: Effort = "medium",
+    latency_ms: int = 2_100,
+) -> CallMetering:
+    """Provenance and cost for one call, as the Anthropic adapter reports it."""
+    return CallMetering(
+        model_id=model_id,
+        prompt_version=prompt_version,
+        effort=effort,
+        input_tokens=1_200,
+        output_tokens=380,
+        cache_read_tokens=4_800,
+        cache_creation_tokens=0,
+        cost_usd=Decimal("0.012345"),
+        latency_ms=latency_ms,
+    )
+
+
+def make_succeeded(*, confidence: float = 0.82) -> AssessmentSucceeded:
+    """A billed call that produced a usable assessment."""
+    return AssessmentSucceeded(
+        assessment=make_assessment(confidence=confidence), metering=make_metering()
+    )
+
+
+def make_failed(
+    *,
+    reason: EscalationReason = EscalationReason.API_ERROR,
+    metering: CallMetering | None = None,
+    latency_ms: int = 900,
+) -> AssessmentFailed:
+    """A call that produced no assessment. ``metering`` is set for a *billed* failure —
+    a refusal or a ``max_tokens`` truncation — and ``None`` when the call never completed.
+    """
+    return AssessmentFailed(
+        reason=reason,
+        detail=f"{reason.value} from the provider",
+        latency_ms=latency_ms,
+        metering=metering,
+    )
+
+
+def make_decision(
+    *,
+    tier: Tier = Tier.WARM,
+    action: Action = Action.EMAIL_SALES,
+    total_score: float = 62.5,
+    escalation_reason: EscalationReason | None = None,
+    note: str = "Routed to sales.",
+) -> RoutingDecision:
+    """What the deterministic layer concluded. Produced by code, never by the model."""
+    return RoutingDecision(
+        tier=tier,
+        action=action,
+        total_score=total_score,
+        note=note,
+        escalation_reason=escalation_reason,
+    )
+
+
+class LeadStoreContract:
+    """Mixin of the behaviour a ``LeadStorePort`` must have, whatever backs it.
+
+    Subclasses override the two fixtures. ``tenants`` yields two *distinct* tenant ids that
+    both exist as far as the implementation is concerned, because half of this contract is
+    about what one tenant cannot see of the other.
+    """
+
+    @pytest.fixture
+    def store(self) -> LeadStorePort:
+        raise NotImplementedError("a LeadStoreContract subclass provides the store")
+
+    @pytest.fixture
+    def tenants(self) -> tuple[str, str]:
+        raise NotImplementedError("a LeadStoreContract subclass provides two tenant ids")
+
+    # ------------------------------------------------------------------ upsert_lead
+
+    def test_a_first_delivery_creates_a_new_lead(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        tenant, _ = tenants
+        lead = store.upsert_lead(
+            tenant_id=tenant,
+            submission_id="sub-1",
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+        assert lead.is_new is True
+        assert lead.lead_id
+
+    def test_replaying_a_submission_returns_the_first_lead(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        """SQS is at-least-once: the second delivery must not raise, must not create a
+        second lead, and must come back carrying the first row's id."""
+        tenant, _ = tenants
+        first = store.upsert_lead(
+            tenant_id=tenant,
+            submission_id="sub-replay",
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+        second = store.upsert_lead(
+            tenant_id=tenant,
+            submission_id="sub-replay",
+            submission=make_submission(message="resent by the browser"),
+            source="web_form",
+            received_at=NOW,
+        )
+        assert second.lead_id == first.lead_id
+        assert second.is_new is False
+
+    def test_two_tenants_may_use_the_same_submission_id(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        """Submission ids are unique *per tenant*. Two customers numbering their forms
+        from 1 is not a collision, and treating it as one would hand tenant B's lead to
+        tenant A."""
+        tenant_a, tenant_b = tenants
+        first = store.upsert_lead(
+            tenant_id=tenant_a,
+            submission_id="shared-id",
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+        second = store.upsert_lead(
+            tenant_id=tenant_b,
+            submission_id="shared-id",
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+        assert second.is_new is True
+        assert second.lead_id != first.lead_id
+
+    # --------------------------------------------------------------- already_routed
+
+    def test_a_stored_lead_has_not_been_routed_yet(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-fresh")
+        assert store.already_routed(tenant_id=tenant, lead_id=lead) is False
+
+    def test_a_dispatched_lead_counts_as_routed(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-dispatched")
+        store.record_routing_event(
+            tenant_id=tenant,
+            lead_id=lead,
+            action=Action.EMAIL_SALES,
+            destination="sales@example.invalid",
+            outcome=RoutingOutcome.DISPATCHED,
+            provider_message_id="ses-1",
+            occurred_at=NOW,
+            detail="Routed to sales.",
+        )
+        assert store.already_routed(tenant_id=tenant, lead_id=lead) is True
+
+    def test_a_suppressed_lead_counts_as_routed(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        """A suppression is a final answer, so a redelivery must do nothing — and the
+        suppression itself is still on the record."""
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-suppressed")
+        store.record_routing_event(
+            tenant_id=tenant,
+            lead_id=lead,
+            action=Action.SUPPRESS,
+            destination=None,
+            outcome=RoutingOutcome.SUPPRESSED,
+            provider_message_id=None,
+            occurred_at=NOW,
+            detail="Spam or test submission.",
+        )
+        assert store.already_routed(tenant_id=tenant, lead_id=lead) is True
+
+    def test_a_failed_dispatch_does_not_count_as_routed(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        """The one that matters most: if a failed send made this true, a single SES outage
+        would convert a retryable failure into a permanently lost lead."""
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-failed-send")
+        store.record_routing_event(
+            tenant_id=tenant,
+            lead_id=lead,
+            action=Action.EMAIL_SALES,
+            destination="sales@example.invalid",
+            outcome=RoutingOutcome.FAILED,
+            provider_message_id=None,
+            occurred_at=NOW,
+            detail="dispatch failed: ConnectionError",
+        )
+        assert store.already_routed(tenant_id=tenant, lead_id=lead) is False
+
+    def test_a_retry_after_a_failed_dispatch_marks_the_lead_routed(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-retry")
+        for outcome, message_id in (
+            (RoutingOutcome.FAILED, None),
+            (RoutingOutcome.DISPATCHED, "ses-2"),
+        ):
+            store.record_routing_event(
+                tenant_id=tenant,
+                lead_id=lead,
+                action=Action.EMAIL_SALES,
+                destination="sales@example.invalid",
+                outcome=outcome,
+                provider_message_id=message_id,
+                occurred_at=NOW,
+                detail="attempt",
+            )
+        assert store.already_routed(tenant_id=tenant, lead_id=lead) is True
+
+    def test_already_routed_is_scoped_to_the_tenant(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        """Invariant 4, asked as the question that would hurt: tenant B must not be able to
+        learn anything about tenant A's lead, even holding its id."""
+        tenant_a, tenant_b = tenants
+        lead = self._lead(store, tenant_a, "sub-private")
+        store.record_routing_event(
+            tenant_id=tenant_a,
+            lead_id=lead,
+            action=Action.EMAIL_SALES,
+            destination="sales@example.invalid",
+            outcome=RoutingOutcome.DISPATCHED,
+            provider_message_id="ses-3",
+            occurred_at=NOW,
+            detail="Routed to sales.",
+        )
+        assert store.already_routed(tenant_id=tenant_b, lead_id=lead) is False
+
+    def test_an_assessment_does_not_make_a_lead_routed(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        """Assessed is not delivered. A worker that died between the two must retry."""
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-assessed-only")
+        store.record_assessment(
+            tenant_id=tenant,
+            lead_id=lead,
+            outcome=make_succeeded(),
+            decision=make_decision(),
+            recorded_at=NOW,
+        )
+        assert store.already_routed(tenant_id=tenant, lead_id=lead) is False
+
+    # ------------------------------------------------------------ record_assessment
+
+    def test_a_successful_assessment_is_recorded(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-ok")
+        store.record_assessment(
+            tenant_id=tenant,
+            lead_id=lead,
+            outcome=make_succeeded(),
+            decision=make_decision(tier=Tier.HOT, total_score=88.25),
+            recorded_at=NOW,
+        )
+
+    def test_a_failed_assessment_is_recorded_too(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        """Invariant 3: an unassessable lead is still a lead, and "never dropped" is only
+        auditable if the attempt leaves a row."""
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-api-error")
+        store.record_assessment(
+            tenant_id=tenant,
+            lead_id=lead,
+            outcome=make_failed(reason=EscalationReason.API_ERROR),
+            decision=make_decision(
+                escalation_reason=EscalationReason.API_ERROR,
+                total_score=0.0,
+                note="The system could not assess this lead.",
+            ),
+            recorded_at=NOW,
+        )
+
+    def test_a_billed_failure_is_recorded(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        """A refusal is an HTTP 200 and it is charged for. A billed failure that left no
+        metering is money the business cannot see."""
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-refusal")
+        store.record_assessment(
+            tenant_id=tenant,
+            lead_id=lead,
+            outcome=make_failed(reason=EscalationReason.MODEL_REFUSAL, metering=make_metering()),
+            decision=make_decision(escalation_reason=EscalationReason.MODEL_REFUSAL),
+            recorded_at=NOW,
+        )
+
+    def test_a_low_confidence_escalation_is_a_successful_assessment(
+        self, store: LeadStorePort, tenants: tuple[str, str]
+    ) -> None:
+        """The model answered; code did not trust the answer. Both facts are recorded."""
+        tenant, _ = tenants
+        lead = self._lead(store, tenant, "sub-low-confidence")
+        store.record_assessment(
+            tenant_id=tenant,
+            lead_id=lead,
+            outcome=make_succeeded(confidence=0.2),
+            decision=make_decision(escalation_reason=EscalationReason.LOW_CONFIDENCE),
+            recorded_at=NOW,
+        )
+
+    # ------------------------------------------------------------------------ helper
+
+    @staticmethod
+    def _lead(store: LeadStorePort, tenant_id: str, submission_id: str) -> str:
+        return store.upsert_lead(
+            tenant_id=tenant_id,
+            submission_id=submission_id,
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        ).lead_id

--- a/tests/integration/test_store_postgres.py
+++ b/tests/integration/test_store_postgres.py
@@ -1,0 +1,886 @@
+"""The Postgres store adapter against a real Postgres.
+
+Two halves. The first is the shared contract from ``tests/contract/lead_store_contract.py``
+— the same fourteen behaviours ``tests/unit/test_lead_store_inmemory.py`` runs against the
+in-memory double, so the double and the adapter cannot drift apart unnoticed. The second is
+everything that is only true of the database: the columns the rows actually carry, the
+composite foreign key that stops a lead being filed under the wrong tenant, and the
+concurrent redelivery that a ``SELECT``-then-``INSERT`` would lose.
+
+Like the rest of ``tests/integration``, this skips — never fails — when ``DATABASE_URL`` is
+unset or nothing is listening, so CI without a service container stays green. Bring one up
+with ``docker compose up -d``; ``migrations`` are applied to a throwaway database of this
+module's own, never to the one in ``DATABASE_URL``.
+"""
+
+from __future__ import annotations
+
+import json
+import threading
+import uuid
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from sqlalchemy import Connection, Engine, Row, create_engine, delete, insert, select
+from sqlalchemy.engine import URL
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session, sessionmaker
+
+from leadquali.adapters.db_schema import Assessment, Lead, RoutingEvent, Tenant
+from leadquali.adapters.seed import seed_tenant, tenant_id_for
+from leadquali.adapters.store_postgres import (
+    UNKNOWN_MODEL_ID,
+    UNKNOWN_PROMPT_VERSION,
+    PostgresLeadStore,
+    PostgresTenantConfigSource,
+    contact_email_hash,
+)
+from leadquali.app.ports import LeadStorePort, RoutingOutcome, StoredLead
+from leadquali.domain.models import Action, EscalationReason, Tier
+from leadquali.domain.tenant_config import TenantConfigError, TenantNotFoundError
+from tests.contract.lead_store_contract import (
+    NOW,
+    LeadStoreContract,
+    make_decision,
+    make_failed,
+    make_metering,
+    make_submission,
+    make_succeeded,
+)
+from tests.integration.conftest import (
+    alembic_config,
+    database_url_in_environment,
+    temporary_database,
+)
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+#: Two tenants, both seeded, because half of what is under test here is what one of them
+#: cannot see of the other.
+TENANT_A = "store-tenant-a"
+TENANT_B = "store-tenant-b"
+
+
+# ------------------------------------------------------------------------- fixtures
+
+
+@pytest.fixture(scope="session")
+def store_database(_database_url: URL) -> Iterator[URL]:
+    """A migrated throwaway database of this module's own.
+
+    Deliberately not the ``<db>_test`` one ``conftest.migrated_engine`` builds: these tests
+    commit rows and run concurrent writers, and sharing a database with the schema suite
+    would make either one able to disturb the other.
+    """
+    name = f"{_database_url.database}_store_test"
+    with temporary_database(_database_url, name) as url, database_url_in_environment(url):
+        command.upgrade(alembic_config(), "head")
+        yield url
+
+
+@pytest.fixture(scope="session")
+def store_engine(store_database: URL) -> Iterator[Engine]:
+    """A normally-pooled engine for the throwaway database.
+
+    Not :func:`~leadquali.adapters.store_postgres.engine_for`: that one is deliberately
+    capped at a single connection per process, which is right for a Lambda container and
+    wrong for a test that needs two writers racing each other.
+    """
+    engine = create_engine(store_database)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(scope="session")
+def default_config_document() -> dict[str, Any]:
+    """The shipped tenant config, used as the shape of every seeded tenant here."""
+    raw = (REPO_ROOT / "tenants" / "default.json").read_text(encoding="utf-8")
+    document: dict[str, Any] = json.loads(raw)
+    return document
+
+
+@pytest.fixture(scope="session")
+def seeded_tenants(
+    store_engine: Engine, default_config_document: dict[str, Any]
+) -> tuple[str, str]:
+    """Two committed tenant rows. Leads cannot exist without one (``ON DELETE RESTRICT``)."""
+    with store_engine.begin() as connection:
+        for slug in (TENANT_A, TENANT_B):
+            seed_tenant(
+                connection,
+                {**default_config_document, "tenant_id": slug, "name": f"Tenant {slug}"},
+            )
+    return (TENANT_A, TENANT_B)
+
+
+@pytest.fixture
+def connection(store_engine: Engine) -> Iterator[Connection]:
+    """A connection whose transaction is rolled back, so tests cannot see each other."""
+    with store_engine.connect() as conn:
+        transaction = conn.begin()
+        try:
+            yield conn
+        finally:
+            transaction.rollback()
+
+
+@pytest.fixture
+def sessions(connection: Connection) -> sessionmaker[Session]:
+    """Sessions joined to the test's transaction as savepoints.
+
+    The adapter commits in every method — that is the behaviour under test — so the only
+    way to keep tests from leaking rows into each other is to make those commits release a
+    savepoint inside a transaction the fixture rolls back.
+    """
+    return sessionmaker(bind=connection, join_transaction_mode="create_savepoint")
+
+
+@pytest.fixture
+def store(sessions: sessionmaker[Session], seeded_tenants: tuple[str, str]) -> PostgresLeadStore:
+    del seeded_tenants  # ordering only: the tenants must exist before any lead does.
+    return PostgresLeadStore(sessions)
+
+
+def lead_row(connection: Connection, lead_id: str) -> Row[Any]:
+    return connection.execute(select(Lead).where(Lead.id == uuid.UUID(lead_id))).one()
+
+
+def assessment_rows(connection: Connection, lead_id: str) -> list[Row[Any]]:
+    return list(
+        connection.execute(select(Assessment).where(Assessment.lead_id == uuid.UUID(lead_id)))
+    )
+
+
+def routing_rows(connection: Connection, lead_id: str) -> list[Row[Any]]:
+    return list(
+        connection.execute(
+            select(RoutingEvent)
+            .where(RoutingEvent.lead_id == uuid.UUID(lead_id))
+            .order_by(RoutingEvent.created_at)
+        )
+    )
+
+
+# --------------------------------------------------------------- the shared contract
+
+
+class TestPostgresLeadStoreContract(LeadStoreContract):
+    """Every behaviour the port promises, checked against Postgres."""
+
+    @pytest.fixture
+    def store(self, store: PostgresLeadStore) -> LeadStorePort:
+        return store
+
+    @pytest.fixture
+    def tenants(self, seeded_tenants: tuple[str, str]) -> tuple[str, str]:
+        return seeded_tenants
+
+
+# ------------------------------------------------------------------- what rows carry
+
+
+def test_a_stored_lead_carries_the_payload_the_hash_and_the_timestamps(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    tenant, _ = seeded_tenants
+    submission = make_submission(email="Ada@Example.com")
+    stored = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="row-shape",
+        submission=submission,
+        source="webhook",
+        received_at=NOW,
+    )
+
+    row = lead_row(connection, stored.lead_id)
+    assert row.tenant_id == tenant_id_for(tenant)
+    assert row.source == "webhook"
+    assert row.received_at == NOW
+    assert row.status == "received"
+    # Invariant 5: the address lives in raw_payload and nowhere else, and the column that
+    # logs may quote is its hash of the *normalised* address.
+    assert row.contact_email_hash == contact_email_hash("ada@example.com")
+    assert row.raw_payload["email"] == "Ada@Example.com"
+
+
+def test_a_lead_with_no_email_hashes_to_null(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    tenant, _ = seeded_tenants
+    stored = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="no-email",
+        submission=make_submission(email=None),
+        source="web_form",
+        received_at=NOW,
+    )
+    assert lead_row(connection, stored.lead_id).contact_email_hash is None
+
+
+def test_a_redelivery_does_not_overwrite_what_first_arrived(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    """The first delivery is the record of what arrived and when. A retry that rewrote it
+    would erase the queue latency ``received_at`` exists to measure."""
+    tenant, _ = seeded_tenants
+    first = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="no-clobber",
+        submission=make_submission(message="original"),
+        source="web_form",
+        received_at=NOW,
+    )
+    later = datetime(2026, 9, 2, 13, 30, tzinfo=UTC)
+    second = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="no-clobber",
+        submission=make_submission(message="rewritten"),
+        source="csv_import",
+        received_at=later,
+    )
+
+    assert second.lead_id == first.lead_id
+    row = lead_row(connection, first.lead_id)
+    assert row.raw_payload["message"] == "original"
+    assert row.source == "web_form"
+    assert row.received_at == NOW
+
+
+def test_a_blank_submission_id_is_refused_before_it_reaches_the_database(
+    store: PostgresLeadStore, seeded_tenants: tuple[str, str]
+) -> None:
+    tenant, _ = seeded_tenants
+    with pytest.raises(ValueError, match="submission_id"):
+        store.upsert_lead(
+            tenant_id=tenant,
+            submission_id="",
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+
+
+def test_a_lead_for_an_unseeded_tenant_is_refused_by_the_foreign_key(
+    store: PostgresLeadStore,
+) -> None:
+    with pytest.raises(IntegrityError):
+        store.upsert_lead(
+            tenant_id="no-such-tenant",
+            submission_id="orphan",
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+
+
+def test_a_tenant_id_that_is_neither_a_uuid_nor_a_slug_is_refused(
+    store: PostgresLeadStore,
+) -> None:
+    """Tenant ids arrive from queue messages and request payloads."""
+    with pytest.raises(ValueError, match="neither a UUID nor a valid slug"):
+        store.already_routed(tenant_id="../../etc/passwd", lead_id=str(uuid.uuid4()))
+
+
+# -------------------------------------------------------------------- assessments
+
+
+def test_a_successful_assessment_records_the_judgment_the_verdict_and_the_cost(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    tenant, _ = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="assess-ok",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+
+    store.record_assessment(
+        tenant_id=tenant,
+        lead_id=lead,
+        outcome=make_succeeded(confidence=0.815),
+        decision=make_decision(tier=Tier.HOT, total_score=88.25),
+        recorded_at=NOW,
+    )
+
+    (row,) = assessment_rows(connection, lead)
+    assert row.status == "ok"
+    assert row.escalation_reason is None
+    assert row.tier == "hot"
+    assert row.total_score == Decimal("88.25")
+    assert row.confidence == Decimal("0.815")
+    assert row.dimension_scores["icp_fit"] == 24
+    assert row.extracted["industry"] == "B2B software"
+    assert row.reasoning
+    assert row.missing_information == ["budget"]
+    assert row.created_at == NOW
+    # Provenance and cost, so "did Tuesday's prompt change make things worse?" and the
+    # per-tenant billing SUM are both queries rather than opinions.
+    assert (row.model_id, row.prompt_version, row.effort) == (
+        "claude-opus-5",
+        "rubric_v1",
+        "medium",
+    )
+    assert (row.input_tokens, row.output_tokens) == (1_200, 380)
+    assert (row.cache_read_tokens, row.cache_creation_tokens) == (4_800, 0)
+    assert row.cost_usd == Decimal("0.012345")
+    assert row.latency_ms == 2_100
+    # An assessment exists, so the lead is qualified — not yet routed.
+    assert lead_row(connection, lead).status == "qualified"
+
+
+def test_a_failed_assessment_records_the_reason_and_leaves_the_model_columns_null(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    """The row #15's ``output_present_iff_ok`` CHECK exists to make possible: an attempt
+    that produced no judgment is still auditable, which is what invariant 3 needs."""
+    tenant, _ = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="assess-failed",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+
+    store.record_assessment(
+        tenant_id=tenant,
+        lead_id=lead,
+        outcome=make_failed(reason=EscalationReason.TIMEOUT, latency_ms=30_000),
+        decision=make_decision(
+            escalation_reason=EscalationReason.TIMEOUT,
+            total_score=0.0,
+            note="The system could not assess this lead.",
+        ),
+        recorded_at=NOW,
+    )
+
+    (row,) = assessment_rows(connection, lead)
+    assert row.status == "failed"
+    assert row.escalation_reason == "timeout"
+    assert row.tier is None
+    assert row.total_score is None
+    assert row.dimension_scores is None
+    assert row.extracted is None
+    assert row.reasoning is None
+    assert row.confidence is None
+    assert row.missing_information == []
+    # An attempt that never reached the model has no provenance to report, and the columns
+    # are NOT NULL: a sentinel is honest, a guess would be a lie in the billing table.
+    assert (row.model_id, row.prompt_version) == (UNKNOWN_MODEL_ID, UNKNOWN_PROMPT_VERSION)
+    assert row.effort is None
+    assert (row.input_tokens, row.output_tokens, row.cost_usd) == (0, 0, Decimal("0.000000"))
+    # The attempt still took time, and how long is the operator's first question.
+    assert row.latency_ms == 30_000
+    assert lead_row(connection, lead).status == "failed"
+
+
+def test_a_billed_refusal_is_metered_even_though_it_produced_nothing(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    """A refusal is an HTTP 200 and Anthropic charges for it; so is a ``max_tokens``
+    truncation. A billed failure that left no metering is money the business cannot see."""
+    tenant, _ = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="assess-refusal",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+
+    store.record_assessment(
+        tenant_id=tenant,
+        lead_id=lead,
+        outcome=make_failed(
+            reason=EscalationReason.MODEL_REFUSAL,
+            metering=make_metering(model_id="claude-opus-5", latency_ms=1_500),
+        ),
+        decision=make_decision(escalation_reason=EscalationReason.MODEL_REFUSAL),
+        recorded_at=NOW,
+    )
+
+    (row,) = assessment_rows(connection, lead)
+    assert row.status == "failed"
+    assert row.escalation_reason == "model_refusal"
+    assert row.model_id == "claude-opus-5"
+    assert row.cost_usd == Decimal("0.012345")
+    assert row.input_tokens == 1_200
+    assert row.latency_ms == 1_500
+
+
+def test_a_low_confidence_escalation_keeps_the_model_output_and_the_reason(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    tenant, _ = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="assess-low-confidence",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+
+    store.record_assessment(
+        tenant_id=tenant,
+        lead_id=lead,
+        outcome=make_succeeded(confidence=0.2),
+        decision=make_decision(escalation_reason=EscalationReason.LOW_CONFIDENCE),
+        recorded_at=NOW,
+    )
+
+    (row,) = assessment_rows(connection, lead)
+    assert row.status == "ok"
+    assert row.escalation_reason == "low_confidence"
+    assert row.confidence == Decimal("0.200")
+    assert row.tier == "warm"
+
+
+# ----------------------------------------------------------------- routing events
+
+
+def test_a_dispatch_stamps_the_time_and_the_receipt_and_routes_the_lead(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    tenant, _ = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="route-dispatched",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+
+    store.record_routing_event(
+        tenant_id=tenant,
+        lead_id=lead,
+        action=Action.EMAIL_SALES,
+        destination="sales@example.invalid",
+        outcome=RoutingOutcome.DISPATCHED,
+        provider_message_id="ses-42",
+        occurred_at=NOW,
+        detail="Routed to sales.",
+    )
+
+    (row,) = routing_rows(connection, lead)
+    assert row.action == "email_sales"
+    assert row.destination == "sales@example.invalid"
+    assert row.provider_message_id == "ses-42"
+    assert row.dispatched_at == NOW
+    assert lead_row(connection, lead).status == "routed"
+
+
+def test_a_suppression_is_recorded_with_no_destination_and_no_dispatch_time(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    """ "We never contacted this lead, and here is why" is an answer the business needs."""
+    tenant, _ = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="route-suppressed",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+
+    store.record_routing_event(
+        tenant_id=tenant,
+        lead_id=lead,
+        action=Action.SUPPRESS,
+        destination=None,
+        outcome=RoutingOutcome.SUPPRESSED,
+        provider_message_id=None,
+        occurred_at=NOW,
+        detail="Spam or test submission.",
+    )
+
+    (row,) = routing_rows(connection, lead)
+    assert row.action == "suppress"
+    assert row.destination is None
+    assert row.dispatched_at is None
+    assert store.already_routed(tenant_id=tenant, lead_id=lead) is True
+
+
+def test_a_failed_send_is_visible_but_leaves_the_lead_unrouted(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    """A lead stuck behind a broken notifier has to be visible rather than merely absent —
+    and still retryable."""
+    tenant, _ = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id="route-failed",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+    store.record_assessment(
+        tenant_id=tenant,
+        lead_id=lead,
+        outcome=make_succeeded(),
+        decision=make_decision(),
+        recorded_at=NOW,
+    )
+
+    store.record_routing_event(
+        tenant_id=tenant,
+        lead_id=lead,
+        action=Action.EMAIL_SALES,
+        destination="sales@example.invalid",
+        outcome=RoutingOutcome.FAILED,
+        provider_message_id=None,
+        occurred_at=NOW,
+        detail="dispatch failed: ConnectionError",
+    )
+
+    (row,) = routing_rows(connection, lead)
+    assert row.dispatched_at is None
+    assert row.provider_message_id is None
+    assert store.already_routed(tenant_id=tenant, lead_id=lead) is False
+    # Still 'qualified': a lead that never went anywhere has not been routed.
+    assert lead_row(connection, lead).status == "qualified"
+
+
+@pytest.mark.parametrize(
+    ("action", "outcome"),
+    [
+        (Action.EMAIL_SALES, RoutingOutcome.SUPPRESSED),
+        (Action.SUPPRESS, RoutingOutcome.DISPATCHED),
+        (Action.SUPPRESS, RoutingOutcome.FAILED),
+    ],
+)
+def test_an_action_and_outcome_that_disagree_about_suppression_are_refused(
+    store: PostgresLeadStore,
+    connection: Connection,
+    seeded_tenants: tuple[str, str],
+    action: Action,
+    outcome: RoutingOutcome,
+) -> None:
+    """Suppression is encoded *as* the action, so a row where the two disagree would be
+    read back wrongly by ``already_routed`` — as a routed lead that was never sent, or a
+    suppressed one still waiting. Refused rather than silently mis-recorded."""
+    tenant, _ = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant,
+        submission_id=f"route-mismatch-{action.value}-{outcome.value}",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+
+    with pytest.raises(ValueError, match="disagree"):
+        store.record_routing_event(
+            tenant_id=tenant,
+            lead_id=lead,
+            action=action,
+            destination=None,
+            outcome=outcome,
+            provider_message_id=None,
+            occurred_at=NOW,
+            detail="nonsense",
+        )
+    assert routing_rows(connection, lead) == []
+
+
+# --------------------------------------------------------------- tenant isolation
+
+
+def test_one_tenant_cannot_read_another_tenants_lead(
+    store: PostgresLeadStore, seeded_tenants: tuple[str, str]
+) -> None:
+    """The seed of #32's isolation suite. Tenant B holds tenant A's lead id — the strongest
+    thing a confused or hostile caller could hold — and still learns nothing."""
+    tenant_a, tenant_b = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant_a,
+        submission_id="isolation",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+    store.record_routing_event(
+        tenant_id=tenant_a,
+        lead_id=lead,
+        action=Action.EMAIL_SALES,
+        destination="sales@example.invalid",
+        outcome=RoutingOutcome.DISPATCHED,
+        provider_message_id="ses-private",
+        occurred_at=NOW,
+        detail="Routed to sales.",
+    )
+
+    assert store.already_routed(tenant_id=tenant_b, lead_id=lead) is False
+
+
+def test_one_tenant_cannot_write_against_another_tenants_lead(
+    store: PostgresLeadStore, seeded_tenants: tuple[str, str]
+) -> None:
+    """The composite ``(tenant_id, lead_id)`` foreign key, doing the job two independent
+    foreign keys could not: the lead exists *and* it belongs to the writing tenant."""
+    tenant_a, tenant_b = seeded_tenants
+    lead = store.upsert_lead(
+        tenant_id=tenant_a,
+        submission_id="isolation-write",
+        submission=make_submission(),
+        source="web_form",
+        received_at=NOW,
+    ).lead_id
+
+    with pytest.raises(IntegrityError):
+        store.record_assessment(
+            tenant_id=tenant_b,
+            lead_id=lead,
+            outcome=make_succeeded(),
+            decision=make_decision(),
+            recorded_at=NOW,
+        )
+
+
+def test_a_tenants_lead_listing_never_includes_another_tenants_rows(
+    store: PostgresLeadStore, connection: Connection, seeded_tenants: tuple[str, str]
+) -> None:
+    tenant_a, tenant_b = seeded_tenants
+    for tenant in (tenant_a, tenant_b):
+        store.upsert_lead(
+            tenant_id=tenant,
+            submission_id="same-id-both-tenants",
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+
+    rows = connection.execute(
+        select(Lead.id).where(
+            Lead.tenant_id == tenant_id_for(tenant_a),
+            Lead.submission_id == "same-id-both-tenants",
+        )
+    ).all()
+    assert len(rows) == 1
+
+
+# ----------------------------------------------------------- concurrent redelivery
+
+
+def test_two_concurrent_deliveries_of_one_lead_produce_one_row_and_one_new(
+    store_engine: Engine, seeded_tenants: tuple[str, str]
+) -> None:
+    """The race a ``SELECT``-then-``INSERT`` loses.
+
+    Two workers pick up the same redelivered SQS message and reach ``upsert_lead`` at the
+    same instant. Exactly one row must exist, both callers must get its id, and exactly one
+    of them may be told the lead is new — otherwise two workers both believe they are the
+    first, and sales is emailed twice.
+
+    Real connections and real threads: the whole point is what the *database* does when two
+    transactions conflict, which a fixture that shares one transaction cannot show.
+    """
+    tenant, _ = seeded_tenants
+    store = PostgresLeadStore(sessionmaker(bind=store_engine))
+    submission_id = f"concurrent-{uuid.uuid4()}"
+    barrier = threading.Barrier(2)
+
+    def deliver() -> tuple[str, bool]:
+        barrier.wait(timeout=10)
+        stored = store.upsert_lead(
+            tenant_id=tenant,
+            submission_id=submission_id,
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+        return (stored.lead_id, stored.is_new)
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = [
+                future.result(timeout=30) for future in [pool.submit(deliver) for _ in range(2)]
+            ]
+
+        lead_ids = {lead_id for lead_id, _ in results}
+        assert len(lead_ids) == 1, "the two deliveries disagree about the lead's identity"
+        assert [is_new for _, is_new in results].count(True) == 1, (
+            "exactly one delivery may be told the lead is new"
+        )
+
+        with store_engine.connect() as conn:
+            rows = conn.execute(
+                select(Lead.id).where(
+                    Lead.tenant_id == tenant_id_for(tenant), Lead.submission_id == submission_id
+                )
+            ).all()
+        assert len(rows) == 1
+    finally:
+        with store_engine.begin() as conn:
+            conn.execute(
+                delete(Lead).where(
+                    Lead.tenant_id == tenant_id_for(tenant), Lead.submission_id == submission_id
+                )
+            )
+
+
+def test_a_redelivery_arriving_mid_insert_waits_and_reports_the_existing_lead(
+    store_engine: Engine, seeded_tenants: tuple[str, str]
+) -> None:
+    """The same race as above, made deterministic rather than hoped for.
+
+    One transaction has inserted the lead and not yet committed when the redelivery
+    arrives. ``ON CONFLICT DO UPDATE`` must *wait* for it and then report the row it finds:
+    a ``SELECT``-then-``INSERT`` would raise a uniqueness error here, and ``DO NOTHING``
+    would return no row at all because the winner's insert is not visible yet — either way
+    a worker would be told a stored lead had failed, and the lead would be processed twice
+    or not at all.
+    """
+    tenant, _ = seeded_tenants
+    store = PostgresLeadStore(sessionmaker(bind=store_engine))
+    submission_id = f"midflight-{uuid.uuid4()}"
+    redelivered: list[StoredLead] = []
+    errors: list[BaseException] = []
+
+    def redeliver() -> None:
+        try:
+            redelivered.append(
+                store.upsert_lead(
+                    tenant_id=tenant,
+                    submission_id=submission_id,
+                    submission=make_submission(),
+                    source="web_form",
+                    received_at=NOW,
+                )
+            )
+        except BaseException as error:  # reported on the main thread, where it fails the test
+            errors.append(error)
+
+    try:
+        with store_engine.connect() as writer:
+            transaction = writer.begin()
+            first_id = writer.execute(
+                insert(Lead)
+                .values(
+                    tenant_id=tenant_id_for(tenant),
+                    submission_id=submission_id,
+                    raw_payload={"source": "first delivery"},
+                    source="web_form",
+                    received_at=NOW,
+                )
+                .returning(Lead.id)
+            ).scalar_one()
+
+            thread = threading.Thread(target=redeliver, daemon=True)
+            thread.start()
+            thread.join(timeout=2)
+            assert thread.is_alive(), "the redelivery did not wait for the in-flight insert"
+
+            transaction.commit()
+            thread.join(timeout=30)
+            assert not thread.is_alive(), "the redelivery never finished"
+
+        assert errors == []
+        (stored,) = redelivered
+        assert stored.lead_id == str(first_id)
+        assert stored.is_new is False
+    finally:
+        with store_engine.begin() as conn:
+            conn.execute(
+                delete(Lead).where(
+                    Lead.tenant_id == tenant_id_for(tenant), Lead.submission_id == submission_id
+                )
+            )
+
+
+def test_the_lambda_shaped_engine_really_connects(
+    store_database: URL, seeded_tenants: tuple[str, str]
+) -> None:
+    """``from_url`` builds the engine the Lambda uses — single connection, pre-ping,
+    prepared statements off for RDS Proxy. Those settings are only worth having if a real
+    server accepts them."""
+    tenant, _ = seeded_tenants
+    store = PostgresLeadStore.from_url(store_database.render_as_string(hide_password=False))
+    submission_id = f"lambda-engine-{uuid.uuid4()}"
+    try:
+        stored = store.upsert_lead(
+            tenant_id=tenant,
+            submission_id=submission_id,
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+        assert stored.is_new is True
+        assert store.already_routed(tenant_id=tenant, lead_id=stored.lead_id) is False
+    finally:
+        engine = create_engine(store_database)
+        with engine.begin() as conn:
+            conn.execute(
+                delete(Lead).where(
+                    Lead.tenant_id == tenant_id_for(tenant), Lead.submission_id == submission_id
+                )
+            )
+        engine.dispose()
+
+
+# ------------------------------------------------------------- tenant config source
+
+
+def test_the_config_source_loads_a_seeded_tenants_rubric(
+    sessions: sessionmaker[Session], seeded_tenants: tuple[str, str]
+) -> None:
+    tenant, _ = seeded_tenants
+    config = PostgresTenantConfigSource(sessions).get(tenant)
+    assert config.tenant_id == tenant
+    assert config.routing_rules[Tier.HOT].destination == "sales@example.invalid"
+    assert config.prompt_version == "rubric_v1"
+
+
+def test_the_config_source_accepts_the_row_id_as_well_as_the_slug(
+    sessions: sessionmaker[Session], seeded_tenants: tuple[str, str]
+) -> None:
+    tenant, _ = seeded_tenants
+    config = PostgresTenantConfigSource(sessions).get(str(tenant_id_for(tenant)))
+    assert config.tenant_id == tenant
+
+
+def test_an_unknown_tenant_is_not_found(sessions: sessionmaker[Session]) -> None:
+    with pytest.raises(TenantNotFoundError):
+        PostgresTenantConfigSource(sessions).get("never-seeded-tenant")
+
+
+def test_an_invalid_rubric_is_a_config_error_not_a_silent_default(
+    connection: Connection, sessions: sessionmaker[Session]
+) -> None:
+    """A tenant whose policy cannot be loaded must not have its leads routed by someone
+    else's policy — so this raises rather than falling back to the defaults."""
+    slug = "broken-rubric-tenant"
+    connection.execute(
+        insert(Tenant).values(
+            id=tenant_id_for(slug),
+            name="Broken",
+            icp_config={"tenant_id": slug, "name": "Broken"},
+        )
+    )
+    with pytest.raises(TenantConfigError):
+        PostgresTenantConfigSource(sessions).get(slug)
+
+
+def test_a_row_whose_config_names_a_different_tenant_is_refused(
+    connection: Connection, sessions: sessionmaker[Session], default_config_document: dict[str, Any]
+) -> None:
+    slug = "mislabelled-tenant"
+    connection.execute(
+        insert(Tenant).values(
+            id=tenant_id_for(slug),
+            name="Mislabelled",
+            icp_config={**default_config_document, "tenant_id": "someone-else"},
+        )
+    )
+    with pytest.raises(TenantConfigError, match="must agree"):
+        PostgresTenantConfigSource(sessions).get(slug)

--- a/tests/unit/test_lead_store_inmemory.py
+++ b/tests/unit/test_lead_store_inmemory.py
@@ -1,0 +1,30 @@
+"""The shared store contract, run against the in-memory double.
+
+``tests.fakes.InMemoryLeadStore`` is what #17, #19, #21 and #26 test their pipelines
+against, so it is only useful for as long as it behaves like the database. Running the same
+contract here and in ``tests/integration/test_store_postgres.py`` is what keeps the two
+honest: a divergence fails one of the two suites instead of surfacing in production, where
+the double is not the thing running.
+
+No database, no network — this file is part of the default suite.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from leadquali.app.ports import LeadStorePort
+from tests.contract.lead_store_contract import LeadStoreContract
+from tests.fakes import InMemoryLeadStore
+
+
+class TestInMemoryLeadStore(LeadStoreContract):
+    """Every behaviour the port promises, checked against the fake."""
+
+    @pytest.fixture
+    def store(self) -> LeadStorePort:
+        return InMemoryLeadStore()
+
+    @pytest.fixture
+    def tenants(self) -> tuple[str, str]:
+        return ("tenant-a", "tenant-b")

--- a/tests/unit/test_store_postgres.py
+++ b/tests/unit/test_store_postgres.py
@@ -1,0 +1,449 @@
+"""The Postgres adapter's offline half.
+
+Everything here is true without a database: the identity mapping between port-level ids and
+the UUIDs the tables key on, the contact-email hash, the column values a successful and a
+failed assessment produce, and three structural properties that a running database would
+never reveal — that no method is reachable without a tenant scope, that importing the
+module opens no connection, and that no SQL is assembled from strings.
+
+The behavioural half — that Postgres accepts these rows, that the upsert is idempotent
+under a real race — is ``tests/integration/test_store_postgres.py``, which needs a server.
+"""
+
+from __future__ import annotations
+
+import ast
+import hashlib
+import inspect
+import uuid
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlalchemy import null
+from sqlalchemy.orm import Session, sessionmaker
+from sqlalchemy.pool import QueuePool
+
+from leadquali.adapters import store_postgres
+from leadquali.adapters.db_schema import (
+    ASSESSMENT_STATUSES,
+    ESCALATION_REASONS,
+    LEAD_STATUSES,
+)
+from leadquali.adapters.seed import tenant_id_for
+from leadquali.adapters.store_postgres import (
+    ASSESSMENT_STATUS_FAILED,
+    ASSESSMENT_STATUS_OK,
+    LEAD_STATUS_FAILED,
+    LEAD_STATUS_QUALIFIED,
+    LEAD_STATUS_ROUTED,
+    UNKNOWN_MODEL_ID,
+    UNKNOWN_PROMPT_VERSION,
+    PostgresLeadStore,
+    PostgresTenantConfigSource,
+    assessment_values,
+    contact_email_hash,
+    engine_for,
+    lead_uuid,
+    session_factory,
+    tenant_uuid,
+)
+from leadquali.app.ports import RoutingOutcome
+from leadquali.domain.models import Action, EscalationReason, Tier
+from tests.contract.lead_store_contract import (
+    NOW,
+    make_decision,
+    make_failed,
+    make_metering,
+    make_submission,
+    make_succeeded,
+)
+
+MODULE_PATH = Path(store_postgres.__file__)
+
+#: A URL that is syntactically valid and points nowhere. ``create_engine`` does not
+#: connect, so an engine can be built from it and inspected without a server.
+NOWHERE_URL = "postgresql+psycopg://leadquali:leadquali@127.0.0.1:5439/nowhere"
+
+
+def unbound_store() -> PostgresLeadStore:
+    """A store whose sessions are never opened.
+
+    Every argument check in the adapter happens before a session is asked for, which is
+    what makes it testable this way — and is also the right order: rejecting a malformed
+    tenant id should not cost a round trip.
+    """
+    return PostgresLeadStore(sessionmaker())
+
+
+# ------------------------------------------------------------------------ identities
+
+
+def test_a_tenant_slug_resolves_to_the_id_the_seed_script_writes() -> None:
+    """One mapping, imported rather than restated. Two spellings of "which row is this
+    tenant" is how a lead ends up filed under a tenant that does not exist."""
+    assert tenant_uuid("default") == tenant_id_for("default")
+
+
+def test_a_tenant_uuid_is_taken_as_the_row_id() -> None:
+    row_id = uuid.uuid4()
+    assert tenant_uuid(str(row_id)) == row_id
+
+
+@pytest.mark.parametrize(
+    "tenant_id",
+    ["", "../../etc/passwd", "Default", "tenant id", "'; drop table leads; --", "x" * 64],
+)
+def test_a_tenant_id_that_is_neither_a_uuid_nor_a_slug_is_refused(tenant_id: str) -> None:
+    """Tenant ids arrive from queue messages and request payloads, so they are checked
+    before they reach a query rather than after."""
+    with pytest.raises(ValueError, match="neither a UUID nor a valid slug"):
+        tenant_uuid(tenant_id)
+
+
+def test_a_lead_id_must_be_a_uuid() -> None:
+    with pytest.raises(ValueError, match="not a UUID"):
+        lead_uuid("lead-0001")
+
+
+def test_the_email_hash_is_over_the_normalised_address() -> None:
+    """``Ada@Example.com`` and ``ada@example.com`` are one person, and correlating their
+    leads without ever logging the address is the whole reason the column exists."""
+    expected = hashlib.sha256(b"ada@example.com").hexdigest()
+    assert contact_email_hash("  Ada@Example.COM ") == expected
+    assert contact_email_hash("ada@example.com") == expected
+
+
+@pytest.mark.parametrize("email", [None, "", "   "])
+def test_a_missing_address_hashes_to_nothing(email: str | None) -> None:
+    """A form is a form: a submission with no address must still be storable."""
+    assert contact_email_hash(email) is None
+
+
+def test_the_hash_is_not_the_address() -> None:
+    """Invariant 5, stated as the property that matters: nothing recognisable survives."""
+    digest = contact_email_hash("ada@example.com")
+    assert digest is not None
+    assert "ada" not in digest
+    assert "example.com" not in digest
+    assert len(digest) == 64
+
+
+# ------------------------------------------------------------------- assessment rows
+
+
+def test_a_successful_assessment_carries_every_model_output_column() -> None:
+    values = assessment_values(
+        outcome=make_succeeded(confidence=0.815),
+        decision=make_decision(tier=Tier.HOT, total_score=88.25),
+    )
+    assert values["status"] == ASSESSMENT_STATUS_OK
+    assert values["tier"] == "hot"
+    assert values["total_score"] == Decimal("88.25")
+    assert values["confidence"] == Decimal("0.815")
+    assert values["dimension_scores"]["icp_fit"] == 24
+    assert values["extracted"]["company_name"] == "Analytical Engines"
+    assert values["reasoning"]
+    assert values["missing_information"] == ["budget"]
+    assert values["escalation_reason"] is None
+
+
+def test_a_failed_assessment_carries_none_of_them_and_says_why() -> None:
+    """The shape ``ck_assessments_output_present_iff_ok`` enforces: all present, or all
+    absent with a reason. A half-written row would let the feedback loop average over
+    assessments that never happened."""
+    values = assessment_values(
+        outcome=make_failed(reason=EscalationReason.API_ERROR, latency_ms=1_234),
+        decision=make_decision(escalation_reason=EscalationReason.API_ERROR, total_score=0.0),
+    )
+    assert values["status"] == ASSESSMENT_STATUS_FAILED
+    assert values["escalation_reason"] == "api_error"
+    assert values["tier"] is None
+    assert values["total_score"] is None
+    assert values["reasoning"] is None
+    assert values["confidence"] is None
+    assert values["missing_information"] == []
+
+
+def test_the_jsonb_columns_of_a_failure_are_sql_null_not_json_null() -> None:
+    """The bug this test exists for: a Python ``None`` bound to a JSONB column is sent as
+    the JSON value ``null``, which satisfies ``IS NOT NULL`` — so the row is rejected by
+    the CHECK, and only a real database says so. ``null()`` is a SQL NULL."""
+    values = assessment_values(
+        outcome=make_failed(),
+        decision=make_decision(escalation_reason=EscalationReason.API_ERROR),
+    )
+    assert values["dimension_scores"] is null()
+    assert values["extracted"] is null()
+
+
+def test_an_unbilled_failure_records_sentinels_and_the_time_it_wasted() -> None:
+    """A call that never reached the model has no provenance to report, and the columns are
+    NOT NULL. It still took time, and how long is the operator's first question."""
+    values = assessment_values(
+        outcome=make_failed(reason=EscalationReason.TIMEOUT, latency_ms=30_000),
+        decision=make_decision(escalation_reason=EscalationReason.TIMEOUT),
+    )
+    assert values["model_id"] == UNKNOWN_MODEL_ID
+    assert values["prompt_version"] == UNKNOWN_PROMPT_VERSION
+    assert values["effort"] is None
+    assert values["input_tokens"] == 0
+    assert values["cost_usd"] == Decimal(0)
+    assert values["latency_ms"] == 30_000
+
+
+def test_a_billed_failure_is_metered_like_a_success() -> None:
+    """A refusal is an HTTP 200 and it is charged for; so is a ``max_tokens`` truncation.
+    Billing is a SUM over this table, and a failure left out of it is money nobody sees."""
+    values = assessment_values(
+        outcome=make_failed(
+            reason=EscalationReason.MODEL_REFUSAL, metering=make_metering(latency_ms=1_500)
+        ),
+        decision=make_decision(escalation_reason=EscalationReason.MODEL_REFUSAL),
+    )
+    assert values["status"] == ASSESSMENT_STATUS_FAILED
+    assert values["model_id"] == "claude-opus-5"
+    assert values["prompt_version"] == "rubric_v1"
+    assert values["effort"] == "medium"
+    assert values["cost_usd"] == Decimal("0.012345")
+    assert values["latency_ms"] == 1_500
+
+
+def test_a_low_confidence_escalation_is_still_a_successful_assessment() -> None:
+    values = assessment_values(
+        outcome=make_succeeded(confidence=0.2),
+        decision=make_decision(escalation_reason=EscalationReason.LOW_CONFIDENCE),
+    )
+    assert values["status"] == ASSESSMENT_STATUS_OK
+    assert values["escalation_reason"] == "low_confidence"
+    assert values["confidence"] == Decimal("0.200")
+
+
+def test_scores_land_on_the_scale_of_their_numeric_columns() -> None:
+    """``Numeric`` is what keeps SUM and AVG over the column exact; going through the
+    binary float would put the imprecision straight back."""
+    values = assessment_values(
+        outcome=make_succeeded(confidence=0.1),
+        decision=make_decision(total_score=62.5),
+    )
+    assert values["total_score"] == Decimal("62.50")
+    assert values["total_score"].as_tuple().exponent == -2
+    assert values["confidence"].as_tuple().exponent == -3
+
+
+def test_every_status_this_adapter_writes_is_one_the_database_accepts() -> None:
+    """The CHECK vocabularies are literals in the DDL; this is what stops the adapter and
+    the schema from drifting into a constraint violation nobody sees until a lead fails."""
+    assert {ASSESSMENT_STATUS_OK, ASSESSMENT_STATUS_FAILED} <= set(ASSESSMENT_STATUSES)
+    assert {LEAD_STATUS_QUALIFIED, LEAD_STATUS_FAILED, LEAD_STATUS_ROUTED} <= set(LEAD_STATUSES)
+    assert {reason.value for reason in EscalationReason} <= set(ESCALATION_REASONS)
+
+
+@pytest.mark.parametrize("reason", list(EscalationReason))
+def test_every_escalation_reason_the_domain_defines_can_be_recorded(
+    reason: EscalationReason,
+) -> None:
+    if reason is EscalationReason.LOW_CONFIDENCE:
+        values = assessment_values(
+            outcome=make_succeeded(), decision=make_decision(escalation_reason=reason)
+        )
+    else:
+        values = assessment_values(
+            outcome=make_failed(reason=reason), decision=make_decision(escalation_reason=reason)
+        )
+    assert values["escalation_reason"] == reason.value
+
+
+# ------------------------------------------------------ guards that need no database
+
+
+@pytest.mark.parametrize(
+    ("action", "outcome"),
+    [
+        (Action.EMAIL_SALES, RoutingOutcome.SUPPRESSED),
+        (Action.ESCALATE_HUMAN, RoutingOutcome.SUPPRESSED),
+        (Action.SUPPRESS, RoutingOutcome.DISPATCHED),
+        (Action.SUPPRESS, RoutingOutcome.FAILED),
+    ],
+)
+def test_an_action_and_outcome_that_disagree_about_suppression_are_refused(
+    action: Action, outcome: RoutingOutcome
+) -> None:
+    """``routing_events`` has no outcome column, so suppression is encoded *as* the action.
+    A row where the two disagree would be read back wrongly by ``already_routed``, so it is
+    refused before any session is opened."""
+    with pytest.raises(ValueError, match="disagree"):
+        unbound_store().record_routing_event(
+            tenant_id="tenant-a",
+            lead_id=str(uuid.uuid4()),
+            action=action,
+            destination=None,
+            outcome=outcome,
+            provider_message_id=None,
+            occurred_at=NOW,
+            detail="nonsense",
+        )
+
+
+@pytest.mark.parametrize(
+    ("action", "outcome"),
+    [
+        (Action.EMAIL_SALES, RoutingOutcome.DISPATCHED),
+        (Action.ESCALATE_HUMAN, RoutingOutcome.FAILED),
+        (Action.SUPPRESS, RoutingOutcome.SUPPRESSED),
+    ],
+)
+def test_the_combinations_the_pipeline_actually_produces_are_accepted(
+    action: Action, outcome: RoutingOutcome
+) -> None:
+    """The guard above must not reject anything ``app/qualify.py`` can emit: it gets past
+    the check and only then fails on the unbound session."""
+    with pytest.raises(Exception) as caught:
+        unbound_store().record_routing_event(
+            tenant_id="tenant-a",
+            lead_id=str(uuid.uuid4()),
+            action=action,
+            destination="sales@example.invalid" if action is not Action.SUPPRESS else None,
+            outcome=outcome,
+            provider_message_id=None,
+            occurred_at=NOW,
+            detail="fine",
+        )
+    assert "disagree" not in str(caught.value)
+
+
+def test_a_blank_submission_id_is_refused_without_a_round_trip() -> None:
+    with pytest.raises(ValueError, match="submission_id"):
+        unbound_store().upsert_lead(
+            tenant_id="tenant-a",
+            submission_id="",
+            submission=make_submission(),
+            source="web_form",
+            received_at=NOW,
+        )
+
+
+# ------------------------------------------------------------- structural properties
+
+
+def port_methods(cls: type) -> dict[str, Any]:
+    """Public instance methods, excluding the ``from_*`` constructors."""
+    return {
+        name: member
+        for name, member in inspect.getmembers(cls, inspect.isfunction)
+        if not name.startswith("_") and not name.startswith("from_")
+    }
+
+
+def test_no_store_method_is_reachable_without_a_tenant() -> None:
+    """Invariant 4, checked as a property of the class rather than of the queries.
+
+    Not one method — including a convenience getter someone adds next year, since this
+    enumerates them rather than listing them — may be callable without naming the tenant,
+    because #32's isolation suite attacks exactly the method that forgot.
+    """
+    methods = port_methods(PostgresLeadStore)
+    assert set(methods) == {
+        "upsert_lead",
+        "already_routed",
+        "record_assessment",
+        "record_routing_event",
+    }
+    for name, method in methods.items():
+        parameters = inspect.signature(method).parameters
+        assert "tenant_id" in parameters, f"{name} has no tenant scope"
+        assert parameters["tenant_id"].kind is inspect.Parameter.KEYWORD_ONLY
+
+
+def test_the_config_source_is_also_tenant_scoped() -> None:
+    methods = port_methods(PostgresTenantConfigSource)
+    assert set(methods) == {"get"}
+    assert "tenant_id" in inspect.signature(methods["get"]).parameters
+
+
+def _calls_executed_at_import(module: ast.Module) -> list[ast.Call]:
+    """Every call that runs when the module is imported.
+
+    Function bodies are skipped — that is where the engine is *supposed* to be built, on
+    first use — while class bodies and module-level statements are not, because those do
+    run at import.
+    """
+    calls: list[ast.Call] = []
+
+    def visit(node: ast.AST) -> None:
+        for child in ast.iter_child_nodes(node):
+            if isinstance(child, ast.FunctionDef | ast.AsyncFunctionDef | ast.Lambda):
+                continue
+            if isinstance(child, ast.Call):
+                calls.append(child)
+            visit(child)
+
+    visit(module)
+    return calls
+
+
+def test_importing_the_module_creates_no_engine() -> None:
+    """A Lambda imports this at cold start, possibly before configuration is resolved. An
+    engine built at module scope would open a socket there — or fail there, in a place
+    where the traceback has no request to attach itself to."""
+    for call in _calls_executed_at_import(ast.parse(MODULE_PATH.read_text(encoding="utf-8"))):
+        name = getattr(call.func, "id", None) or getattr(call.func, "attr", None)
+        assert name not in {"create_engine", "sessionmaker"}, (
+            f"line {call.lineno}: an engine is created at import time"
+        )
+
+
+def test_no_sql_is_assembled_from_strings() -> None:
+    """Acceptance criterion: no SQL string interpolation of user input anywhere. Every
+    statement is a Core construct, so ids and payloads travel as bound parameters; the one
+    textual fragment in the module is a constant with no input in it."""
+    module = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
+    textual = {"text", "literal_column", "column", "table"}
+    found = 0
+    for call in (n for n in ast.walk(module) if isinstance(n, ast.Call)):
+        name = getattr(call.func, "id", None) or getattr(call.func, "attr", None)
+        if name not in textual:
+            continue
+        found += 1
+        first = call.args[0]
+        assert isinstance(first, ast.Constant) and isinstance(first.value, str), (
+            f"line {call.lineno}: {name}() is given something other than a literal string"
+        )
+    assert found == 1, "expected exactly the (xmax = 0) fragment; a new one needs a look"
+
+
+def test_the_engine_is_shaped_for_a_lambda_container() -> None:
+    """One connection per container, pre-pinged, recycled before any proxy idle timeout —
+    which also makes reserved concurrency in #27 the connection budget, with no second
+    number to keep in step."""
+    engine = engine_for(NOWHERE_URL)
+    assert isinstance(engine.pool, QueuePool)
+    assert engine.pool.size() == 1
+    # Private attributes because SQLAlchemy exposes no public reader for either, and both
+    # are load-bearing enough to be worth asserting on.
+    assert engine.pool._max_overflow == 0
+    assert engine.pool._pre_ping is True
+    assert engine.pool._recycle == store_postgres.DEFAULT_POOL_RECYCLE_SECONDS
+
+
+def test_one_engine_and_one_session_factory_per_url() -> None:
+    """A warm container reuses its connection; a second engine would mean a second
+    connection doing nothing but holding a backend slot."""
+    assert engine_for(NOWHERE_URL) is engine_for(NOWHERE_URL)
+    factory = session_factory(NOWHERE_URL)
+    assert session_factory(NOWHERE_URL) is factory
+    assert factory.kw["bind"] is engine_for(NOWHERE_URL)
+
+
+def test_a_store_can_be_built_from_a_url_without_connecting() -> None:
+    store = PostgresLeadStore.from_url(NOWHERE_URL)
+    assert isinstance(store, PostgresLeadStore)
+    assert isinstance(PostgresTenantConfigSource.from_url(NOWHERE_URL), PostgresTenantConfigSource)
+
+
+def test_the_sessions_the_store_is_given_are_the_ones_it_uses() -> None:
+    """The factory is a constructor argument, not a global: the entrypoint wires one per
+    container and the integration tests bind one to a transaction they roll back."""
+    factory: sessionmaker[Session] = sessionmaker()
+    assert PostgresLeadStore(factory)._sessions is factory


### PR DESCRIPTION
Closes #16. On top of #50 (schema) → #56 (pipeline).

`PostgresLeadStore` implements #56's `LeadStorePort`; `PostgresTenantConfigSource` reads `tenants.icp_config` into a validated `TenantConfig`.

## What carries the weight

- **Idempotency is a real upsert.** `INSERT ... ON CONFLICT DO UPDATE ... RETURNING (xmax = 0)` against `uq_leads_tenant_id_submission_id`, not SELECT-then-INSERT, which races under concurrent redelivery. `is_new` comes from `xmax`, so it is correct even when two workers insert the same lead simultaneously — there is an integration test that does exactly that.
- **Every statement filters on `tenant_id`.** No method is reachable without a tenant scope, not even a convenience getter. #32's isolation suite will attack this.
- **Failed assessments are recordable** — status, escalation reason, model-output columns NULL, satisfying #50's `output_present_iff_ok` CHECK.
- **Lambda-shaped connections**: no engine at import time, built lazily per URL and cached; `pool_size=1`, `max_overflow=0`, `pool_pre_ping`, 300s recycle, and `prepare_threshold=None` so RDS Proxy is not pinned (#27's constraint). A unit test asserts no engine is created at import; an integration test proves the one it builds actually connects.

## A real bug the integration tests caught

A Python `None` bound to a **JSONB** column is sent as JSON `null` — which satisfies `IS NOT NULL`. So a failed assessment, which must leave the model-output columns empty, was being **rejected by the very CHECK constraint added to make failures recordable**. Fixed with an explicit SQL `null()`, and pinned by a unit test.

This is the class of bug that only appears against a real database, and it would have surfaced in production as "every API failure crashes the worker" — precisely the path invariant 3 exists to protect.

## Substitutability

`tests/contract/lead_store_contract.py` runs the **same 14 behaviours against both** `tests.fakes.InMemoryLeadStore` (#56) and real Postgres. A divergence between the fake and the adapter is a bug that would otherwise only show up in production, so the two are held to one contract.

## Verification — observed, not claimed

- **41 integration tests run for real** against Docker Postgres 16: `docker compose up -d`, healthcheck green, `alembic upgrade head` into a throwaway `leadquali_store_test` database.
- With Postgres up: **833 passed, 1 skipped**. With `DATABASE_URL` unset: **729 passed, 105 skipped** — the clean-skip path CI takes.

## Two things for you

1. **`routing_events` has no `outcome`/`detail` column.** Finality is encoded as `dispatched_at IS NOT NULL OR action = 'suppress'`, and a mismatched action/outcome pair is refused. `detail` is logged rather than stored. Giving it a column is a migration this issue does not own — worth deciding before #21 wants to query on it.
2. **Feedback writes are deferred.** No port defines them yet, and #22 owns the `rater`/`verdict` semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_