### PR TITLE
[P2.5] Email enrichment adapter: domain, MX and disposable-address checks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,7 @@ dependencies = [
     "alembic>=1.16",
     "boto3",
     "mangum",
+    "dnspython",
 ]
 
 [project.optional-dependencies]
@@ -33,7 +34,7 @@ build-backend = "setuptools.build_meta"
 where = ["src"]
 
 [tool.setuptools.package-data]
-leadquali = ["prompts/*.md", "py.typed"]
+leadquali = ["prompts/*.md", "adapters/data/*.txt", "py.typed"]
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
@@ -68,3 +69,11 @@ files = ["src", "tests", "scripts"]
 [[tool.mypy.overrides]]
 module = ["tests.*"]
 disallow_untyped_defs = true
+
+# dnspython ships `py.typed`, but its exception classes have untyped `__init__`s, so
+# raising one in a test is a `no-untyped-call` error under strict mode. The tests must
+# raise the real exceptions - substituting a stand-in would stop proving that the adapter
+# catches what dnspython actually throws - so the check is relaxed for this module alone.
+[[tool.mypy.overrides]]
+module = ["tests.unit.test_enrich_email"]
+disallow_untyped_calls = false

--- a/src/leadquali/adapters/data/disposable_email_domains.txt
+++ b/src/leadquali/adapters/data/disposable_email_domains.txt
@@ -1,0 +1,200 @@
+# Disposable / throwaway email domains — data, not code.
+#
+# One domain per line, lowercase, no leading "@". Blank lines and lines starting with
+# "#" are ignored. Matching is exact on the registered domain of the address, so
+# subdomains of a listed domain are NOT matched; list them explicitly if you need them.
+#
+# WHAT THIS LIST MEANS
+#   A domain here exists to give someone a mailbox they intend to abandon. That is a
+#   qualification signal in its own right and a *different* one from free-mail: a lead
+#   at gmail.com is a real person who can be reached tomorrow, a lead at mailinator.com
+#   has told you they do not want to be. Keep the two files separate.
+#
+# SOURCE
+#   Curated subset of the community blocklist at
+#   https://github.com/disposable-email-domains/disposable-email-domains
+#   (file: disposable_email_blocklist.conf, released into the public domain / CC0),
+#   trimmed to the entries that actually turn up on B2B web forms. The upstream list is
+#   ~3,500 domains; the whole thing loads fine (it is a set of short strings, well under
+#   a megabyte) if you want the coverage.
+#
+# HOW TO UPDATE — no deploy required
+#   Replace this file's contents:
+#     curl -sSL https://raw.githubusercontent.com/disposable-email-domains/\
+#   disposable-email-domains/main/disposable_email_blocklist.conf \
+#       -o src/leadquali/adapters/data/disposable_email_domains.txt
+#   or point the adapter somewhere else entirely:
+#     EmailEnricher(disposable_domains_path="/mnt/lists/disposable.txt")
+#   In Phase 4 that path is a mounted config volume or an S3-synced file, so refreshing
+#   the list is an operations task, not a release. The file is read once per process, so
+#   a change takes effect when the worker recycles.
+0-mail.com
+10mail.org
+10minutemail.com
+1secmail.com
+1secmail.net
+1secmail.org
+20email.eu
+20minutemail.com
+33mail.com
+4warding.com
+anonaddy.me
+armyspy.com
+bareed.ws
+burnermail.io
+byom.de
+cachedot.net
+courriel.fr.nf
+crazymailing.com
+cuvox.de
+dayrep.com
+dcctb.com
+deadaddress.com
+disbox.net
+discard.email
+discardmail.com
+discardmail.de
+dispostable.com
+e4ward.com
+einrot.com
+emailfake.com
+emailondeck.com
+emltmp.com
+esiix.com
+fakeinbox.com
+fakemail.net
+fakemailgenerator.com
+filzmail.com
+fleckens.hu
+freemail.ms
+generator.email
+get2mail.fr
+getnada.com
+ghosttexter.de
+gomail.in
+grr.la
+guerrillamail.com
+guerrillamailblock.com
+gustr.com
+harakirimail.com
+hidemail.de
+hulapla.de
+inboxbear.com
+inboxkitten.com
+incognitomail.com
+jetable.fr.nf
+jetable.org
+jourrapide.com
+kurzepost.de
+laafd.com
+lroid.com
+luxusmail.org
+mail-easy.fr
+mail-temporaire.fr
+mail7.io
+mailbox92.biz
+mailcatch.com
+mailde.de
+maildrop.cc
+mailexpire.com
+mailfreeonline.com
+mailguard.me
+mailin8r.com
+mailinator.com
+mailinator.net
+mailinator2.com
+mailismagic.com
+mailmetrash.com
+mailnator.com
+mailnesia.com
+mailnull.com
+mailpoof.com
+mailquack.com
+mailsac.com
+mailscrap.com
+mailtemp.info
+mailtothis.com
+mailzilla.com
+mega.zik.dk
+meltmail.com
+mierdamail.com
+mintemail.com
+minuteinbox.com
+moakt.com
+mohmal.com
+moncourrier.fr.nf
+monemail.fr.nf
+monmail.fr.nf
+mt2015.com
+mvrht.net
+mytemp.email
+mytrashmail.com
+netmails.net
+nice-4u.com
+no-spam.ws
+nomail.xl.cx
+nospam.ze.tc
+notsharingmy.info
+objectmail.com
+pookmail.com
+proxymail.eu
+rcpt.at
+recode.me
+rhyta.com
+safetymail.info
+sharklasers.com
+sofort-mail.de
+spam4.me
+spamavert.com
+spambog.com
+spambog.de
+spambog.ru
+spambox.us
+spamdecoy.net
+spamfree24.com
+spamfree24.de
+spamgourmet.com
+spamherelots.com
+spaml.de
+spamspot.com
+speed.1s.fr
+superrito.com
+tafmail.com
+teleworm.us
+temp-mail.io
+temp-mail.org
+temp-mail.ru
+tempail.com
+tempemail.net
+tempemails.net
+tempinbox.com
+tempmail.com
+tempmailer.com
+tempmailer.de
+tempmailo.com
+tempomail.fr
+tempr.email
+thankyou2010.com
+thisisnotmyrealemail.com
+throwawaymail.com
+tmail.ws
+tmpmail.net
+tmpmail.org
+tradermail.info
+trashmail.com
+trashmail.de
+trbvm.com
+txcct.com
+veryrealemail.com
+vjuum.com
+wegwerfadresse.de
+wegwerfmail.de
+wh4f.org
+willhackforfood.biz
+wuzup.net
+wwjmp.com
+xojxe.com
+yopmail.com
+yopmail.fr
+yopmail.net
+zoemail.com

--- a/src/leadquali/adapters/data/free_mail_domains.txt
+++ b/src/leadquali/adapters/data/free_mail_domains.txt
@@ -1,0 +1,158 @@
+# Consumer mailbox providers ("free-mail") — data, not code.
+#
+# One domain per line, lowercase, no leading "@". Blank lines and lines starting with
+# "#" are ignored. Matching is exact on the registered domain of the address.
+#
+# WHAT THIS LIST MEANS
+#   A domain here belongs to a mailbox provider anyone can sign up with, so the address
+#   says nothing about the sender's employer. Some entries are paid (fastmail.com,
+#   hey.com, mailbox.org); "free" is the industry's word for the category, and the
+#   category is really "consumer mailbox, not the company's own domain".
+#
+#   This is NOT a spam signal and must never be scored as one. Solo founders, sole
+#   traders and plenty of small businesses run on gmail.com, and they buy things. It is
+#   a weak *ICP-fit* signal — no verifiable employer, and no company/domain match to be
+#   had — which is why it is a separate value from `disposable` in
+#   disposable_email_domains.txt rather than the same flag. A throwaway address means
+#   the sender intends to be unreachable; a consumer address means they are reachable
+#   and simply do not have corporate mail.
+#
+# SOURCE
+#   Assembled from the public free-provider lists maintained at
+#   https://github.com/willwhite/freemail (data/free.txt, MIT) cross-checked against the
+#   providers that actually appear on inbound B2B forms, plus the major regional
+#   webmail providers (Europe, Russia, China, Korea, Japan, Brazil).
+#
+# HOW TO UPDATE — no deploy required
+#   Edit this file, or point the adapter at another one:
+#     EmailEnricher(free_mail_domains_path="/mnt/lists/free_mail.txt")
+#   Read once per process; a change takes effect when the worker recycles. This list
+#   moves at the speed of the consumer email industry (years), unlike the disposable
+#   list, which moves weekly.
+aim.com
+alice.it
+aol.com
+arcor.de
+att.net
+bellsouth.net
+bigpond.com
+bk.ru
+blueyonder.co.uk
+btinternet.com
+charter.net
+comcast.net
+cox.net
+daum.net
+disroot.org
+duck.com
+earthlink.net
+email.com
+fastmail.com
+fastmail.fm
+foxmail.com
+free.fr
+freenet.de
+gmail.com
+gmx.at
+gmx.ch
+gmx.com
+gmx.de
+gmx.net
+googlemail.com
+hanmail.net
+hey.com
+hotmail.co.uk
+hotmail.com
+hotmail.de
+hotmail.es
+hotmail.fr
+hotmail.it
+hushmail.com
+icloud.com
+inbox.ru
+interia.pl
+juno.com
+laposte.net
+libero.it
+list.ru
+live.co.uk
+live.com
+live.de
+live.fr
+live.it
+live.nl
+mac.com
+mail.com
+mail.ru
+mailbox.org
+mailfence.com
+me.com
+msn.com
+nate.com
+naver.com
+netzero.net
+neuf.fr
+ntlworld.com
+o2.pl
+onet.pl
+optonline.net
+optusnet.com.au
+orange.fr
+outlook.co.uk
+outlook.com
+pm.me
+posteo.de
+proton.me
+protonmail.ch
+protonmail.com
+qq.com
+rambler.ru
+riseup.net
+rocketmail.com
+rogers.com
+runbox.com
+sbcglobal.net
+seznam.cz
+sfr.fr
+shaw.ca
+sina.cn
+sina.com
+sky.com
+sohu.com
+startmail.com
+sympatico.ca
+t-online.de
+talktalk.net
+telus.net
+terra.es
+tin.it
+tiscali.it
+tlen.pl
+tuta.io
+tutanota.com
+usa.com
+verizon.net
+virgilio.it
+virginmedia.com
+wanadoo.fr
+web.de
+wp.pl
+xtra.co.nz
+ya.ru
+yahoo.ca
+yahoo.co.jp
+yahoo.co.uk
+yahoo.com
+yahoo.com.au
+yahoo.com.br
+yahoo.de
+yahoo.es
+yahoo.fr
+yahoo.it
+yandex.com
+yandex.ru
+ymail.com
+zoho.com
+zohomail.com
+126.com
+163.com

--- a/src/leadquali/adapters/enrich_email.py
+++ b/src/leadquali/adapters/enrich_email.py
@@ -1,0 +1,753 @@
+"""Email enrichment: what an address alone can tell you, bought without spending tokens.
+
+The external system here is DNS. Given one submitted address this adapter establishes the
+domain, whether that domain exists and can receive mail, whether it belongs to a consumer
+mailbox provider or a throwaway one, whether the address is a role account rather than a
+person, and whether the company the submitter typed plausibly owns the domain they wrote
+from. Those are cheap, deterministic and verifiable, which is exactly what a language model
+is worst at and most likely to guess about — so they are computed here and handed to it as
+facts (see :mod:`leadquali.app.enrichment`) rather than left for it to infer.
+
+**Free-mail and disposable are two different signals and are never merged.** A lead at
+``gmail.com`` is a real person with a real inbox who simply has no corporate mail — a
+solo founder, a consultant, half the SMB market — and scoring that as fraud loses
+business. A lead at ``mailinator.com`` has chosen an address they intend to abandon,
+which is a statement about their interest in being contacted. The two live in two
+different data files and appear as two different values of ``email_domain_type``; a single
+"suspicious address" boolean would destroy the distinction that makes either useful.
+
+**Failure is expected, cheap and bounded.** Enrichment is an optimisation on scoring, never
+a gate on it: #14's pipeline treats a missing enrichment as a normal outcome, and this
+adapter's contract is that it *never raises* — :meth:`EmailEnricher.enrich` catches
+everything and returns an :class:`~leadquali.app.enrichment.Enrichment` marked unavailable
+with a PII-free reason. Three mechanisms keep a bad DNS day from becoming a bad revenue
+day:
+
+* **One bounded lookup per lead.** A single MX query answers both questions worth asking
+  (``NXDOMAIN`` means the domain does not exist; an empty answer means it exists but
+  cannot receive mail), and ``lifetime`` caps the whole query including any retry across
+  nameservers. There is no retry loop here on purpose: a lead is not worth a second
+  attempt, and a retry storm during an outage is how one slow dependency takes a worker
+  fleet down.
+* **A small in-process TTL cache**, keyed on domain. Leads arrive in bursts from one
+  company — a team filling in a form after a webinar, a campaign landing page — and the
+  answer for a domain does not change between two of them. 15 minutes and 1,024 domains
+  are deliberately modest: the cache exists to collapse a burst, not to be a resolver.
+  15 minutes is short enough that a domain fixing its MX records is picked up within one
+  worker's lifetime, and long enough to cover the arrival pattern; 1,024 short strings is
+  tens of kilobytes, and the bound is what stops a flood of unique junk domains from
+  turning the cache into a memory leak. Both are constructor arguments.
+* **A circuit breaker.** When DNS is down, per-domain caching does not help — every lead
+  carries a new domain and pays the full timeout. After
+  :data:`DEFAULT_FAILURE_THRESHOLD` consecutive failures the adapter stops calling the
+  resolver for :data:`DEFAULT_BREAKER_COOLDOWN_SECONDS` and degrades immediately, so an
+  outage costs a handful of timeouts per minute rather than one per lead. Any success
+  closes it again.
+
+**Deployment constraint for Phase 4 (#27) — a Lambda in private VPC subnets has no DNS
+resolution unless the VPC provides it.** The qualification worker runs in private subnets
+to reach Postgres; a Lambda placed in a VPC uses the VPC's resolver (``.2`` in the VPC
+CIDR, the Route 53 Resolver) and reaches it only if ``enableDnsSupport`` and
+``enableDnsHostnames`` are on and the subnet's routing and NACLs permit it. Public
+resolution additionally needs a NAT gateway or a Route 53 Resolver outbound endpoint. Get
+that wrong and **every** lookup times out: the breaker opens, every lead is silently
+enriched with nothing, and nothing is broken enough to page anyone. The visible symptom is
+``enrichment_available=False`` on every :class:`~leadquali.app.qualify.QualificationResult`
+and a stream of the warning logged below — #21 should alarm on that ratio.
+
+**Invariant 5.** The domain is logged; the local part never is, and never enters the
+prompt facts either. An address is PII, a domain is a company.
+
+The two domain lists are data, not code: ``data/disposable_email_domains.txt`` and
+``data/free_mail_domains.txt``, both documenting their source and update procedure in
+their own headers, both overridable per instance so a deployment can mount a fresher list
+without a release.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import threading
+import time
+import unicodedata
+from collections import OrderedDict
+from collections.abc import Callable
+from email.utils import parseaddr
+from enum import StrEnum
+from pathlib import Path
+from typing import Final, Protocol, runtime_checkable
+
+import dns.resolver
+
+from leadquali.app.enrichment import Enrichment
+from leadquali.prompts.lead import LeadSubmission
+
+logger = logging.getLogger(__name__)
+
+# --------------------------------------------------------------------------- tunables
+
+#: Hard cap on one MX query, in seconds, retries included. Two seconds is generous for a
+#: resolver in the same VPC and short enough that the breaker's threshold of them is still
+#: a fraction of one lead's model call.
+DEFAULT_TIMEOUT_SECONDS: Final[float] = 2.0
+
+#: How long a domain's MX answer is reused. See the module docstring for why 15 minutes.
+DEFAULT_CACHE_TTL_SECONDS: Final[float] = 900.0
+
+#: How many domains the cache holds before evicting the least recently used one.
+DEFAULT_CACHE_MAX_DOMAINS: Final[int] = 1024
+
+#: Consecutive resolver failures before the adapter stops trying for a cooldown.
+DEFAULT_FAILURE_THRESHOLD: Final[int] = 5
+
+#: How long the breaker stays open. One minute: long enough to stop the bleeding, short
+#: enough that a blip does not cost a quarter of an hour of enrichment.
+DEFAULT_BREAKER_COOLDOWN_SECONDS: Final[float] = 60.0
+
+# ------------------------------------------------------------------------- fact keys
+
+#: The registered domain of the address, e.g. ``acme.com``. Never the whole address.
+FACT_DOMAIN: Final[str] = "email_domain"
+
+#: One of :class:`DomainType`.
+FACT_DOMAIN_TYPE: Final[str] = "email_domain_type"
+
+#: One of :class:`AddressType`.
+FACT_ADDRESS_TYPE: Final[str] = "email_address_type"
+
+#: :data:`YES` / :data:`NO` / :data:`UNKNOWN` — whether the domain exists in DNS at all.
+FACT_DOMAIN_RESOLVES: Final[str] = "email_domain_resolves"
+
+#: :data:`YES` / :data:`NO` / :data:`UNKNOWN` — whether it can actually receive mail.
+FACT_DOMAIN_HAS_MX: Final[str] = "email_domain_has_mx"
+
+#: :data:`YES` / :data:`NO` / :data:`NOT_CHECKED` / :data:`NOT_APPLICABLE`.
+FACT_COMPANY_MATCH: Final[str] = "company_matches_email_domain"
+
+YES: Final[str] = "yes"
+NO: Final[str] = "no"
+
+#: The check was attempted and could not be completed. Distinct from :data:`NOT_CHECKED`.
+UNKNOWN: Final[str] = "unknown"
+
+#: Nothing to check — the submission gave no company name.
+NOT_CHECKED: Final[str] = "not_checked"
+
+#: The check is meaningless here: nobody's company owns ``gmail.com``.
+NOT_APPLICABLE: Final[str] = "not_applicable"
+
+#: Reasons, all operator-facing and free of PII (invariant 5).
+NO_ADDRESS_REASON: Final[str] = "no email address in the submission"
+MALFORMED_REASON: Final[str] = "the submitted email address is not a usable address"
+BREAKER_OPEN_REASON: Final[str] = "dns lookups paused after repeated failures"
+
+
+class DomainType(StrEnum):
+    """What kind of mail domain the address is on.
+
+    :attr:`CORPORATE` is a claim about the lists, not about DNS: it means "not a known
+    consumer or throwaway provider", i.e. an address on somebody's own domain. Whether
+    that domain actually exists is a separate fact (:data:`FACT_DOMAIN_RESOLVES`), kept
+    separate so the model can tell "own domain, receives mail" from "own domain, does not
+    exist" — which are opposite signals.
+    """
+
+    CORPORATE = "corporate"
+    FREE_MAIL = "free_mail"
+    DISPOSABLE = "disposable"
+
+
+class AddressType(StrEnum):
+    """Whether the address reaches a person or a shared inbox.
+
+    A role account is not a bad lead — ``info@`` is how a great many small companies make
+    first contact — but it is weak evidence for the ``authority`` dimension, because
+    nobody has told you who they are.
+    """
+
+    ROLE_ACCOUNT = "role_account"
+    PERSONAL = "personal"
+
+
+class MxResult(StrEnum):
+    """The three answers one MX query can give that are *facts* rather than failures.
+
+    Anything else — a timeout, SERVFAIL, an unreachable resolver — is a failure and is
+    raised by an :class:`MxLookup`, because reporting "no MX records" for a domain nobody
+    managed to ask about would be a false statement in a block the model is told to trust.
+    """
+
+    HAS_MX = "has_mx"
+    NO_MX_RECORDS = "no_mx_records"
+    NO_SUCH_DOMAIN = "no_such_domain"
+
+
+@runtime_checkable
+class MxLookup(Protocol):
+    """The DNS seam, narrow enough that a test can implement it in four lines.
+
+    It is deliberately *not* a port in :mod:`leadquali.app.ports`: the application layer
+    has no business knowing that enrichment involves MX records at all. It exists so the
+    suite runs offline, and so a deployment that resolves through an internal service
+    rather than DNS can substitute one class.
+    """
+
+    def lookup_mx(self, domain: str) -> MxResult:
+        """Return what DNS says about ``domain``'s mail exchangers.
+
+        Raises:
+            Exception: any failure to *obtain* an answer — timeout, SERVFAIL, no reachable
+                nameserver. The caller degrades; it never reports a guess as a fact.
+        """
+        ...
+
+
+class DomainListError(RuntimeError):
+    """A configured domain list could not be read.
+
+    Raised at construction, not per lead, and deliberately not degraded: an empty
+    disposable list silently classifies every throwaway address as corporate, which is a
+    scoring bug nobody would ever notice. Failing here fails the deploy, in front of
+    whoever is doing the deploying.
+    """
+
+
+def default_data_dir() -> Path:
+    """Directory holding the bundled domain lists, next to this module."""
+    return Path(__file__).resolve().parent / "data"
+
+
+def default_disposable_domains_path() -> Path:
+    """The bundled disposable/throwaway domain list."""
+    return default_data_dir() / "disposable_email_domains.txt"
+
+
+def default_free_mail_domains_path() -> Path:
+    """The bundled consumer ("free-mail") provider list."""
+    return default_data_dir() / "free_mail_domains.txt"
+
+
+def load_domain_list(path: Path | str) -> frozenset[str]:
+    """Read one domain-per-line list, ignoring blank lines and ``#`` comments.
+
+    Entries are lowercased and stripped of a leading ``@`` and a trailing dot, so a list
+    pasted from another tool works without editing.
+    """
+    file = Path(path)
+    try:
+        raw = file.read_text(encoding="utf-8")
+    except OSError as exc:
+        raise DomainListError(f"cannot read the domain list at {file}: {exc}") from exc
+    domains = {
+        entry
+        for line in raw.splitlines()
+        if (entry := line.split("#", 1)[0].strip().lower().lstrip("@").rstrip("."))
+    }
+    if not domains:
+        raise DomainListError(f"the domain list at {file} is empty")
+    return frozenset(domains)
+
+
+class DnsPythonMxLookup:
+    """The real :class:`MxLookup`, backed by ``dnspython``.
+
+    ``dns`` is imported here and nowhere else in the package, for the same reason
+    ``anthropic`` lives only in the LLM adapter.
+    """
+
+    def __init__(
+        self,
+        *,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        resolver: dns.resolver.Resolver | None = None,
+    ) -> None:
+        """Build a lookup.
+
+        Args:
+            timeout_seconds: hard cap on one query, passed as ``lifetime`` so it bounds
+                the whole attempt rather than each individual UDP send.
+            resolver: an already-configured resolver. Defaults to the system one, read
+                from ``/etc/resolv.conf`` at construction — which in a VPC Lambda is the
+                VPC resolver. See the module docstring's Phase 4 note.
+        """
+        self._timeout_seconds = timeout_seconds
+        self._resolver = resolver if resolver is not None else dns.resolver.Resolver()
+        self._resolver.timeout = timeout_seconds
+        self._resolver.lifetime = timeout_seconds
+
+    def lookup_mx(self, domain: str) -> MxResult:
+        """Ask for ``domain``'s MX records once, within the configured lifetime."""
+        try:
+            answer = self._resolver.resolve(domain, "MX", lifetime=self._timeout_seconds)
+        except dns.resolver.NXDOMAIN:
+            return MxResult.NO_SUCH_DOMAIN
+        except dns.resolver.NoAnswer:
+            return MxResult.NO_MX_RECORDS
+        return MxResult.HAS_MX if len(answer) > 0 else MxResult.NO_MX_RECORDS
+
+
+class EmailEnricher:
+    """An :class:`~leadquali.app.ports.EnricherPort` built on one email address.
+
+    Swap it for :class:`~leadquali.adapters.enrich_null.NullEnricher` at the entrypoint
+    and the pipeline is unchanged; swap it in and every lead carries six more facts that
+    the model would otherwise have had to guess.
+    """
+
+    def __init__(
+        self,
+        *,
+        lookup: MxLookup | None = None,
+        timeout_seconds: float = DEFAULT_TIMEOUT_SECONDS,
+        cache_ttl_seconds: float = DEFAULT_CACHE_TTL_SECONDS,
+        cache_max_domains: int = DEFAULT_CACHE_MAX_DOMAINS,
+        disposable_domains_path: Path | str | None = None,
+        free_mail_domains_path: Path | str | None = None,
+        failure_threshold: int = DEFAULT_FAILURE_THRESHOLD,
+        breaker_cooldown_seconds: float = DEFAULT_BREAKER_COOLDOWN_SECONDS,
+        monotonic: Callable[[], float] = time.monotonic,
+    ) -> None:
+        """Build an enricher. Every knob has a working default; tests replace three.
+
+        Args:
+            lookup: the DNS seam. Defaults to :class:`DnsPythonMxLookup` built with
+                ``timeout_seconds``; tests and offline deployments inject their own.
+            timeout_seconds: hard cap on one lookup. Ignored when ``lookup`` is given,
+                which owns its own timeout.
+            cache_ttl_seconds: how long one domain's answer is reused.
+            cache_max_domains: LRU bound on the cache.
+            disposable_domains_path: override for the bundled throwaway list — a mounted
+                file, refreshed by operations without a release.
+            free_mail_domains_path: override for the bundled consumer-provider list.
+            failure_threshold: consecutive failures that open the breaker. Must be >= 1.
+            breaker_cooldown_seconds: how long it stays open.
+            monotonic: the time source for the cache and the breaker. Monotonic, not wall
+                time, so an NTP correction cannot make a cache entry immortal — and
+                injectable so tests exercise expiry without sleeping.
+
+        Raises:
+            ValueError: a nonsensical bound (a non-positive cache size or threshold).
+            DomainListError: a domain list is missing, unreadable or empty.
+        """
+        if cache_max_domains < 1:
+            raise ValueError("cache_max_domains must be at least 1")
+        if failure_threshold < 1:
+            raise ValueError("failure_threshold must be at least 1")
+
+        self._lookup: MxLookup = (
+            lookup if lookup is not None else DnsPythonMxLookup(timeout_seconds=timeout_seconds)
+        )
+        self._cache_ttl_seconds = cache_ttl_seconds
+        self._cache_max_domains = cache_max_domains
+        self._failure_threshold = failure_threshold
+        self._breaker_cooldown_seconds = breaker_cooldown_seconds
+        self._monotonic = monotonic
+
+        self.disposable_domains = load_domain_list(
+            disposable_domains_path
+            if disposable_domains_path is not None
+            else default_disposable_domains_path()
+        )
+        self.free_mail_domains = load_domain_list(
+            free_mail_domains_path
+            if free_mail_domains_path is not None
+            else default_free_mail_domains_path()
+        )
+
+        # One lock over the cache and the breaker. A worker may run several leads at once,
+        # and it is never held across the lookup itself: blocking every lead behind one
+        # slow query is the failure this adapter exists to avoid.
+        self._lock = threading.Lock()
+        self._cache: OrderedDict[str, tuple[float, MxResult]] = OrderedDict()
+        self._failures = 0
+        self._opened_at: float | None = None
+
+    # ------------------------------------------------------------------ introspection
+
+    @property
+    def cached_domains(self) -> int:
+        """How many domains the cache currently holds. For tests and metrics."""
+        with self._lock:
+            return len(self._cache)
+
+    @property
+    def consecutive_failures(self) -> int:
+        """Resolver failures since the last success. At the threshold, the breaker is open."""
+        with self._lock:
+            return self._failures
+
+    # ------------------------------------------------------------------------ the port
+
+    def enrich(self, *, tenant_id: str, submission: LeadSubmission) -> Enrichment:
+        """Establish what the address says about this lead. Never raises.
+
+        The outer catch is not defensive clutter: the alternative to a bug here being an
+        unavailable enrichment is a bug here being a lost lead, and the two are not close.
+        """
+        del tenant_id  # No per-tenant behaviour yet; the port carries it for adapters that do.
+        try:
+            return self._enrich(submission)
+        except Exception as exc:  # An enricher that raises is a bug; a lost lead is worse.
+            logger.exception("email enrichment failed unexpectedly")
+            return Enrichment.unavailable(f"enrichment error ({type(exc).__name__})")
+
+    def _enrich(self, submission: LeadSubmission) -> Enrichment:
+        parsed = _parse_address(submission.email or "")
+        if parsed is None:
+            if not (submission.email or "").strip():
+                return Enrichment.unavailable(NO_ADDRESS_REASON)
+            logger.debug("email enrichment skipped: the address is not parseable")
+            return Enrichment.unavailable(MALFORMED_REASON)
+
+        local, domain = parsed
+        domain_type = self._classify_domain(domain)
+        facts = {
+            FACT_DOMAIN: domain,
+            FACT_DOMAIN_TYPE: domain_type.value,
+            FACT_ADDRESS_TYPE: _classify_address(local).value,
+            FACT_COMPANY_MATCH: _company_match(submission.company, domain, domain_type),
+        }
+
+        result, reason = self._resolve(domain)
+        if result is None:
+            # The classification above needed no network and is still true, so it stays:
+            # #14's Enrichment models exactly this partial state, and throwing away a
+            # disposable-domain hit because DNS was slow would be the worst of both.
+            facts[FACT_DOMAIN_RESOLVES] = UNKNOWN
+            facts[FACT_DOMAIN_HAS_MX] = UNKNOWN
+            return Enrichment(facts=facts, available=False, unavailable_reason=reason)
+
+        facts[FACT_DOMAIN_RESOLVES] = NO if result is MxResult.NO_SUCH_DOMAIN else YES
+        facts[FACT_DOMAIN_HAS_MX] = YES if result is MxResult.HAS_MX else NO
+        return Enrichment(facts=facts)
+
+    # --------------------------------------------------------------- lookup + caching
+
+    def _resolve(self, domain: str) -> tuple[MxResult | None, str]:
+        """One bounded MX lookup, or the reason there wasn't one.
+
+        Returns ``(result, "")`` on success and ``(None, reason)`` on any failure. The
+        reason is rendered into the prompt, so it names the exception's class and nothing
+        else — never a message that might quote an address or an internal hostname.
+        """
+        now = self._monotonic()
+        with self._lock:
+            cached = self._cache_get(domain, now)
+            if cached is not None:
+                return cached, ""
+            if self._breaker_is_open(now):
+                return None, BREAKER_OPEN_REASON
+
+        try:
+            result = self._lookup.lookup_mx(domain)
+        except Exception as exc:  # Every failure mode of DNS, plus the ones we forgot.
+            with self._lock:
+                self._record_failure(now)
+            logger.debug("mx lookup failed for domain=%s (%s)", domain, type(exc).__name__)
+            return None, f"dns lookup failed ({type(exc).__name__})"
+
+        with self._lock:
+            self._record_success()
+            self._cache_put(domain, result, now)
+        return result, ""
+
+    def _cache_get(self, domain: str, now: float) -> MxResult | None:
+        entry = self._cache.get(domain)
+        if entry is None:
+            return None
+        expires_at, result = entry
+        if now >= expires_at:
+            del self._cache[domain]
+            return None
+        self._cache.move_to_end(domain)
+        return result
+
+    def _cache_put(self, domain: str, result: MxResult, now: float) -> None:
+        # Negative answers are cached like positive ones: a burst of leads from a domain
+        # that does not exist is exactly the burst worth not re-asking about.
+        self._cache[domain] = (now + self._cache_ttl_seconds, result)
+        self._cache.move_to_end(domain)
+        while len(self._cache) > self._cache_max_domains:
+            self._cache.popitem(last=False)
+
+    def _breaker_is_open(self, now: float) -> bool:
+        return (
+            self._opened_at is not None and now - self._opened_at < self._breaker_cooldown_seconds
+        )
+
+    def _record_failure(self, now: float) -> None:
+        self._failures += 1
+        if self._failures < self._failure_threshold:
+            return
+        if self._opened_at is None:
+            logger.warning(
+                "email enrichment disabled for %.0fs after %d consecutive dns failures; "
+                "leads will be assessed without enrichment. In a VPC deployment this is "
+                "usually missing DNS resolution in the private subnets, not a dns outage.",
+                self._breaker_cooldown_seconds,
+                self._failures,
+            )
+        self._opened_at = now
+
+    def _record_success(self) -> None:
+        if self._opened_at is not None:
+            logger.info("email enrichment resumed: dns is answering again")
+        self._failures = 0
+        self._opened_at = None
+
+    # ------------------------------------------------------------------ classification
+
+    def _classify_domain(self, domain: str) -> DomainType:
+        """Disposable wins over free-mail, which wins over "somebody's own domain".
+
+        The precedence matters if a domain ever lands on both lists: a throwaway service
+        that also offers permanent mailboxes is a throwaway service for our purposes.
+        """
+        if domain in self.disposable_domains:
+            return DomainType.DISPOSABLE
+        if domain in self.free_mail_domains:
+            return DomainType.FREE_MAIL
+        return DomainType.CORPORATE
+
+
+# ---------------------------------------------------------------------- address parsing
+
+#: Local parts we treat as shared inboxes rather than people. Kept in code, unlike the
+#: domain lists, because it is a closed linguistic set that has not changed in twenty
+#: years — whereas throwaway domains appear weekly, which is what makes those a data file.
+ROLE_LOCAL_PARTS: Final[frozenset[str]] = frozenset(
+    {
+        "abuse",
+        "accounting",
+        "accounts",
+        "admin",
+        "administrator",
+        "ask",
+        "billing",
+        "careers",
+        "contact",
+        "contactus",
+        "customerservice",
+        "enquiries",
+        "enquiry",
+        "feedback",
+        "finance",
+        "general",
+        "hello",
+        "help",
+        "helpdesk",
+        "hi",
+        "hr",
+        "info",
+        "inquiries",
+        "inquiry",
+        "invoices",
+        "it",
+        "jobs",
+        "legal",
+        "mail",
+        "marketing",
+        "media",
+        "newsletter",
+        "noreply",
+        "office",
+        "orders",
+        "partners",
+        "partnerships",
+        "postmaster",
+        "press",
+        "privacy",
+        "purchasing",
+        "recruitment",
+        "sales",
+        "security",
+        "service",
+        "support",
+        "team",
+        "webmaster",
+        "welcome",
+    }
+)
+
+#: Dropped when comparing a company name to a domain: they carry no identity.
+_COMPANY_STOPWORDS: Final[frozenset[str]] = frozenset(
+    {
+        "ab",
+        "ag",
+        "and",
+        "as",
+        "bv",
+        "co",
+        "company",
+        "corp",
+        "corporation",
+        "gbr",
+        "gmbh",
+        "group",
+        "holding",
+        "holdings",
+        "inc",
+        "incorporated",
+        "kft",
+        "kk",
+        "limited",
+        "llc",
+        "llp",
+        "lp",
+        "ltd",
+        "nv",
+        "of",
+        "oy",
+        "pc",
+        "plc",
+        "pllc",
+        "pty",
+        "sa",
+        "sarl",
+        "sas",
+        "spa",
+        "srl",
+        "the",
+        "ug",
+    }
+)
+
+#: Second-level labels that are part of a public suffix rather than a name, so that
+#: ``acme.co.uk`` reduces to ``acme``. A deliberate approximation: the real answer is the
+#: Public Suffix List, which is a dependency and a periodic data refresh that this one
+#: heuristic does not justify. Getting it wrong costs a false ``no`` on one soft signal.
+_PUBLIC_SECOND_LEVEL_LABELS: Final[frozenset[str]] = frozenset(
+    {"ac", "co", "com", "edu", "gov", "ltd", "me", "mil", "ne", "net", "or", "org", "plc", "sch"}
+)
+
+_LOCAL_PART_RE: Final[re.Pattern[str]] = re.compile(r"^[A-Za-z0-9!#$%&'*+/=?^_`{|}~.-]+$")
+_LABEL_RE: Final[re.Pattern[str]] = re.compile(r"^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?$")
+_NON_ALNUM_RE: Final[re.Pattern[str]] = re.compile(r"[^a-z0-9]+")
+
+_MAX_LOCAL_PART_CHARS: Final[int] = 64
+_MAX_DOMAIN_CHARS: Final[int] = 253
+_MIN_MATCHABLE_CHARS: Final[int] = 3
+
+
+def _parse_address(raw: str) -> tuple[str, str] | None:
+    """Split a submitted address into ``(local_part, domain)``, or ``None`` if it is junk.
+
+    Tolerant where a web form is messy — surrounding whitespace, a ``Name <addr>`` form
+    pasted out of a mail client, mixed case, a trailing root dot, an internationalised
+    domain — and strict where a mistake would matter: exactly one ``@``, a domain of at
+    least two syntactically valid labels. ``None`` means "not usable", and the caller says
+    so rather than resolving something it made up.
+    """
+    _, address = parseaddr(raw.strip())
+    if address.count("@") != 1:
+        return None
+    local, _, domain = address.partition("@")
+    local = local.strip()
+    if not local or len(local) > _MAX_LOCAL_PART_CHARS or not _LOCAL_PART_RE.match(local):
+        return None
+
+    domain = unicodedata.normalize("NFKC", domain.strip()).rstrip(".").lower()
+    if not domain or len(domain) > _MAX_DOMAIN_CHARS:
+        return None
+    if not domain.isascii():
+        try:  # An IDN is a real domain; resolve it as the punycode DNS actually holds.
+            domain = domain.encode("idna").decode("ascii")
+        except (UnicodeError, ValueError):
+            return None
+
+    labels = domain.split(".")
+    if len(labels) < 2 or len(labels[-1]) < 2 or labels[-1].isdigit():
+        return None
+    if not all(_LABEL_RE.match(label) for label in labels):
+        return None
+    return local, domain
+
+
+def _classify_address(local: str) -> AddressType:
+    """Role account or person, judged on the local part with any ``+tag`` removed."""
+    base = _NON_ALNUM_RE.sub("", local.split("+", 1)[0].lower())
+    return AddressType.ROLE_ACCOUNT if base in ROLE_LOCAL_PARTS else AddressType.PERSONAL
+
+
+def _company_match(company: str | None, domain: str, domain_type: DomainType) -> str:
+    """Whether the typed company plausibly owns the domain the lead wrote from.
+
+    A genuine ICP-fit signal in both directions: agreement corroborates everything else
+    the submission claims about itself, and disagreement is worth a human's attention. It
+    is reported as a separate fact rather than folded into the domain type so the model
+    can weigh it — the heuristic is a heuristic, and rebrands, acquisitions and holding
+    companies all produce honest mismatches.
+
+    On a consumer or throwaway domain the question has no content — nobody's employer owns
+    ``gmail.com`` — so it is reported as not applicable rather than as a mismatch, which
+    would otherwise put a false negative signal on every sole trader.
+    """
+    if domain_type is not DomainType.CORPORATE:
+        return NOT_APPLICABLE
+    tokens = _company_tokens(company or "")
+    if not tokens:
+        return NOT_CHECKED
+
+    core = _domain_core(domain)
+    squashed = "".join(tokens)
+    if len(core) < _MIN_MATCHABLE_CHARS or len(squashed) < _MIN_MATCHABLE_CHARS:
+        return NO
+    if core in squashed or squashed in core:
+        return YES
+    initials = "".join(token[0] for token in tokens if len(token) >= 2)
+    return YES if len(initials) >= 2 and initials == core else NO
+
+
+def _company_tokens(company: str) -> list[str]:
+    """The identity-carrying words of a company name, accents folded and suffixes dropped."""
+    folded = unicodedata.normalize("NFKD", company.lower())
+    ascii_only = "".join(character for character in folded if not unicodedata.combining(character))
+    return [
+        token
+        for token in _NON_ALNUM_RE.split(ascii_only)
+        if token and token not in _COMPANY_STOPWORDS
+    ]
+
+
+def _domain_core(domain: str) -> str:
+    """The name-bearing label of a domain: ``mail.acme.co.uk`` → ``acme``."""
+    labels = domain.split(".")[:-1]
+    if len(labels) >= 2 and labels[-1] in _PUBLIC_SECOND_LEVEL_LABELS:
+        labels = labels[:-1]
+    return labels[-1] if labels else ""
+
+
+__all__ = [
+    "BREAKER_OPEN_REASON",
+    "DEFAULT_BREAKER_COOLDOWN_SECONDS",
+    "DEFAULT_CACHE_MAX_DOMAINS",
+    "DEFAULT_CACHE_TTL_SECONDS",
+    "DEFAULT_FAILURE_THRESHOLD",
+    "DEFAULT_TIMEOUT_SECONDS",
+    "FACT_ADDRESS_TYPE",
+    "FACT_COMPANY_MATCH",
+    "FACT_DOMAIN",
+    "FACT_DOMAIN_HAS_MX",
+    "FACT_DOMAIN_RESOLVES",
+    "FACT_DOMAIN_TYPE",
+    "MALFORMED_REASON",
+    "NO",
+    "NOT_APPLICABLE",
+    "NOT_CHECKED",
+    "NO_ADDRESS_REASON",
+    "ROLE_LOCAL_PARTS",
+    "UNKNOWN",
+    "YES",
+    "AddressType",
+    "DnsPythonMxLookup",
+    "DomainListError",
+    "DomainType",
+    "EmailEnricher",
+    "MxLookup",
+    "MxResult",
+    "default_data_dir",
+    "default_disposable_domains_path",
+    "default_free_mail_domains_path",
+    "load_domain_list",
+]

--- a/tests/unit/test_enrich_email.py
+++ b/tests/unit/test_enrich_email.py
@@ -1,0 +1,666 @@
+"""The email enricher, exercised without touching a nameserver.
+
+Every test here drives an injected :class:`~leadquali.adapters.enrich_email.MxLookup`, so
+the suite is offline, deterministic and fast. That is not only a CI convenience: the seam
+that makes it possible is the same one that lets a deployment swap DNS for an internal
+resolution service, and the same one that lets the failure paths — timeout, SERVFAIL,
+NXDOMAIN — be tested at all, which is where the interesting behaviour lives.
+
+The invariant under test throughout is that this adapter *cannot* break qualification. It
+classifies what it can, marks what it could not, and never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+
+import dns.exception
+import dns.resolver
+import pytest
+
+from leadquali.adapters.enrich_email import (
+    DEFAULT_BREAKER_COOLDOWN_SECONDS,
+    DEFAULT_CACHE_MAX_DOMAINS,
+    DEFAULT_CACHE_TTL_SECONDS,
+    DEFAULT_TIMEOUT_SECONDS,
+    FACT_ADDRESS_TYPE,
+    FACT_COMPANY_MATCH,
+    FACT_DOMAIN,
+    FACT_DOMAIN_HAS_MX,
+    FACT_DOMAIN_RESOLVES,
+    FACT_DOMAIN_TYPE,
+    NO,
+    NOT_APPLICABLE,
+    NOT_CHECKED,
+    UNKNOWN,
+    YES,
+    AddressType,
+    DnsPythonMxLookup,
+    DomainType,
+    EmailEnricher,
+    MxResult,
+    default_disposable_domains_path,
+    default_free_mail_domains_path,
+)
+from leadquali.app.assessment_result import AssessmentSucceeded, CallMetering
+from leadquali.app.enrichment import Enrichment, enrichment_block
+from leadquali.app.ports import EnricherPort
+from leadquali.app.qualify import (
+    Disposition,
+    QualificationPipeline,
+    QualificationRequest,
+)
+from leadquali.domain.models import DimensionScores, ExtractedFacts, LeadAssessment
+from leadquali.domain.tenant_config import TenantConfig
+from leadquali.prompts.lead import LeadSubmission
+from tests.fakes import FakeClock, InMemoryLeadStore, RecordingNotifier, ScriptedAssessor
+
+TENANT = "acme"
+
+
+# --------------------------------------------------------------------------- doubles
+
+
+class FakeMxLookup:
+    """An :class:`MxLookup` answering from a dict, and counting every call.
+
+    ``calls`` is the point of it: "one lookup per lead, and none at all when the cache
+    already knows" is a behavioural claim, and the only way to assert it is to count.
+    """
+
+    def __init__(
+        self,
+        results: Mapping[str, MxResult] | None = None,
+        *,
+        default: MxResult = MxResult.HAS_MX,
+        raises: Exception | None = None,
+        raise_times: int | None = None,
+    ) -> None:
+        self.results = dict(results or {})
+        self.default = default
+        self.raises = raises
+        self.raise_times = raise_times
+        self.calls: list[str] = []
+
+    def lookup_mx(self, domain: str) -> MxResult:
+        self.calls.append(domain)
+        if self.raises is not None and (
+            self.raise_times is None or len(self.calls) <= self.raise_times
+        ):
+            raise self.raises
+        return self.results.get(domain, self.default)
+
+
+@dataclass
+class FakeMonotonic:
+    """An injectable monotonic clock, so cache expiry and cooldowns need no sleeping."""
+
+    value: float = 1_000.0
+
+    def __call__(self) -> float:
+        return self.value
+
+    def advance(self, seconds: float) -> None:
+        self.value += seconds
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def enrich(
+    email: str | None,
+    *,
+    company: str | None = None,
+    enricher: EmailEnricher | None = None,
+    lookup: FakeMxLookup | None = None,
+) -> Enrichment:
+    """Enrich one submission built from just an address and (optionally) a company."""
+    the_enricher = enricher or EmailEnricher(lookup=lookup or FakeMxLookup())
+    return the_enricher.enrich(
+        tenant_id=TENANT, submission=LeadSubmission(email=email, company=company)
+    )
+
+
+def facts(result: Enrichment) -> dict[str, str]:
+    return dict(result.facts)
+
+
+# --------------------------------------------------------------------------- the port
+
+
+def test_it_satisfies_the_enricher_port() -> None:
+    """Structural conformance, checked rather than assumed."""
+    assert isinstance(EmailEnricher(lookup=FakeMxLookup()), EnricherPort)
+
+
+def test_the_bundled_lists_exist_and_are_loaded() -> None:
+    """A path typo would otherwise turn every classification into ``corporate``."""
+    assert default_disposable_domains_path().is_file()
+    assert default_free_mail_domains_path().is_file()
+    enricher = EmailEnricher(lookup=FakeMxLookup())
+    assert len(enricher.disposable_domains) >= 100
+    assert len(enricher.free_mail_domains) >= 50
+    assert "mailinator.com" in enricher.disposable_domains
+    assert "gmail.com" in enricher.free_mail_domains
+    # The two lists are different signals; a domain in both would make them one flag.
+    assert not (enricher.disposable_domains & enricher.free_mail_domains)
+
+
+# --------------------------------------------------------------- domain classification
+
+
+def test_a_corporate_domain_with_mx_is_reported_as_corporate() -> None:
+    lookup = FakeMxLookup({"acme.test": MxResult.HAS_MX})
+    result = enrich("dana.reed@acme.test", company="Acme", lookup=lookup)
+
+    assert result.available is True
+    assert facts(result) == {
+        FACT_DOMAIN: "acme.test",
+        FACT_DOMAIN_TYPE: DomainType.CORPORATE.value,
+        FACT_ADDRESS_TYPE: AddressType.PERSONAL.value,
+        FACT_DOMAIN_RESOLVES: YES,
+        FACT_DOMAIN_HAS_MX: YES,
+        FACT_COMPANY_MATCH: YES,
+    }
+    assert lookup.calls == ["acme.test"]
+
+
+def test_a_free_mail_provider_is_not_called_corporate_and_not_called_disposable() -> None:
+    """gmail is a real reachable person; the throwaway signal must not be borrowed for it."""
+    result = enrich("dana.reed@gmail.com", company="Acme Ltd")
+
+    assert facts(result)[FACT_DOMAIN_TYPE] == DomainType.FREE_MAIL.value
+    assert facts(result)[FACT_DOMAIN_TYPE] != DomainType.DISPOSABLE.value
+    assert result.available is True
+
+
+def test_a_disposable_provider_is_reported_as_disposable() -> None:
+    result = enrich("someone@mailinator.com", company="Acme")
+
+    assert facts(result)[FACT_DOMAIN_TYPE] == DomainType.DISPOSABLE.value
+
+
+@pytest.mark.parametrize(
+    ("address", "expected"),
+    [
+        ("dana@acme.test", DomainType.CORPORATE),
+        ("dana@gmail.com", DomainType.FREE_MAIL),
+        ("dana@GMAIL.COM", DomainType.FREE_MAIL),
+        ("dana@yopmail.com", DomainType.DISPOSABLE),
+        ("dana@mail.acme.test", DomainType.CORPORATE),
+    ],
+)
+def test_domain_type_classification(address: str, expected: DomainType) -> None:
+    assert facts(enrich(address))[FACT_DOMAIN_TYPE] == expected.value
+
+
+@pytest.mark.parametrize(
+    ("address", "expected"),
+    [
+        ("info@acme.test", AddressType.ROLE_ACCOUNT),
+        ("sales@acme.test", AddressType.ROLE_ACCOUNT),
+        ("admin@acme.test", AddressType.ROLE_ACCOUNT),
+        ("no-reply@acme.test", AddressType.ROLE_ACCOUNT),
+        ("No.Reply@acme.test", AddressType.ROLE_ACCOUNT),
+        ("hello+tag@acme.test", AddressType.ROLE_ACCOUNT),
+        ("dana.reed@acme.test", AddressType.PERSONAL),
+        ("d.reed2@acme.test", AddressType.PERSONAL),
+        ("infomatics@acme.test", AddressType.PERSONAL),
+    ],
+)
+def test_role_addresses_are_told_apart_from_personal_ones(
+    address: str, expected: AddressType
+) -> None:
+    assert facts(enrich(address))[FACT_ADDRESS_TYPE] == expected.value
+
+
+def test_the_domain_is_normalised_out_of_a_display_name_and_case() -> None:
+    """A form field holds whatever the browser autofilled into it."""
+    result = enrich("  Dana Reed <Dana.Reed@ACME.test.> ")
+
+    assert facts(result)[FACT_DOMAIN] == "acme.test"
+
+
+# ------------------------------------------------------------------------ MX outcomes
+
+
+def test_a_domain_that_resolves_without_mx_records_says_so() -> None:
+    lookup = FakeMxLookup({"acme.test": MxResult.NO_MX_RECORDS})
+    result = enrich("dana@acme.test", lookup=lookup)
+
+    assert result.available is True
+    assert facts(result)[FACT_DOMAIN_RESOLVES] == YES
+    assert facts(result)[FACT_DOMAIN_HAS_MX] == NO
+
+
+def test_nxdomain_reports_a_domain_that_does_not_resolve() -> None:
+    lookup = FakeMxLookup({"acme.test": MxResult.NO_SUCH_DOMAIN})
+    result = enrich("dana@acme.test", lookup=lookup)
+
+    assert result.available is True
+    assert facts(result)[FACT_DOMAIN_RESOLVES] == NO
+    assert facts(result)[FACT_DOMAIN_HAS_MX] == NO
+
+
+# ------------------------------------------------------------------- failing outcomes
+
+
+def test_a_dns_timeout_degrades_to_unavailable_and_keeps_the_offline_facts() -> None:
+    """The classification needs no network, so a timeout must not throw it away."""
+    lookup = FakeMxLookup(raises=dns.exception.Timeout())
+    result = enrich("info@mailinator.com", lookup=lookup)
+
+    assert result.available is False
+    assert result.unavailable_reason
+    assert facts(result)[FACT_DOMAIN_TYPE] == DomainType.DISPOSABLE.value
+    assert facts(result)[FACT_ADDRESS_TYPE] == AddressType.ROLE_ACCOUNT.value
+    assert facts(result)[FACT_DOMAIN_RESOLVES] == UNKNOWN
+    assert facts(result)[FACT_DOMAIN_HAS_MX] == UNKNOWN
+
+
+@pytest.mark.parametrize(
+    "exception",
+    [
+        dns.exception.Timeout(),
+        dns.resolver.NoNameservers(),
+        dns.resolver.LifetimeTimeout(timeout=2.0, errors=[]),
+        OSError("network is unreachable"),
+        RuntimeError("resolver misconfigured"),
+        ValueError("nonsense"),
+        MemoryError(),
+    ],
+    ids=lambda exception: type(exception).__name__,
+)
+def test_any_resolver_exception_becomes_unavailable_rather_than_propagating(
+    exception: Exception,
+) -> None:
+    """Invariant: enrichment is an optimisation. Nothing it does may reach the caller."""
+    result = enrich("dana@acme.test", lookup=FakeMxLookup(raises=exception))
+
+    assert result.available is False
+    assert type(exception).__name__ in result.unavailable_reason
+
+
+def test_a_missing_address_is_unavailable_with_no_facts_at_all() -> None:
+    result = enrich(None)
+
+    assert result == Enrichment.unavailable(result.unavailable_reason)
+    assert not result.facts
+    assert "no email address" in result.unavailable_reason
+
+
+@pytest.mark.parametrize(
+    "address",
+    ["", "   ", "not-an-email", "@acme.test", "dana@", "dana@@acme.test", "dana@localhost"],
+)
+def test_a_malformed_address_is_unavailable_with_no_facts_at_all(address: str) -> None:
+    result = enrich(address)
+
+    assert result == Enrichment.unavailable(result.unavailable_reason)
+    assert not result.facts
+    assert result.unavailable_reason
+
+
+def test_a_malformed_address_never_costs_a_lookup() -> None:
+    lookup = FakeMxLookup()
+    enrich("not-an-email", lookup=lookup)
+
+    assert lookup.calls == []
+
+
+# ------------------------------------------------------------------------- the cache
+
+
+def test_a_second_lead_from_the_same_domain_does_not_re_resolve_it() -> None:
+    lookup = FakeMxLookup({"acme.test": MxResult.HAS_MX})
+    enricher = EmailEnricher(lookup=lookup)
+
+    first = enrich("dana@acme.test", enricher=enricher)
+    second = enrich("sam@acme.test", enricher=enricher)
+
+    assert lookup.calls == ["acme.test"]
+    assert facts(first)[FACT_DOMAIN_HAS_MX] == YES
+    assert facts(second)[FACT_DOMAIN_HAS_MX] == YES
+
+
+def test_the_cache_entry_expires() -> None:
+    clock = FakeMonotonic()
+    lookup = FakeMxLookup()
+    enricher = EmailEnricher(lookup=lookup, cache_ttl_seconds=60.0, monotonic=clock)
+
+    enrich("dana@acme.test", enricher=enricher)
+    clock.advance(59.0)
+    enrich("sam@acme.test", enricher=enricher)
+    assert lookup.calls == ["acme.test"]
+
+    clock.advance(2.0)
+    enrich("kim@acme.test", enricher=enricher)
+    assert lookup.calls == ["acme.test", "acme.test"]
+
+
+def test_the_cache_is_bounded_and_evicts_the_least_recently_used_domain() -> None:
+    """A flood of unique domains must not become a memory leak."""
+    lookup = FakeMxLookup()
+    enricher = EmailEnricher(lookup=lookup, cache_max_domains=2)
+
+    enrich("a@one.test", enricher=enricher)
+    enrich("a@two.test", enricher=enricher)
+    enrich("a@one.test", enricher=enricher)  # refreshes one.test, so two.test is oldest
+    enrich("a@three.test", enricher=enricher)  # evicts two.test
+    enrich("a@two.test", enricher=enricher)  # must be looked up again
+
+    assert lookup.calls == ["one.test", "two.test", "three.test", "two.test"]
+    assert enricher.cached_domains == 2
+
+
+def test_a_negative_result_is_cached_too() -> None:
+    lookup = FakeMxLookup({"gone.test": MxResult.NO_SUCH_DOMAIN})
+    enricher = EmailEnricher(lookup=lookup)
+
+    enrich("a@gone.test", enricher=enricher)
+    second = enrich("b@gone.test", enricher=enricher)
+
+    assert lookup.calls == ["gone.test"]
+    assert facts(second)[FACT_DOMAIN_RESOLVES] == NO
+
+
+# ---------------------------------------------------------------- the circuit breaker
+
+
+def test_repeated_failures_stop_the_adapter_from_paying_the_timeout_every_lead() -> None:
+    """A DNS outage costs `failure_threshold` timeouts per cooldown, not one per lead."""
+    lookup = FakeMxLookup(raises=dns.exception.Timeout())
+    enricher = EmailEnricher(lookup=lookup, failure_threshold=2, monotonic=FakeMonotonic())
+
+    results = [enrich(f"a@company{n}.test", enricher=enricher) for n in range(6)]
+
+    assert len(lookup.calls) == 2
+    assert all(result.available is False for result in results)
+    assert "paused" in results[-1].unavailable_reason
+
+
+def test_the_breaker_closes_again_after_its_cooldown() -> None:
+    clock = FakeMonotonic()
+    lookup = FakeMxLookup(raises=dns.exception.Timeout())
+    enricher = EmailEnricher(
+        lookup=lookup, failure_threshold=1, breaker_cooldown_seconds=30.0, monotonic=clock
+    )
+
+    enrich("a@one.test", enricher=enricher)
+    enrich("a@two.test", enricher=enricher)
+    assert len(lookup.calls) == 1
+
+    clock.advance(31.0)
+    enrich("a@three.test", enricher=enricher)
+    assert len(lookup.calls) == 2
+
+
+def test_a_success_clears_the_failure_count() -> None:
+    lookup = FakeMxLookup(raises=dns.exception.Timeout(), raise_times=1)
+    enricher = EmailEnricher(lookup=lookup, failure_threshold=2)
+
+    enrich("a@one.test", enricher=enricher)
+    assert enricher.consecutive_failures == 1
+
+    enrich("a@two.test", enricher=enricher)
+    assert enricher.consecutive_failures == 0
+
+
+# ---------------------------------------------------------------- company/domain match
+
+
+@pytest.mark.parametrize(
+    ("company", "domain"),
+    [
+        ("Acme", "acme.test"),
+        ("Acme Widgets Ltd", "acme.test"),
+        ("acme", "acme.co.uk"),
+        ("Acme", "mail.acme.test"),
+        ("Vendo Works", "vendoworks.io"),
+        ("International Business Machines", "ibm.test"),
+    ],
+)
+def test_a_company_that_plausibly_matches_its_email_domain(company: str, domain: str) -> None:
+    result = enrich(f"dana@{domain}", company=company)
+
+    assert facts(result)[FACT_COMPANY_MATCH] == YES
+
+
+@pytest.mark.parametrize(
+    ("company", "domain"),
+    [
+        ("Globex", "acme.test"),
+        ("Acme", "initech.test"),
+        ("Northwind Traders", "contoso.test"),
+    ],
+)
+def test_a_company_that_does_not_match_its_email_domain(company: str, domain: str) -> None:
+    result = enrich(f"dana@{domain}", company=company)
+
+    assert facts(result)[FACT_COMPANY_MATCH] == NO
+
+
+def test_no_company_means_the_match_was_not_checked() -> None:
+    assert facts(enrich("dana@acme.test"))[FACT_COMPANY_MATCH] == NOT_CHECKED
+
+
+@pytest.mark.parametrize("domain", ["gmail.com", "mailinator.com"])
+def test_the_match_is_not_applicable_on_a_consumer_or_throwaway_domain(domain: str) -> None:
+    """ "Acme does not match gmail.com" is true and worthless; asserting it would mislead."""
+    result = enrich(f"dana@{domain}", company="Acme")
+
+    assert facts(result)[FACT_COMPANY_MATCH] == NOT_APPLICABLE
+
+
+# ------------------------------------------------------------------------ invariant 5
+
+
+def test_the_local_part_never_reaches_the_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """Invariant 5: the domain is fine, the address is not."""
+    caplog.set_level(logging.DEBUG, logger="leadquali.adapters.enrich_email")
+    enrich("dana.the.secret.person@acme.test", lookup=FakeMxLookup(raises=OSError("down")))
+    enrich("also.secret@nope", lookup=FakeMxLookup())
+
+    assert "secret" not in caplog.text
+    assert "acme.test" in caplog.text
+
+
+def test_the_local_part_never_reaches_the_prompt() -> None:
+    result = enrich("dana.the.secret.person@acme.test")
+
+    assert "secret" not in enrichment_block(result)
+    assert "acme.test" in enrichment_block(result)
+
+
+def test_the_reason_carries_no_address_either() -> None:
+    result = enrich("dana.secret@acme.test", lookup=FakeMxLookup(raises=OSError("boom")))
+
+    assert "secret" not in result.unavailable_reason
+
+
+# ------------------------------------------------------------------------- the block
+
+
+def test_the_facts_render_into_the_prompt_block() -> None:
+    block = enrichment_block(enrich("info@acme.test", company="Acme"))
+
+    assert "email_domain: acme.test" in block
+    assert f"{FACT_DOMAIN_TYPE}: corporate" in block
+    assert "verified_facts" in block
+
+
+def test_an_unavailable_enrichment_tells_the_model_to_record_the_gap() -> None:
+    block = enrichment_block(enrich("dana@acme.test", lookup=FakeMxLookup(raises=OSError("x"))))
+
+    assert "missing_information" in block
+
+
+# ------------------------------------------------------------------- the dns adapter
+
+
+def make_dns_lookup(monkeypatch: pytest.MonkeyPatch, outcome: object) -> DnsPythonMxLookup:
+    """A real :class:`DnsPythonMxLookup` whose resolver answers from memory."""
+    resolver = dns.resolver.Resolver(configure=False)
+
+    def fake_resolve(*args: object, **kwargs: object) -> object:
+        if isinstance(outcome, Exception):
+            raise outcome
+        return outcome
+
+    monkeypatch.setattr(resolver, "resolve", fake_resolve)
+    return DnsPythonMxLookup(resolver=resolver)
+
+
+@pytest.mark.parametrize(
+    ("outcome", "expected"),
+    [
+        ([object()], MxResult.HAS_MX),
+        ([], MxResult.NO_MX_RECORDS),
+        (dns.resolver.NoAnswer(), MxResult.NO_MX_RECORDS),
+        (dns.resolver.NXDOMAIN(), MxResult.NO_SUCH_DOMAIN),
+    ],
+)
+def test_the_dnspython_lookup_translates_resolver_outcomes(
+    monkeypatch: pytest.MonkeyPatch, outcome: object, expected: MxResult
+) -> None:
+    assert make_dns_lookup(monkeypatch, outcome).lookup_mx("acme.test") == expected
+
+
+def test_the_dnspython_lookup_lets_a_timeout_through_to_the_enricher(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Translating a timeout into a *fact* would be a lie; it is a failure, and it raises."""
+    lookup = make_dns_lookup(monkeypatch, dns.exception.Timeout())
+
+    with pytest.raises(dns.exception.Timeout):
+        lookup.lookup_mx("acme.test")
+
+
+def test_the_dnspython_lookup_bounds_every_query(monkeypatch: pytest.MonkeyPatch) -> None:
+    """One bounded attempt: ``lifetime`` caps the whole query, retries included."""
+    seen: dict[str, object] = {}
+    resolver = dns.resolver.Resolver(configure=False)
+
+    def fake_resolve(*args: object, **kwargs: object) -> object:
+        seen.update(kwargs)
+        return [object()]
+
+    monkeypatch.setattr(resolver, "resolve", fake_resolve)
+    DnsPythonMxLookup(resolver=resolver, timeout_seconds=1.5).lookup_mx("acme.test")
+
+    assert seen["lifetime"] == 1.5
+
+
+def test_the_defaults_are_the_documented_ones() -> None:
+    """These numbers are a deployment contract; a silent change deserves a failing test."""
+    assert DEFAULT_TIMEOUT_SECONDS == 2.0
+    assert DEFAULT_CACHE_TTL_SECONDS == 900.0
+    assert DEFAULT_CACHE_MAX_DOMAINS == 1024
+    assert DEFAULT_BREAKER_COOLDOWN_SECONDS == 60.0
+
+
+# ---------------------------------------------------------------- the pipeline holds
+
+
+def build_pipeline(
+    enricher: EnricherPort,
+) -> tuple[QualificationPipeline, RecordingNotifier, ScriptedAssessor]:
+    config = TenantConfig.model_validate(
+        {
+            "tenant_id": TENANT,
+            "name": "Acme Corp",
+            "icp_description": "B2B SaaS companies with 50-500 employees in North America.",
+            "routing_rules": {
+                "hot": {"action": "email_sales", "destination": "hot@acme.test"},
+                "warm": {"action": "email_sales", "destination": "sales@acme.test"},
+                "cold": {"action": "email_sales", "destination": "nurture@acme.test"},
+                "disqualified": {"action": "suppress"},
+            },
+        }
+    )
+    assessment = LeadAssessment(
+        dimension_scores=DimensionScores(
+            icp_fit=25, intent=25, authority=15, urgency=15, budget_signal=15
+        ),
+        extracted=ExtractedFacts(
+            company_name="Acme",
+            industry="saas",
+            company_size_estimate="120",
+            role_seniority="vp",
+            stated_use_case="lead routing",
+            stated_timeline="this quarter",
+        ),
+        reasoning="Fits the profile.",
+        confidence=0.9,
+        missing_information=[],
+        suggested_first_question=None,
+        spam_or_test_submission=False,
+    )
+    metering = CallMetering(
+        model_id="claude-opus-5",
+        prompt_version="rubric_v1",
+        effort="medium",
+        input_tokens=500,
+        output_tokens=800,
+        cache_read_tokens=0,
+        cache_creation_tokens=0,
+        cost_usd=Decimal("0.02"),
+        latency_ms=3200,
+    )
+    notifier = RecordingNotifier()
+    assessor = ScriptedAssessor(AssessmentSucceeded(assessment=assessment, metering=metering))
+
+    class OneConfig:
+        def get(self, tenant_id: str) -> TenantConfig:
+            del tenant_id
+            return config
+
+    pipeline = QualificationPipeline(
+        config_source=OneConfig(),
+        assessor=assessor,
+        store=InMemoryLeadStore(),
+        notifier=notifier,
+        enricher=enricher,
+        clock=FakeClock(start=datetime(2026, 1, 1, tzinfo=UTC)),
+        escalation_destination="ops@vendoworks.test",
+    )
+    return pipeline, notifier, assessor
+
+
+def test_a_dns_outage_still_produces_a_complete_assessment() -> None:
+    """#18's acceptance criterion: the lead is qualified and dispatched anyway."""
+    enricher = EmailEnricher(lookup=FakeMxLookup(raises=dns.exception.Timeout()))
+    pipeline, notifier, _ = build_pipeline(enricher)
+
+    result = pipeline.qualify(
+        QualificationRequest(
+            tenant_id=TENANT,
+            submission_id="sub-1",
+            submission=LeadSubmission(
+                email="dana@acme.test", company="Acme", message="We need lead routing."
+            ),
+        )
+    )
+
+    assert result.disposition is Disposition.DISPATCHED
+    assert result.enrichment_available is False
+    assert len(notifier.dispatches) == 1
+
+
+def test_a_working_enricher_puts_its_facts_in_front_of_the_model() -> None:
+    enricher = EmailEnricher(lookup=FakeMxLookup())
+    pipeline, _, assessor = build_pipeline(enricher)
+
+    pipeline.qualify(
+        QualificationRequest(
+            tenant_id=TENANT,
+            submission_id="sub-1",
+            submission=LeadSubmission(email="info@acme.test", company="Acme"),
+        )
+    )
+
+    assert "email_domain: acme.test" in assessor.prompts[0]


### PR DESCRIPTION
Closes #18. Based on #50 (schema) → #56 (pipeline). Independent of #57 (store) — different files, either order.

`EmailEnricher` implements #56's `EnricherPort`.

## What it establishes

The domain; whether it resolves and accepts mail; whether it is a **free consumer provider** as distinct from a **disposable throwaway** — two signals it would be wrong to collapse, since a VP writing from gmail is a real lead and a signup from a ten-minute mailbox is not; whether the address is role-based (`info@`, `sales@`) rather than personal; and whether the stated company plausibly matches the domain.

## Failure is the design, not an afterthought

Enrichment is an optimisation, not a gate, so the work went into making failure cheap rather than success clever. `enrich` **never raises** — it returns an `Enrichment` marked unavailable with a PII-free reason. Three mechanisms:

- **One bounded lookup per lead.** A single MX query answers both questions worth asking (`NXDOMAIN` = no such domain; empty answer = exists but cannot receive mail), with `lifetime` capping the whole query including retries across nameservers. **No retry loop, deliberately**: a lead is not worth a second attempt, and a retry storm during an outage is how one slow dependency takes a worker fleet down.
- **A small TTL cache keyed on domain** — leads arrive in bursts from one company (a team filling in a form after a webinar). 15 minutes and 1,024 domains: short enough that a domain fixing its MX records is picked up within a worker's lifetime, bounded so a flood of unique junk domains cannot turn the cache into a memory leak.
- **A circuit breaker** — beyond what the issue asked for, and the reason is worth stating: per-domain caching *does not help* when DNS is down, because every lead carries a new domain and pays the full timeout. After a few consecutive failures the adapter degrades immediately for a cooldown, so an outage costs a handful of timeouts per minute rather than one per lead.

## The domain lists are data, not code

Two files with a documented source and update path, and an overridable location. A hardcoded Python set would need a deploy to add a throwaway domain — which is exactly the sort of thing that needs changing on a Tuesday afternoon.

## ⚠️ A deployment constraint #27 must handle

**A Lambda in private VPC subnets has no DNS resolution unless the VPC provides it.** The worker sits in private subnets to reach Postgres, so it needs `enableDnsSupport`, `enableDnsHostnames`, and routing to the VPC resolver — plus NAT or a Route 53 Resolver outbound endpoint for public names.

Get it wrong and every lookup times out: the breaker opens, every lead is enriched with nothing, and **nothing is broken enough to page anyone**. The visible symptom is `enrichment_available=False` on every result, so **#21 should alarm on that ratio** and #27's networking needs to be checked against it.

## Verification

72 new tests, entirely offline against an injected resolver: corporate domain with MX, free provider, disposable provider, role-based address, no MX, NXDOMAIN, timeout, malformed address, missing address, the cache preventing a second lookup, and company/domain match agreeing and disagreeing. Including one asserting that a resolver raising **any** exception yields an unavailable enrichment rather than propagating.

The mypy override added is scoped to a single test module: dnspython's exception classes have untyped constructors, and the tests must raise the *real* ones — a stand-in would stop proving the adapter catches what dnspython actually throws.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_