### PR TITLE
[P2.6] SES routing email with good/bad feedback links + feedback endpoint

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,3 +13,24 @@ DATABASE_URL=postgresql+psycopg://leadquali:leadquali@localhost:5432/leadquali
 # Produce the hash with:
 #   python -c "from leadquali.api.signing import hash_api_key; print(hash_api_key('<key>'))"
 INGEST_CREDENTIALS=
+
+# --- routing email and the feedback loop (P2.6) --------------------------------------
+# The verified SES identity every routing email is sent from, and the configuration set
+# that routes its bounce/complaint/delivery events. Both come from docs/runbooks/ses-setup.md
+# (P2.7) and differ per environment — never hardcode them.
+AWS_REGION=eu-west-1
+SES_SENDER=LeadQuali <leads@mail.example.com>
+SES_CONFIGURATION_SET=
+
+# The public origin the one-click good/bad links in that email point at. Absolute, and the
+# origin a sales rep's phone can actually reach: behind API Gateway it carries the stage
+# prefix (https://<api-id>.execute-api.<region>.amazonaws.com/prod).
+FEEDBACK_BASE_URL=http://localhost:8000
+
+# Signs those links. 32+ characters of random material, and NOT one of the per-tenant ingest
+# signing secrets above: those live on a customer's website, and this one authorises writes
+# to the labelled dataset. Generate one with:
+#   python -c "import secrets; print(secrets.token_urlsafe(48))"
+FEEDBACK_TOKEN_SECRET=
+# How long a feedback link keeps working, in days.
+FEEDBACK_TOKEN_TTL_DAYS=30

--- a/migrations/versions/20260902_0409_484c0bafc202_initial_schema.py
+++ b/migrations/versions/20260902_0409_484c0bafc202_initial_schema.py
@@ -247,6 +247,14 @@ def upgrade() -> None:
             ondelete="CASCADE",
         ),
         sa.PrimaryKeyConstraint("id", name=op.f("pk_feedback")),
+        # One verdict per rater per lead (#19). The conflict target the feedback endpoint
+        # upserts against, so a prefetched link, a double tap and a change of mind all
+        # resolve to one row instead of three. Added here rather than in a follow-up
+        # revision, per this file's own in-place policy: nothing is deployed and no row
+        # exists, so there is nothing to migrate.
+        sa.UniqueConstraint(
+            "tenant_id", "lead_id", "rater", name=op.f("uq_feedback_tenant_id_lead_id_rater")
+        ),
     )
     op.create_index("ix_feedback_lead_id", "feedback", ["lead_id"], unique=False)
     op.create_index(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,9 @@ dev = [
     "ruff",
     "mypy",
     "httpx",
+    # SES is mocked in-process: there are no AWS credentials in CI and a test that
+    # needed them would simply never run.
+    "moto[ses]",
 ]
 
 [build-system]

--- a/src/leadquali/adapters/db_schema.py
+++ b/src/leadquali/adapters/db_schema.py
@@ -424,6 +424,16 @@ class Feedback(Base):
 
     __table_args__ = (
         _owned_lead_fk(),
+        # One verdict per rater per lead, so a second click is an UPDATE and not a second
+        # row. Mail clients prefetch links, phones register double taps, and a rep is
+        # allowed to change their mind — without this, "how often does sales disagree with
+        # the model" would measure how many times a link was clicked. It is also the
+        # conflict target `PostgresFeedbackStore.record_feedback` upserts against, which is
+        # what makes that a single statement and therefore safe under a race. Added by #19
+        # with migration `20260903_feedback_one_verdict_per_rater`.
+        UniqueConstraint(
+            "tenant_id", "lead_id", "rater", name="uq_feedback_tenant_id_lead_id_rater"
+        ),
         # Join side of the feedback-loop analytics query.
         Index("ix_feedback_lead_id", "lead_id"),
         # ... and its filter side: WHERE tenant_id = ? AND verdict = 'bad'

--- a/src/leadquali/adapters/notify_ses.py
+++ b/src/leadquali/adapters/notify_ses.py
@@ -1,0 +1,428 @@
+"""SES delivery of the routing email, and the feedback links that ride on it.
+
+The :class:`~leadquali.app.ports.NotifierPort` implementation, and the only module in the
+system that imports ``boto3`` for email (``CLAUDE.md``'s layering rule). Everything about
+*what the email says* lives in :mod:`leadquali.app.lead_email`, which is pure and needs no
+credentials to test; everything here is about handing those bytes to Amazon and about what
+to do when Amazon says no.
+
+What this adapter is actually for
+---------------------------------
+
+Not "sending an email" — the routing email is the *carrier*. `docs/IMPLEMENTATION_PLAN.md`
+§7 and the decision record are blunt about it: there is no historical labelled data, so the
+golden set can only grow from the ``feedback`` table, and the only thing that writes to that
+table is a rep clicking a link in one of these messages. Every send therefore mints two
+signed, expiring, single-verdict links (:mod:`leadquali.app.feedback`) and puts them where a
+thumb lands. A send that goes out without them is a lead that arrives and teaches us
+nothing.
+
+Failure is the queue's problem, not ours
+----------------------------------------
+
+``app/qualify.py`` persists the lead and its assessment *before* dispatching, records a
+non-final ``FAILED`` routing event if the dispatch raises, and re-raises so SQS redelivers
+and, eventually, the DLQ alarms. That ordering is what makes raising safe, so every failure
+here raises — a throttle, a rejected identity, a network error, a malformed response. There
+is deliberately no swallow-and-return-``None`` path: returning normally tells the pipeline
+the lead reached a person, which would let it write a *final* routing event and make
+:meth:`~leadquali.app.ports.LeadStorePort.already_routed` true forever. One SES outage would
+then turn into permanently lost leads, which is invariant 3 broken by the very mechanism
+meant to protect it.
+
+Throttling gets its own exception type (:class:`SesThrottledError`) because it means something
+different operationally — the sending rate is above the account's quota and the right
+response is to slow the workers down (#26 owns the concurrency), not to page someone about a
+broken identity — and because #21's metrics need to tell the two apart.
+
+Boto is configured with standard-mode retries so a single 429 or 5xx is retried inside the
+call before it becomes an SQS redelivery: a redelivery costs a whole model call, and a retry
+costs a few hundred milliseconds.
+
+Invariant 5 in an adapter that handles addresses
+------------------------------------------------
+
+This module necessarily *holds* email addresses — that is what it is for — but it never logs
+one. Log lines carry the tenant, the lead id, the SES message id and
+:func:`~leadquali.app.feedback.rater_id`'s opaque hash of the destination, which is the same
+value the resulting ``feedback`` row is filed under, so an operator can follow one inbox
+through the logs and into the database without an address appearing in either. Exception
+messages are held to the same rule: a ``ClientError`` from botocore can quote the recipient,
+so the raised error is constructed from the error code and never from the SDK's message.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import timedelta
+from typing import Any, Final
+
+import boto3
+from botocore.config import Config
+from botocore.exceptions import BotoCoreError, ClientError
+
+from leadquali.adapters.clock_system import SystemClock
+from leadquali.app.feedback import (
+    DEFAULT_TOKEN_TTL_DAYS,
+    Verdict,
+    check_token_secret,
+    feedback_url,
+    load_token_secret,
+    mint_token,
+    rater_id,
+)
+from leadquali.app.lead_email import FeedbackLink, RenderedEmail, render_routing_email
+from leadquali.app.ports import ClockPort
+from leadquali.config import Settings, get_settings
+from leadquali.domain.models import LeadAssessment, RoutingDecision
+from leadquali.prompts.lead import LeadSubmission
+
+LOGGER = logging.getLogger(__name__)
+
+#: The SES API this adapter speaks. v2 is the current one: it is where configuration sets,
+#: per-message tags and the account-level suppression list live, and v1 is maintenance-only.
+#: Annotated bare ``Final`` rather than ``Final[str]`` so it keeps its literal type: boto3's
+#: stubs overload ``client()`` on the service name, and a widened ``str`` matches no overload.
+SES_SERVICE_NAME: Final = "sesv2"
+
+#: Charset for every part of the message. A lead writes in whatever language they like, and
+#: an email that mangles a name is an email a rep will not send from.
+CHARSET: Final[str] = "UTF-8"
+
+#: The verdicts a routing email offers. ``UNSURE`` is a real verdict in the schema but not a
+#: button: three choices on a phone is a decision, and the feature depends on it being a
+#: reflex. A rep with no opinion simply does not click.
+OFFERED_VERDICTS: Final[tuple[Verdict, ...]] = (Verdict.GOOD, Verdict.BAD)
+
+#: SES error codes that mean "you are going too fast", as opposed to "this message is
+#: wrong". Matched case-sensitively because that is how botocore reports them.
+THROTTLING_CODES: Final[frozenset[str]] = frozenset(
+    {
+        "Throttling",
+        "ThrottlingException",
+        "TooManyRequestsException",
+        "SendingPausedException",
+        "LimitExceededException",
+        "RequestThrottled",
+        "SlowDown",
+    }
+)
+
+#: Retries inside the SDK before the failure becomes an SQS redelivery. Standard mode
+#: retries throttles and transient 5xx with exponential backoff and jitter.
+_MAX_ATTEMPTS: Final[int] = 3
+_CONNECT_TIMEOUT_SECONDS: Final[int] = 5
+_READ_TIMEOUT_SECONDS: Final[int] = 10
+
+#: Tag values SES accepts are ``[A-Za-z0-9_-]`` only, and a rejected tag rejects the whole
+#: send — so anything that does not fit is replaced rather than passed through.
+_TAG_SAFE: Final[str] = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-"
+_MAX_TAG_CHARS: Final[int] = 256
+
+
+class SesDispatchError(RuntimeError):
+    """The routing email did not go out.
+
+    Raised for every failure, because the pipeline's contract is that a dispatch failure
+    re-raises so the queue redelivers. The message names the error code and never the
+    recipient (invariant 5).
+    """
+
+
+class SesThrottledError(SesDispatchError):
+    """SES refused because we are sending faster than the account's quota allows.
+
+    Its own type because the operational response is different: throttling is a capacity
+    signal for #26's worker concurrency, not a broken configuration. It is still an
+    exception, because a throttled send is a lead that has not reached anybody yet.
+    """
+
+
+@dataclass(frozen=True, slots=True)
+class SesIdentity:
+    """The sending identity and the SES configuration set, both from configuration.
+
+    Never literals: `docs/runbooks/ses-setup.md` (#20) owns the verified domain, the DKIM
+    records and the configuration set that routes bounce and complaint events, and those
+    differ per environment. A hardcoded sender is an email that fails to send in staging or,
+    worse, one that sends from production's domain.
+    """
+
+    sender: str
+    """``From``, either a bare address or ``Display Name <address>``."""
+
+    configuration_set: str | None = None
+    """The SES configuration set. ``None`` sends without one — legal, and it means bounce
+    and complaint events go nowhere, which #20's runbook exists to prevent."""
+
+    def __post_init__(self) -> None:
+        if not self.sender.strip():
+            raise ValueError("the SES sender identity must not be blank; see SES_SENDER")
+
+
+class SesNotifier:
+    """:class:`~leadquali.app.ports.NotifierPort` over Amazon SES v2.
+
+    The boto client is a constructor argument rather than something built on demand: it is
+    deployment-scoped and expensive to create (it resolves credentials and loads service
+    models), a Lambda container should build exactly one and reuse it across invocations,
+    and a test wants to hand in a ``moto``-backed one. :meth:`from_env` is the production
+    convenience that builds all of it from :class:`~leadquali.config.Settings`.
+    """
+
+    def __init__(
+        self,
+        *,
+        client: Any,
+        identity: SesIdentity,
+        feedback_base_url: str,
+        token_secret: bytes,
+        clock: ClockPort | None = None,
+        token_ttl_days: int = DEFAULT_TOKEN_TTL_DAYS,
+    ) -> None:
+        """Wire the notifier.
+
+        Args:
+            client: an SES v2 client, or anything with its ``send_email``.
+            identity: the sender and configuration set, from #20's runbook via config.
+            feedback_base_url: the public origin the feedback links point at. Configuration,
+                not a request header — see :func:`~leadquali.app.feedback.feedback_url`.
+            token_secret: the process feedback signing secret.
+            clock: time, injected. Defaults to the system clock.
+            token_ttl_days: how long a feedback link stays usable.
+
+        Raises:
+            ValueError: the base URL is not absolute, the secret is too short, or the TTL is
+                not positive. All three are wiring mistakes that would otherwise ship as
+                links nobody can use.
+        """
+        if token_ttl_days <= 0:
+            raise ValueError("token_ttl_days must be positive; a link that never works is not one")
+        # Fail here rather than on the first lead: both raise on bad input.
+        feedback_url(base_url=feedback_base_url, token="probe")  # noqa: S106 — a throwaway probe
+        check_token_secret(token_secret)
+
+        self._client = client
+        self._identity = identity
+        self._base_url = feedback_base_url
+        self._secret = token_secret
+        self._clock: ClockPort = clock if clock is not None else SystemClock()
+        self._ttl = timedelta(days=token_ttl_days)
+
+    @classmethod
+    def from_env(
+        cls, settings: Settings | None = None, *, clock: ClockPort | None = None
+    ) -> SesNotifier:
+        """Build the production notifier from the environment.
+
+        Raises:
+            RuntimeError: a required value — ``SES_SENDER``, ``FEEDBACK_BASE_URL`` or
+                ``FEEDBACK_TOKEN_SECRET`` — is not configured. Loud at wiring time: a worker
+                that starts without them would qualify leads and then fail to deliver every
+                one of them.
+        """
+        resolved = settings if settings is not None else get_settings()
+        return cls(
+            client=build_client(resolved),
+            identity=SesIdentity(
+                sender=resolved.require_ses_sender(),
+                configuration_set=resolved.ses_configuration_set,
+            ),
+            feedback_base_url=resolved.require_feedback_base_url(),
+            token_secret=load_token_secret(resolved.require_feedback_token_secret()),
+            clock=clock,
+            token_ttl_days=resolved.feedback_token_ttl_days,
+        )
+
+    # ------------------------------------------------------------------- the port
+
+    def dispatch(
+        self,
+        *,
+        tenant_id: str,
+        lead_id: str,
+        destination: str,
+        submission: LeadSubmission,
+        decision: RoutingDecision,
+        assessment: LeadAssessment | None,
+    ) -> str | None:
+        """Send one routed lead to one destination and return the SES message id.
+
+        ``assessment is None`` is the system-failure path and is **not** an error here: the
+        email still goes, carrying #9's "system could not assess" banner, because a lead
+        nobody can score is still a lead somebody must call.
+
+        Raises:
+            ValueError: ``destination`` is blank. Choosing where a lead goes is policy and
+                the caller resolved it; a blank one is a bug upstream, and sending to nobody
+                is not a recoverable state.
+            SesThrottledError: SES refused for rate. The pipeline records a non-final failure and
+                re-raises, and the queue redelivers.
+            SesDispatchError: any other delivery failure, for the same treatment.
+        """
+        if not destination.strip():
+            raise ValueError("destination must not be blank; the caller resolves it from policy")
+
+        rater = rater_id(destination)
+        email = render_routing_email(
+            submission=submission,
+            decision=decision,
+            assessment=assessment,
+            links=self._links(tenant_id=tenant_id, lead_id=lead_id, rater=rater),
+            lead_reference=lead_id,
+        )
+        message_id = self._send(
+            destination=destination,
+            email=email,
+            reply_to=submission.email,
+            tenant_id=tenant_id,
+            decision=decision,
+        )
+
+        # Identifiers and an opaque destination hash. Never the address (invariant 5).
+        LOGGER.info(
+            "routing email sent tenant=%s lead=%s rater=%s tier=%s assessed=%s message_id=%s",
+            tenant_id,
+            lead_id,
+            rater,
+            decision.tier.value,
+            assessment is not None,
+            message_id,
+        )
+        return message_id
+
+    # ---------------------------------------------------------------- the pieces
+
+    def _links(self, *, tenant_id: str, lead_id: str, rater: str) -> list[FeedbackLink]:
+        """Mint one single-purpose link per offered verdict.
+
+        Separate tokens rather than one token plus a verdict parameter: a verdict outside
+        the signature is a verdict anyone holding the link can change, and the link travels
+        through mail servers, spam filters and forwarded mailboxes.
+        """
+        expires_at = self._clock.now() + self._ttl
+        return [
+            FeedbackLink(
+                verdict=verdict,
+                url=feedback_url(
+                    base_url=self._base_url,
+                    token=mint_token(
+                        secret=self._secret,
+                        tenant_id=tenant_id,
+                        lead_id=lead_id,
+                        verdict=verdict,
+                        rater=rater,
+                        expires_at=expires_at,
+                    ),
+                ),
+            )
+            for verdict in OFFERED_VERDICTS
+        ]
+
+    def _send(
+        self,
+        *,
+        destination: str,
+        email: RenderedEmail,
+        reply_to: str | None,
+        tenant_id: str,
+        decision: RoutingDecision,
+    ) -> str | None:
+        """One ``SendEmail`` call, with every failure converted into a raise."""
+        request: dict[str, Any] = {
+            "FromEmailAddress": self._identity.sender,
+            "Destination": {"ToAddresses": [destination]},
+            "Content": {
+                "Simple": {
+                    "Subject": {"Data": email.subject, "Charset": CHARSET},
+                    "Body": {
+                        # Both parts, always: SES assembles the multipart/alternative, and a
+                        # message with no text part reads as spam to filters and as nothing
+                        # at all to a screen reader.
+                        "Text": {"Data": email.text_body, "Charset": CHARSET},
+                        "Html": {"Data": email.html_body, "Charset": CHARSET},
+                    },
+                }
+            },
+            "EmailTags": _tags(tenant_id=tenant_id, decision=decision),
+        }
+        # Reply-To is the lead, so a rep hits reply and reaches the human being who filled
+        # in the form. The address is in the body either way; this removes the copy-paste
+        # step that is the difference between a reply and a lead going cold.
+        if reply_to and reply_to.strip():
+            request["ReplyToAddresses"] = [reply_to.strip()]
+        if self._identity.configuration_set:
+            request["ConfigurationSetName"] = self._identity.configuration_set
+
+        try:
+            response = self._client.send_email(**request)
+        except ClientError as error:
+            code = str(error.response.get("Error", {}).get("Code", "Unknown"))
+            # The SDK's message can quote the recipient; only the code crosses this line.
+            if code in THROTTLING_CODES:
+                raise SesThrottledError(f"SES throttled the send (code {code})") from None
+            raise SesDispatchError(f"SES refused the send (code {code})") from None
+        except BotoCoreError as error:
+            raise SesDispatchError(
+                f"SES send failed before a response ({type(error).__name__})"
+            ) from None
+
+        message_id = response.get("MessageId") if isinstance(response, dict) else None
+        if not message_id:
+            # Every successful SendEmail returns one. Nothing without it is a success we can
+            # trace a bounce back to, and treating it as one would put a lie in
+            # routing_events.provider_message_id.
+            raise SesDispatchError("SES returned no MessageId; treating the send as failed")
+        return str(message_id)
+
+
+def build_client(settings: Settings | None = None) -> Any:
+    """Build the SES v2 client this adapter uses in production.
+
+    Region comes from configuration when set and from the ambient AWS chain otherwise, so a
+    Lambda picks up its own region without being told. Retries are standard mode so a single
+    throttle or 5xx costs a backoff rather than a redelivery and another model call.
+    """
+    resolved = settings if settings is not None else get_settings()
+    config = Config(
+        retries={"max_attempts": _MAX_ATTEMPTS, "mode": "standard"},
+        connect_timeout=_CONNECT_TIMEOUT_SECONDS,
+        read_timeout=_READ_TIMEOUT_SECONDS,
+    )
+    if resolved.aws_region:
+        return boto3.client(SES_SERVICE_NAME, region_name=resolved.aws_region, config=config)
+    return boto3.client(SES_SERVICE_NAME, config=config)
+
+
+def _tags(*, tenant_id: str, decision: RoutingDecision) -> list[dict[str, str]]:
+    """Per-message tags, which become dimensions on the configuration set's events.
+
+    This is what makes "which tenant's hot leads are bouncing" answerable in #21 without
+    joining anything. Values are sanitised because SES accepts only ``[A-Za-z0-9_-]`` in a
+    tag and rejects the entire send otherwise — a metric label must never be able to stop a
+    lead reaching sales.
+    """
+    return [
+        {"Name": "tenant", "Value": _tag_value(tenant_id)},
+        {"Name": "tier", "Value": _tag_value(decision.tier.value)},
+        {"Name": "escalated", "Value": "yes" if decision.escalated else "no"},
+    ]
+
+
+def _tag_value(value: str) -> str:
+    cleaned = "".join(character if character in _TAG_SAFE else "_" for character in value)
+    return cleaned[:_MAX_TAG_CHARS] or "unknown"
+
+
+__all__ = [
+    "CHARSET",
+    "OFFERED_VERDICTS",
+    "SES_SERVICE_NAME",
+    "THROTTLING_CODES",
+    "SesDispatchError",
+    "SesIdentity",
+    "SesNotifier",
+    "SesThrottledError",
+    "build_client",
+]

--- a/src/leadquali/adapters/store_postgres.py
+++ b/src/leadquali/adapters/store_postgres.py
@@ -91,6 +91,7 @@ from sqlalchemy import (
     Boolean,
     Engine,
     create_engine,
+    func,
     insert,
     literal_column,
     null,
@@ -99,12 +100,14 @@ from sqlalchemy import (
     update,
 )
 from sqlalchemy.dialects.postgresql import insert as pg_insert
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session, sessionmaker
 
-from leadquali.adapters.db_schema import Assessment, Lead, RoutingEvent, Tenant
+from leadquali.adapters.db_schema import Assessment, Feedback, Lead, RoutingEvent, Tenant
 from leadquali.adapters.seed import tenant_id_for
 from leadquali.app.assessment_result import AssessmentOutcome, CallMetering
-from leadquali.app.ports import RoutingOutcome, StoredLead
+from leadquali.app.feedback import UnknownLeadError, Verdict
+from leadquali.app.ports import RecordedFeedback, RoutingOutcome, StoredLead
 from leadquali.config import Settings, get_settings
 from leadquali.domain.models import Action, RoutingDecision
 from leadquali.domain.tenant_config import (
@@ -116,9 +119,11 @@ from leadquali.domain.tenant_config import (
 from leadquali.prompts.lead import LeadSubmission
 
 __all__ = [
+    "FEEDBACK_IDEMPOTENCY_CONSTRAINT",
     "LEAD_IDEMPOTENCY_CONSTRAINT",
     "UNKNOWN_MODEL_ID",
     "UNKNOWN_PROMPT_VERSION",
+    "PostgresFeedbackStore",
     "PostgresLeadStore",
     "PostgresTenantConfigSource",
     "assessment_values",
@@ -134,6 +139,14 @@ LOGGER = logging.getLogger(__name__)
 #: The unique constraint ``upsert_lead`` resolves its conflict against. Named rather than
 #: inferred from columns so that a rename in #15's schema breaks loudly here.
 LEAD_IDEMPOTENCY_CONSTRAINT: Final[str] = "uq_leads_tenant_id_submission_id"
+
+#: The unique constraint ``record_feedback`` resolves its conflict against: one verdict per
+#: rater per lead, which is what makes a second click an update rather than a second row.
+FEEDBACK_IDEMPOTENCY_CONSTRAINT: Final[str] = "uq_feedback_tenant_id_lead_id_rater"
+
+#: SQLSTATE for ``foreign_key_violation``. The composite ``(tenant_id, lead_id)`` key is the
+#: only one this module can trip, so it means "no such lead for this tenant" and nothing else.
+_FOREIGN_KEY_VIOLATION: Final[str] = "23503"
 
 #: Recorded as the model provenance of an attempt that never reached the model — a
 #: connection error or a timeout has no ``model_id`` to report, and the columns are NOT
@@ -612,6 +625,130 @@ class PostgresLeadStore:
         session.execute(
             update(Lead).where(Lead.tenant_id == tenant, Lead.id == lead).values(status=status)
         )
+
+
+class PostgresFeedbackStore:
+    """:class:`~leadquali.app.ports.FeedbackStorePort` over the ``feedback`` table.
+
+    A separate class from :class:`PostgresLeadStore` because the callers are separate — the
+    pipeline writes leads from a worker, a rep's browser writes feedback through the API —
+    and an endpoint handed a feedback writer cannot reach the lead lifecycle by accident.
+    They share the session factory, so a process doing both still opens one pool.
+
+    Conventions are #16's, unchanged: ``tenant_id`` on the method and in the statement
+    (invariant 4, including in the ``ON CONFLICT ... WHERE`` clause where the unique index
+    already implies it), one short transaction per call, failures raised rather than
+    swallowed.
+
+    **Idempotency is the database's job here too.** One ``INSERT ... ON CONFLICT DO UPDATE``
+    against ``uq_feedback_tenant_id_lead_id_rater``: a mail scanner's prefetch, a rep's
+    double tap and a change of mind three days later all resolve to the same row. A
+    ``SELECT`` followed by an ``INSERT`` would duplicate under exactly the concurrency this
+    endpoint sees — a phone retrying a POST on a flaky connection.
+    """
+
+    def __init__(self, sessions: sessionmaker[Session]) -> None:
+        """Take the session factory to use. See :func:`session_factory`."""
+        self._sessions = sessions
+
+    @classmethod
+    def from_url(cls, url: str) -> PostgresFeedbackStore:
+        """A feedback store over the memoised engine for ``url``."""
+        return cls(session_factory(url))
+
+    @classmethod
+    def from_env(cls, settings: Settings | None = None) -> PostgresFeedbackStore:
+        """A feedback store over the configured ``DATABASE_URL``."""
+        return cls(session_factory_from_env(settings))
+
+    def record_feedback(
+        self,
+        *,
+        tenant_id: str,
+        lead_id: str,
+        rater: str,
+        verdict: Verdict,
+        notes: str | None,
+        recorded_at: datetime,
+    ) -> RecordedFeedback:
+        """Record this rater's verdict on this lead, replacing any verdict they gave before.
+
+        The prior verdict is read in the same transaction before the upsert, because the
+        page the rep lands on says "changed from good lead to bad lead" and ``RETURNING``
+        after ``DO UPDATE`` yields the *new* row, not the one that was there. Under a
+        genuine race the reader may see the other writer's value — which changes one
+        sentence of wording and never the row, since the write is still one atomic
+        statement.
+
+        ``created_at`` moves forward on an update: the row *is* the current verdict, and
+        leaving it stamped with a verdict that has since been replaced would misdate the
+        training data. #15's table has no ``updated_at``, so the first-recorded time is not
+        kept; that is flagged in the report rather than smuggled into ``notes``.
+
+        Raises:
+            UnknownLeadError: this tenant has no such lead. Read off the composite foreign
+                key rather than from a prior existence check, so there is no window between
+                the check and the write — and so a link that outlived #37's retention job
+                produces a page that says so instead of a 500.
+        """
+        tenant = tenant_uuid(tenant_id)
+        lead = lead_uuid(lead_id)
+        if not rater:
+            raise ValueError("rater must not be blank; feedback with no subject is unattributable")
+
+        previous = select(Feedback.verdict).where(
+            Feedback.tenant_id == tenant,
+            Feedback.lead_id == lead,
+            Feedback.rater == rater,
+        )
+        insertion = pg_insert(Feedback).values(
+            tenant_id=tenant,
+            lead_id=lead,
+            rater=rater,
+            verdict=verdict.value,
+            notes=notes,
+            created_at=recorded_at,
+        )
+        statement = insertion.on_conflict_do_update(
+            constraint=FEEDBACK_IDEMPOTENCY_CONSTRAINT,
+            set_={
+                "verdict": insertion.excluded.verdict,
+                "created_at": insertion.excluded.created_at,
+                # A click carrying no note must not erase the sentence the rep typed last
+                # time: the new value wins only when there is one.
+                "notes": func.coalesce(insertion.excluded.notes, Feedback.notes),
+            },
+            # Redundant against the conflict target and kept anyway: invariant 4 has no
+            # exceptions for the statements that are provably safe.
+            where=Feedback.tenant_id == tenant,
+        ).returning(literal_column("(xmax = 0)", Boolean))
+
+        try:
+            with self._sessions.begin() as session:
+                existing = session.execute(previous).scalar_one_or_none()
+                inserted = bool(session.execute(statement).scalar_one())
+        except IntegrityError as error:
+            if _is_foreign_key_violation(error):
+                raise UnknownLeadError(
+                    f"tenant '{tenant_id}' has no lead {lead_id}; a link can outlive its row"
+                ) from None
+            raise
+
+        return RecordedFeedback(
+            verdict=verdict,
+            created=inserted,
+            previous_verdict=Verdict(existing) if existing is not None else None,
+        )
+
+
+def _is_foreign_key_violation(error: IntegrityError) -> bool:
+    """Whether this integrity error is the composite lead foreign key rejecting the row.
+
+    Matched on SQLSTATE rather than on the message, which is localised and version-specific.
+    Anything else — a broken CHECK, a duplicate that somehow escaped the upsert — is a bug
+    here, and is re-raised rather than reported to a rep as "that lead is gone".
+    """
+    return getattr(error.orig, "sqlstate", None) == _FOREIGN_KEY_VIOLATION
 
 
 class PostgresTenantConfigSource:

--- a/src/leadquali/api/feedback.py
+++ b/src/leadquali/api/feedback.py
@@ -1,0 +1,515 @@
+"""The feedback endpoint: where a click in a sales rep's inbox becomes training data.
+
+This is the other half of :mod:`leadquali.adapters.notify_ses`, and between them they are
+the only mechanism by which this product ever learns anything. The decision record is
+explicit that there is no historical labelled data, so the golden set (#22) can only grow
+from the ``feedback`` table, and #23's eval harness measures nothing until it does. Every
+decision in this file is therefore made in favour of *the click actually happening and
+actually meaning something*.
+
+Why a GET does not write
+------------------------
+
+The obvious design — one link, ``GET`` it, row written — is broken by the environment it
+ships into. Outlook Safe Links, Proofpoint, Mimecast, Gmail's image and link prefetchers and
+half the corporate mail gateways in existence **fetch every URL in a message before a human
+sees it**, some of them from a data centre on another continent, some of them twice. A
+mutating GET means every routed lead silently acquires a verdict nobody gave, and the golden
+set fills with noise that looks exactly like signal. That is worse than having no feedback
+at all: an eval harness calibrated on scanner clicks would confidently point the rubric in a
+random direction.
+
+So the endpoint is split along the lines HTTP already draws:
+
+* ``GET /feedback/{token}`` is **safe**. It verifies the token and renders a page with one
+  large button and an optional notes box. It writes nothing, so a scanner that fetches it
+  ten times changes nothing.
+* ``POST /feedback/{token}`` writes. The form carries a ``confirm`` field whose value is
+  derived from the token with the same secret (:func:`confirmation_code`), so the write
+  requires having *rendered the page*, not merely having seen the URL. A scanner that
+  blindly POSTs the URL with no body — rare, but they exist — gets the confirmation page
+  back instead of a write.
+
+The cost is one extra tap. The alternative considered was an idempotent write on GET plus a
+visible undo, which keeps the single tap; it was rejected because the undo only helps a
+*human* who is looking at the page, and the population being defended against is machines
+that never render it. A tap that a rep expects (the page says "one more tap") is a far
+cheaper price than a dataset we cannot trust. The confirmation page also has somewhere
+honest to put the notes box, which #19 asks for and which a bare redirect has no room for.
+
+Everything else the rep sees
+----------------------------
+
+The response is always a page, never JSON: this URL is opened by a human in a mobile
+browser, and a bare ``{"ok": true}`` is a feature that looks broken. A repeat click updates
+rather than duplicates (the store's job), and the thank-you page offers the opposite verdict
+as a one-tap change of mind — minted here, server-side, bound to the same lead, rater and
+expiry as the token that got them here, so changing your mind cannot become a way to write
+feedback about anything else.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import html
+import logging
+import urllib.parse
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Final
+
+from fastapi import FastAPI, Request, Response
+
+from leadquali.adapters.clock_system import SystemClock
+from leadquali.adapters.store_postgres import PostgresFeedbackStore
+from leadquali.app.feedback import (
+    FEEDBACK_PATH_PREFIX,
+    MAX_NOTES_CHARS,
+    FeedbackClaim,
+    TokenFailure,
+    TokenRejected,
+    UnknownLeadError,
+    Verdict,
+    check_token_secret,
+    load_token_secret,
+    mint_token,
+    verify_token,
+)
+from leadquali.app.ports import ClockPort, FeedbackStorePort, RecordedFeedback
+from leadquali.config import Settings, get_settings
+
+LOGGER = logging.getLogger(__name__)
+
+#: The route, built from the prefix the link minter uses, so the two cannot drift apart.
+FEEDBACK_ROUTE: Final[str] = f"{FEEDBACK_PATH_PREFIX}{{token}}"
+
+#: The form field that proves the page was rendered before the verdict was posted.
+CONFIRM_FIELD: Final[str] = "confirm"
+NOTES_FIELD: Final[str] = "notes"
+
+#: Longest form body accepted. A verdict plus a sentence; anything larger is not a rep.
+MAX_FORM_BYTES: Final[int] = 8 * 1024
+
+#: Never cached, never indexed. These URLs are single-purpose capabilities, and a copy in a
+#: corporate proxy or a search index is a copy nobody controls.
+_PAGE_HEADERS: Final[dict[str, str]] = {
+    "Cache-Control": "no-store, no-cache, must-revalidate, private",
+    "Referrer-Policy": "no-referrer",
+    "X-Robots-Tag": "noindex, nofollow",
+    "X-Content-Type-Options": "nosniff",
+}
+
+_GOOD_COLOUR: Final[str] = "#067647"
+_BAD_COLOUR: Final[str] = "#b42318"
+
+
+@dataclass(frozen=True, slots=True)
+class FeedbackDeps:
+    """Everything the feedback routes need, injected rather than imported.
+
+    Deliberately not :class:`~leadquali.api.main.IngestDeps`: the two endpoints share an
+    ASGI app and nothing else. Ingest must not be able to reach a feedback writer, and the
+    feedback endpoint has no business holding ingest credentials or the lead queue.
+    """
+
+    store: FeedbackStorePort
+    token_secret: bytes
+    clock: ClockPort
+
+    def __post_init__(self) -> None:
+        check_token_secret(self.token_secret)
+
+
+def build_feedback_deps(settings: Settings | None = None) -> FeedbackDeps:
+    """Wire the production feedback dependencies: Postgres, the real clock, the real secret.
+
+    Raises:
+        RuntimeError: ``DATABASE_URL`` or ``FEEDBACK_TOKEN_SECRET`` is not configured.
+        ValueError: the secret is configured but too short to be one.
+    """
+    resolved = settings if settings is not None else get_settings()
+    return FeedbackDeps(
+        store=PostgresFeedbackStore.from_env(resolved),
+        token_secret=load_token_secret(resolved.require_feedback_token_secret()),
+        clock=SystemClock(),
+    )
+
+
+@lru_cache(maxsize=1)
+def _default_feedback_deps() -> FeedbackDeps:
+    """The production wiring, built on first request rather than at import.
+
+    Same reasoning as :func:`leadquali.api.main._default_deps`: importing the module at a
+    Lambda cold start must not open a database connection or demand a secret.
+    """
+    return build_feedback_deps()
+
+
+def register_feedback_routes(app: FastAPI, deps: FeedbackDeps | None = None) -> None:
+    """Add ``GET`` and ``POST /feedback/{token}`` to an existing application.
+
+    Called by :func:`leadquali.api.main.create_app`, so there is one app and one deployment
+    rather than a second service to route to. ``deps`` of ``None`` resolves the production
+    wiring lazily on the first request.
+    """
+    provide: Callable[[], FeedbackDeps] = (
+        (lambda: deps) if deps is not None else _default_feedback_deps
+    )
+
+    @app.get(
+        FEEDBACK_ROUTE,
+        response_class=Response,
+        summary="Show the confirmation page for a feedback link. Writes nothing.",
+        responses={
+            200: {"description": "The confirmation page, or an explanation of a bad link."},
+            400: {"description": "The link is not one of ours."},
+            410: {"description": "The link has expired."},
+        },
+    )
+    async def show_feedback(token: str) -> Response:
+        """Render the confirmation page. Deliberately safe: see the module docstring."""
+        return _show(token, provide())
+
+    @app.post(
+        FEEDBACK_ROUTE,
+        response_class=Response,
+        summary="Record the verdict this link carries.",
+        responses={
+            200: {"description": "Recorded, updated, or asked to confirm."},
+            400: {"description": "The link is not one of ours."},
+            404: {"description": "The lead this link names no longer exists."},
+            410: {"description": "The link has expired."},
+            503: {"description": "The verdict could not be stored; try again."},
+        },
+    )
+    async def record_feedback(token: str, request: Request) -> Response:
+        """Verify, confirm, write, and say thank you."""
+        form = _parse_form(await _read_bounded(request))
+        return _record(token, form, provide())
+
+
+# ------------------------------------------------------------------------- the handlers
+
+
+def _show(token: str, deps: FeedbackDeps) -> Response:
+    result = verify_token(secret=deps.token_secret, token=token, now=deps.clock.now())
+    if isinstance(result, TokenRejected):
+        return _rejection_page(result)
+    return _page(
+        title="Confirm your feedback",
+        status=200,
+        body=_confirm_form(claim=result.claim, token=token, deps=deps, notes=""),
+    )
+
+
+def _record(token: str, form: Mapping[str, str], deps: FeedbackDeps) -> Response:
+    result = verify_token(secret=deps.token_secret, token=token, now=deps.clock.now())
+    if isinstance(result, TokenRejected):
+        return _rejection_page(result)
+
+    claim = result.claim
+    notes = _clean_notes(form.get(NOTES_FIELD, ""))
+    if not _confirmation_matches(form.get(CONFIRM_FIELD, ""), token=token, deps=deps):
+        # Not an error page: an unconfirmed POST is almost always a machine, and the one
+        # human who could reach this (a resubmitted form after a rotation) deserves the
+        # button rather than a scolding.
+        LOGGER.info(
+            "feedback post without a valid confirmation tenant=%s lead=%s",
+            claim.tenant_id,
+            claim.lead_id,
+        )
+        return _page(
+            title="Confirm your feedback",
+            status=200,
+            body=_confirm_form(claim=claim, token=token, deps=deps, notes=notes),
+        )
+
+    now = deps.clock.now()
+    try:
+        recorded = deps.store.record_feedback(
+            tenant_id=claim.tenant_id,
+            lead_id=claim.lead_id,
+            rater=claim.rater,
+            verdict=claim.verdict,
+            notes=notes or None,
+            recorded_at=now,
+        )
+    except UnknownLeadError:
+        LOGGER.warning(
+            "feedback for a lead that no longer exists tenant=%s lead=%s",
+            claim.tenant_id,
+            claim.lead_id,
+        )
+        return _page(
+            title="That lead is gone",
+            status=404,
+            body=_message_block(
+                heading="We could not find that lead",
+                detail=(
+                    "The lead this link points at is no longer in the system — it may have "
+                    "been deleted under the data retention policy. Nothing was recorded."
+                ),
+            ),
+        )
+    except Exception:
+        # The rep must never be told "thank you" for a verdict that was not stored: this is
+        # the one signal the product learns from, and a silent loss is unrecoverable.
+        LOGGER.exception("feedback write failed tenant=%s lead=%s", claim.tenant_id, claim.lead_id)
+        return _page(
+            title="We could not save that",
+            status=503,
+            body=_message_block(
+                heading="Something went wrong on our side",
+                detail="Your verdict was not saved. Please tap the link again in a minute.",
+            ),
+        )
+
+    # Identifiers and an opaque rater id only. Never the notes — a rep writes about a
+    # person, in free text — and never an address (invariant 5).
+    LOGGER.info(
+        "feedback recorded tenant=%s lead=%s rater=%s verdict=%s created=%s changed=%s notes=%s",
+        claim.tenant_id,
+        claim.lead_id,
+        claim.rater,
+        recorded.verdict.value,
+        recorded.created,
+        recorded.changed,
+        "yes" if notes else "no",
+    )
+    return _page(
+        title="Thank you",
+        status=200,
+        body=_thank_you(claim=claim, recorded=recorded, deps=deps, notes=notes),
+    )
+
+
+# -------------------------------------------------------------------- the confirmation
+
+
+def confirmation_code(*, secret: bytes, token: str) -> str:
+    """A short value derived from the token, proving the confirmation page was rendered.
+
+    Not a CSRF defence in the session sense — there is no session and nothing to steal —
+    but the thing that keeps a *blind* POST from writing. Deriving it from the token with
+    the same secret means the server stores nothing, the code cannot be guessed, and it is
+    valid for exactly as long as the token it belongs to.
+    """
+    digest = hmac.new(secret, f"confirm|{token}".encode(), hashlib.sha256).hexdigest()
+    return digest[:32]
+
+
+def _confirmation_matches(presented: str, *, token: str, deps: FeedbackDeps) -> bool:
+    return hmac.compare_digest(presented, confirmation_code(secret=deps.token_secret, token=token))
+
+
+# --------------------------------------------------------------------------- the pages
+
+
+def _confirm_form(*, claim: FeedbackClaim, token: str, deps: FeedbackDeps, notes: str) -> str:
+    colour = _GOOD_COLOUR if claim.verdict is Verdict.GOOD else _BAD_COLOUR
+    code = confirmation_code(secret=deps.token_secret, token=token)
+    return (
+        f'<p class="lede">Marking this lead as a '
+        f'<strong style="color:{colour}">{html.escape(claim.verdict.label)}</strong>.</p>'
+        f'<form method="post" action="{html.escape(_path_for(token), quote=True)}">'
+        f'<input type="hidden" name="{CONFIRM_FIELD}" value="{html.escape(code, quote=True)}" />'
+        f'<label for="{NOTES_FIELD}">Anything worth adding? (optional)</label>'
+        f'<textarea id="{NOTES_FIELD}" name="{NOTES_FIELD}" rows="3" '
+        f'maxlength="{MAX_NOTES_CHARS}" placeholder="e.g. wrong industry, but a good fit '
+        f'for the other product">{html.escape(notes)}</textarea>'
+        f'<button type="submit" style="background:{colour}">'
+        f"Confirm: {html.escape(claim.verdict.label)}</button>"
+        "</form>"
+        '<p class="note">One more tap, and only because mail scanners follow links before '
+        "you do — this keeps their clicks out of the data.</p>"
+    )
+
+
+def _thank_you(
+    *, claim: FeedbackClaim, recorded: RecordedFeedback, deps: FeedbackDeps, notes: str
+) -> str:
+    colour = _GOOD_COLOUR if recorded.verdict is Verdict.GOOD else _BAD_COLOUR
+    verdict = f'<strong style="color:{colour}">{html.escape(recorded.verdict.label)}</strong>'
+    if recorded.changed and recorded.previous_verdict is not None:
+        headline = f"Changed from {html.escape(recorded.previous_verdict.label)} to {verdict}."
+    elif recorded.created:
+        headline = f"Recorded as a {verdict}."
+    else:
+        headline = f"Still recorded as a {verdict}."
+
+    blocks = [
+        f'<p class="lede">{headline}</p>',
+        '<p class="note">This is what tunes the scoring — thank you. You can close this tab.</p>',
+    ]
+    if notes:
+        blocks.append('<p class="note">Your note was saved.</p>')
+
+    opposite = claim.verdict.opposite
+    if opposite is not claim.verdict:
+        # Minted here, with the same lead, rater and expiry: a change of mind must not be a
+        # way to write feedback about anything else, or to extend the capability's life.
+        other_token = mint_token(
+            secret=deps.token_secret,
+            tenant_id=claim.tenant_id,
+            lead_id=claim.lead_id,
+            verdict=opposite,
+            rater=claim.rater,
+            expires_at=claim.expires_at,
+        )
+        other_code = confirmation_code(secret=deps.token_secret, token=other_token)
+        blocks.append(
+            f'<form method="post" action="{html.escape(_path_for(other_token), quote=True)}" '
+            'class="secondary">'
+            f'<input type="hidden" name="{CONFIRM_FIELD}" '
+            f'value="{html.escape(other_code, quote=True)}" />'
+            f'<button type="submit" class="link">Actually, this was a '
+            f"{html.escape(opposite.label)}</button></form>"
+        )
+    return "".join(blocks)
+
+
+def _rejection_page(rejected: TokenRejected) -> Response:
+    """One page per refusal reason, and never a hint about what a good link looks like."""
+    if rejected.failure is TokenFailure.EXPIRED:
+        return _page(
+            title="This link has expired",
+            status=410,
+            body=_message_block(
+                heading="This link has expired",
+                detail=(
+                    "Feedback links stop working after a while so that an old email cannot "
+                    "keep changing the record. Nothing was recorded."
+                ),
+            ),
+        )
+    return _page(
+        title="This link is not valid",
+        status=400,
+        body=_message_block(
+            heading="This link is not valid",
+            detail=(
+                "It may have been altered or truncated by a mail client. Open the original "
+                "link from the routing email. Nothing was recorded."
+            ),
+        ),
+    )
+
+
+def _message_block(*, heading: str, detail: str) -> str:
+    return f'<p class="lede">{html.escape(heading)}</p><p class="note">{html.escape(detail)}</p>'
+
+
+def _page(*, title: str, status: int, body: str) -> Response:
+    """One small self-contained page. No external assets, no scripts, no tracking.
+
+    A rep opens this on a phone, on a train, on a corporate network that may block
+    everything but the origin they were sent to, so the whole page is one document with its
+    styles inline. There is no JavaScript at all: nothing here needs it, and a page that
+    writes to a database is a page that should work with scripting disabled.
+    """
+    document = (
+        "<!DOCTYPE html><html lang='en'><head><meta charset='utf-8' />"
+        "<meta name='viewport' content='width=device-width, initial-scale=1' />"
+        "<meta name='robots' content='noindex, nofollow' />"
+        f"<title>{html.escape(title)} · LeadQuali</title>"
+        "<style>"
+        ":root{color-scheme:light dark}"
+        "*{box-sizing:border-box}"
+        "body{margin:0;min-height:100vh;display:flex;align-items:center;"
+        "justify-content:center;padding:24px;background:#f2f4f7;color:#101828;"
+        "font:16px/1.5 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,"
+        "Arial,sans-serif}"
+        "main{background:#fff;border:1px solid #e4e7ec;border-radius:12px;padding:28px;"
+        "max-width:32rem;width:100%}"
+        "h1{font-size:15px;letter-spacing:.08em;text-transform:uppercase;color:#475467;"
+        "margin:0 0 16px}"
+        ".lede{font-size:20px;margin:0 0 12px}"
+        ".note{color:#475467;font-size:14px;margin:12px 0 0}"
+        "label{display:block;font-size:14px;color:#475467;margin:20px 0 6px}"
+        "textarea{width:100%;padding:10px;font:inherit;border:1px solid #d0d5dd;"
+        "border-radius:8px;resize:vertical;background:#fff;color:#101828}"
+        "button{margin-top:18px;width:100%;padding:16px;font:inherit;font-weight:700;"
+        "color:#fff;border:0;border-radius:8px;cursor:pointer}"
+        "form.secondary{margin-top:20px;border-top:1px solid #e4e7ec;padding-top:8px}"
+        "button.link{background:none;color:#475467;font-weight:500;text-decoration:underline;"
+        "padding:8px;margin-top:8px}"
+        "@media (prefers-color-scheme:dark){body{background:#101828;color:#f9fafb}"
+        "main{background:#1d2939;border-color:#344054}h1,.note,label{color:#98a2b3}"
+        "textarea{background:#101828;color:#f9fafb;border-color:#475467}"
+        "button.link{color:#98a2b3}}"
+        "</style></head><body><main><h1>LeadQuali feedback</h1>"
+        f"{body}</main></body></html>"
+    )
+    return Response(
+        content=document,
+        status_code=status,
+        media_type="text/html; charset=utf-8",
+        headers=dict(_PAGE_HEADERS),
+    )
+
+
+def _path_for(token: str) -> str:
+    """The form's action: a relative path, so it works behind any host or stage prefix."""
+    return f"{FEEDBACK_PATH_PREFIX}{urllib.parse.quote(token, safe='')}"
+
+
+# ------------------------------------------------------------------------ the form body
+
+
+async def _read_bounded(request: Request) -> bytes:
+    """Read the form body, refusing anything past :data:`MAX_FORM_BYTES`.
+
+    Counted across the stream rather than trusted from ``Content-Length``: this endpoint is
+    as public as the ingest one, and a declared length is a claim by the sender.
+    """
+    chunks: list[bytes] = []
+    size = 0
+    async for chunk in request.stream():
+        size += len(chunk)
+        if size > MAX_FORM_BYTES:
+            return b""
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _parse_form(body: bytes) -> dict[str, str]:
+    """Parse ``application/x-www-form-urlencoded`` without a multipart dependency.
+
+    The form has two short fields and is submitted by a page this module rendered, so the
+    stdlib parser is the whole requirement — pulling in ``python-multipart`` to read two
+    strings would add an attack surface to the only unauthenticated write in the system.
+    """
+    try:
+        decoded = body.decode("utf-8")
+    except UnicodeDecodeError:
+        return {}
+    return {
+        key: values[0]
+        for key, values in urllib.parse.parse_qs(decoded, keep_blank_values=True).items()
+    }
+
+
+def _clean_notes(raw: str) -> str:
+    """Bound and de-fang the rep's free text.
+
+    Truncated rather than refused — losing a sentence a rep took the trouble to type is
+    worse than storing 2 kB — and stripped of control characters, which a browser will not
+    send but a hand-rolled POST will.
+    """
+    text = "".join(character for character in raw if character >= " " or character in "\n\t")
+    text = text.strip()
+    return text[:MAX_NOTES_CHARS]
+
+
+__all__ = [
+    "CONFIRM_FIELD",
+    "FEEDBACK_ROUTE",
+    "MAX_FORM_BYTES",
+    "NOTES_FIELD",
+    "FeedbackDeps",
+    "build_feedback_deps",
+    "confirmation_code",
+    "register_feedback_routes",
+]

--- a/src/leadquali/api/main.py
+++ b/src/leadquali/api/main.py
@@ -1,7 +1,7 @@
 """The public ingest edge: ``POST /leads`` and ``GET /health``.
 
-Everything a stranger can reach is in this file, and it is written for that. The order of
-operations is the order of cost, cheapest and most sceptical first:
+The ingest route is written for a stranger, and the order of operations is the order of
+cost, cheapest and most sceptical first:
 
 1. **Size.** ``Content-Length`` is checked before a byte is read, and the stream is counted
    as it arrives so a request that lies about its length — or declares nothing at all — is
@@ -30,6 +30,12 @@ form post that waits on one produces browser timeouts, duplicate submissions and
 lost every time the model is slow. The app is constructed without a
 :class:`~leadquali.app.ports.LeadAssessorPort` at all, so the fast path cannot regress into
 a slow one by accident; ``tests/unit/test_api_ingest.py`` asserts that structurally.
+
+The other public surface, ``/feedback/{token}``, is registered here by
+:func:`~leadquali.api.feedback.register_feedback_routes` and implemented in
+:mod:`leadquali.api.feedback`. It shares this app because it is one deployment, and it
+shares nothing else: its dependencies are a separate object, so the ingest handler cannot
+reach a feedback writer and the feedback handler holds no ingest credentials.
 """
 
 from __future__ import annotations
@@ -47,6 +53,7 @@ from pydantic import ValidationError
 from leadquali.adapters.clock_system import SystemClock
 from leadquali.adapters.queue_inprocess import InProcessLeadQueue
 from leadquali.adapters.store_postgres import PostgresLeadStore, contact_email_hash
+from leadquali.api.feedback import FeedbackDeps, register_feedback_routes
 from leadquali.api.ratelimit import NoRateLimit, RateLimiterPort
 from leadquali.api.schemas import (
     MAX_BODY_BYTES,
@@ -150,12 +157,24 @@ def _default_deps() -> IngestDeps:
     return build_deps()
 
 
-def create_app(deps: IngestDeps | None = None) -> FastAPI:
+def create_app(
+    deps: IngestDeps | None = None, feedback_deps: FeedbackDeps | None = None
+) -> FastAPI:
     """Build the ASGI application.
 
+    Two public surfaces share it and share nothing else: ``POST /leads``, which a customer's
+    website calls with a signed request, and ``GET``/``POST /feedback/{token}``, which a
+    sales rep opens from an email. One app because it is one deployment — the feedback link
+    has to resolve on a host the rep can reach, and standing up a second service for two
+    routes would mean a second domain, a second certificate and a second thing to page
+    someone about. Their dependencies stay separate objects (see
+    :class:`~leadquali.api.feedback.FeedbackDeps`) so that neither endpoint can reach the
+    other's collaborators.
+
     Args:
-        deps: the wiring to use. ``None`` — the default, and what uvicorn and Mangum get —
+        deps: the ingest wiring. ``None`` — the default, and what uvicorn and Mangum get —
             resolves the production dependencies lazily on the first request.
+        feedback_deps: the feedback wiring, resolved the same way.
 
     Returns:
         A deployment-agnostic ASGI app. It is served by uvicorn locally (``run_local.py``)
@@ -164,12 +183,16 @@ def create_app(deps: IngestDeps | None = None) -> FastAPI:
     provide: Callable[[], IngestDeps] = (lambda: deps) if deps is not None else _default_deps
 
     app = FastAPI(
-        title="LeadQuali ingest",
+        title="LeadQuali",
         version="1",
-        summary="Accepts inbound web-form leads and answers before the model is ever called.",
+        summary=(
+            "Accepts inbound web-form leads before the model is ever called, and records "
+            "the one-click verdicts that grow the golden set."
+        ),
         docs_url="/docs",
         redoc_url=None,
     )
+    register_feedback_routes(app, feedback_deps)
 
     @app.get(
         HEALTH_PATH,

--- a/src/leadquali/app/feedback.py
+++ b/src/leadquali/app/feedback.py
@@ -1,0 +1,466 @@
+"""The feedback capability: what a verdict is, and the token that authorises one.
+
+This module is the reason the product can ever be evaluated. `docs/IMPLEMENTATION_PLAN.md`
+§7 says the golden set grows from the ``feedback`` table, and the only thing that writes to
+that table is a sales rep clicking a link in a routing email. So the link has to work from
+a phone, in a mail client, with no login — and it has to be impossible to forge, because a
+public URL that writes to the training set is a public URL that poisons it.
+
+Why the token is a *bearer capability* and not a session
+--------------------------------------------------------
+
+There is no login and there will not be one: a rep who has to authenticate does not click,
+and a feedback loop nobody uses is worth exactly nothing. What the URL carries instead is
+one capability — "record verdict V for lead L, on behalf of rater R, until time T" — signed
+with a key only this deployment holds. Everything that could be tampered with is inside the
+signed material, so there is nothing an attacker can vary:
+
+* **The lead id is signed.** It is never a bare path parameter, so a leaked link cannot be
+  edited into a verdict on somebody else's lead — which, since ``lead_id`` is a UUID that
+  appears in no other public surface, would otherwise be the one way to write arbitrary
+  feedback.
+* **The verdict is signed.** One token means one verdict. A "good lead" link cannot be
+  turned into a "bad lead" one, so a leaked link cannot flip the label it was minted for.
+* **The tenant is signed, and keys are derived per tenant** (:func:`tenant_key`). A token
+  minted for tenant A does not verify under tenant B even if the process secret leaks into
+  one tenant's logs.
+* **An expiry is signed.** A link found in a forwarded mailbox two years later is inert.
+
+Why this is a second HMAC scheme and not :mod:`leadquali.api.signing`
+---------------------------------------------------------------------
+
+The construction is deliberately the same shape as ``api.signing.signing_string`` — a
+newline-separated canonical string, an algorithm label and a version as its first two
+lines, HMAC-SHA256, :func:`hmac.compare_digest` — so there is one thing to learn and one
+thing to review. It is a separate module for two reasons that are not stylistic:
+
+* **Layering.** ``adapters/notify_ses.py`` mints these tokens and ``api/main.py`` verifies
+  them. ``app`` is the only layer both may import (``domain ← app ← adapters/api``); an
+  adapter importing the API package would invert that for the sake of a hash function.
+* **Different threat, different key.** ``api.signing`` authenticates a *request* from a
+  customer's website using a secret that customer holds. This authorises a *link* handed to
+  that customer's staff. Signing feedback with the ingest secret would mean anyone holding
+  a website's ingest key could mint labels straight into the training data.
+
+Nothing here does I/O and nothing here imports a third-party package, so a token can be
+minted and verified in a unit test, in the SES adapter and in the request handler with the
+same code.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import hashlib
+import hmac
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Final
+
+#: Names the scheme inside the signed material, so a future v2 with different fields cannot
+#: be confused for a v1 token by either end.
+TOKEN_ALGORITHM: Final[str] = "LEADQUALI-FEEDBACK-HMAC-SHA256"  # noqa: S105 — a label, not a secret
+
+#: The scheme version, and the token's first dot-separated part.
+TOKEN_VERSION: Final[str] = "fb1"  # noqa: S105 — a version marker, not a secret
+
+#: Shortest process secret a deployment may configure, in characters. The same bar as
+#: :data:`leadquali.api.signing.MIN_SIGNING_SECRET_CHARS`, for the same reason: the check
+#: exists to catch a placeholder in a config file, not to make an HMAC stronger.
+MIN_TOKEN_SECRET_CHARS: Final[int] = 32
+
+#: How long a feedback link stays usable by default. Long enough that a rep who reads the
+#: email on Monday and acts on Friday still counts, short enough that a link sitting in an
+#: archived mailbox is not a standing write capability. Configurable per deployment.
+DEFAULT_TOKEN_TTL_DAYS: Final[int] = 30
+
+#: Longest token this module will even look at. A token is ~230 characters; the cap stops a
+#: multi-megabyte path from being base64-decoded before it is rejected.
+MAX_TOKEN_CHARS: Final[int] = 1024
+
+#: Longest free-text note kept from the thank-you page. A rep writes a sentence; anything
+#: past this is truncated rather than refused, because losing a rep's words to a validation
+#: error is a worse outcome than storing 2 kB.
+MAX_NOTES_CHARS: Final[int] = 2000
+
+#: The public path a feedback link points at, with the token as its last segment. Defined
+#: here, in the one module both ends import, so the adapter that *mints* the link and the
+#: route that *serves* it cannot disagree about where it goes — a mismatch would be a dead
+#: link in every email, discovered by a rep rather than by a test.
+FEEDBACK_PATH_PREFIX: Final[str] = "/feedback/"
+
+_KEY_DERIVATION_LABEL: Final[bytes] = b"LEADQUALI-FEEDBACK-KEY-v1"
+
+
+class Verdict(StrEnum):
+    """What a human thought of a routed lead.
+
+    The three values mirror ``feedback.verdict``'s CHECK constraint in #15's schema
+    (``verdict_known``). :attr:`UNSURE` exists so a rep who genuinely cannot tell has
+    somewhere to put that: a forced good/bad choice on an ambiguous lead is noise in the
+    golden set, and noise is worse than a smaller set.
+    """
+
+    GOOD = "good"
+    BAD = "bad"
+    UNSURE = "unsure"
+
+    @property
+    def label(self) -> str:
+        """How this verdict is written to a human, on a button or a page."""
+        return _VERDICT_LABELS[self]
+
+    @property
+    def opposite(self) -> Verdict:
+        """The verdict a rep changing their mind would want.
+
+        :attr:`UNSURE` is its own opposite — there is no "the other one" for it — which is
+        why the thank-you page offers a change link only for the two decisive verdicts.
+        """
+        return _VERDICT_OPPOSITES[self]
+
+
+_VERDICT_LABELS: Final[dict[Verdict, str]] = {
+    Verdict.GOOD: "good lead",
+    Verdict.BAD: "bad lead",
+    Verdict.UNSURE: "not sure",
+}
+
+_VERDICT_OPPOSITES: Final[dict[Verdict, Verdict]] = {
+    Verdict.GOOD: Verdict.BAD,
+    Verdict.BAD: Verdict.GOOD,
+    Verdict.UNSURE: Verdict.UNSURE,
+}
+
+
+class UnknownLeadError(LookupError):
+    """The token names a lead this tenant does not have.
+
+    Raised by a :class:`~leadquali.app.ports.FeedbackStorePort` implementation rather than
+    guessed at by the caller. It is a real, expected condition and not a bug: #37's
+    retention job deletes leads, and the link in a rep's mailbox outlives the row. The
+    endpoint turns it into a page that says so instead of a stack trace.
+    """
+
+
+# --------------------------------------------------------------------------- rater ids
+
+
+def rater_id(destination: str) -> str:
+    """The opaque subject id recorded in ``feedback.rater`` for a routing destination.
+
+    #16 flags ``rater`` as an **opaque subject id, never an email address**, and #15's
+    schema comment says why: feedback is retained for as long as it is useful to the
+    rubric, which is longer than ``leads.raw_payload`` is kept, so an address here would
+    put personal data outside the one place invariant 5 allows it to live.
+
+    A v1 routing email goes to a shared sales destination and the person who clicks is not
+    identified — so the honest subject is *the destination*, hashed. It is stable (the same
+    inbox produces the same id every time, which is what makes a second click an update
+    rather than a new row), it is not reversible from the database alone, and it carries no
+    address. When #29 adds per-rep identities, this is the one function that changes.
+
+    Raises:
+        ValueError: the destination is blank. A rater id derived from nothing would collide
+            across every tenant, and a feedback row is worthless without knowing whose it is.
+    """
+    normalised = destination.strip().lower()
+    if not normalised:
+        raise ValueError("destination must not be blank; it is what the rater id is derived from")
+    digest = hashlib.sha256(f"destination:{normalised}".encode()).hexdigest()
+    return f"dest:{digest[:32]}"
+
+
+# ------------------------------------------------------------------------ the token
+
+
+@dataclass(frozen=True, slots=True)
+class FeedbackClaim:
+    """What one feedback link authorises. Every field of it is signed.
+
+    Immutable, because it is what the signature attests to: a claim that could be edited
+    after verification would make the verification meaningless.
+    """
+
+    tenant_id: str
+    lead_id: str
+    verdict: Verdict
+    rater: str
+    expires_at: datetime
+
+    def signing_string(self) -> str:
+        """The canonical string the MAC is computed over.
+
+        Seven newline-separated lines::
+
+            LEADQUALI-FEEDBACK-HMAC-SHA256
+            fb1
+            <tenant id>
+            <lead id>
+            <verdict>
+            <rater subject id>
+            <expiry, unix seconds>
+
+        Field-per-line with no separator that can appear in a field, so no combination of
+        values can be re-cut into a different claim with the same string.
+        """
+        return "\n".join(
+            (
+                TOKEN_ALGORITHM,
+                TOKEN_VERSION,
+                self.tenant_id,
+                self.lead_id,
+                self.verdict.value,
+                self.rater,
+                str(int(self.expires_at.timestamp())),
+            )
+        )
+
+
+class TokenFailure(StrEnum):
+    """Why a token was refused.
+
+    For the log and for choosing the page's wording — an expired link deserves "ask for a
+    fresh email", a forged one deserves nothing but a flat refusal.
+    """
+
+    MALFORMED = "malformed"
+    """Not a token at all: wrong shape, wrong version, undecodable, unknown verdict."""
+
+    BAD_SIGNATURE = "bad_signature"
+    """Well-formed and not signed by us. Tampered, forged, or minted with another key."""
+
+    EXPIRED = "expired"
+    """Signed by us, and past its expiry."""
+
+
+@dataclass(frozen=True, slots=True)
+class TokenAccepted:
+    """The token verifies, and this is what it authorises."""
+
+    claim: FeedbackClaim
+
+
+@dataclass(frozen=True, slots=True)
+class TokenRejected:
+    """The token does not verify, and the visitor is told very little about why."""
+
+    failure: TokenFailure
+
+
+TokenResult = TokenAccepted | TokenRejected
+
+
+def tenant_key(secret: bytes, tenant_id: str) -> bytes:
+    """Derive one tenant's signing key from the process secret.
+
+    A single configured secret with a per-tenant derived key, rather than a secret per
+    tenant: one value for #26/#28 to provision and rotate, and still no way to move a token
+    from one tenant to another. Standard HMAC-as-KDF, with a label so this key cannot
+    collide with anything else derived from the same secret later.
+    """
+    return hmac.new(
+        secret, _KEY_DERIVATION_LABEL + b"|" + tenant_id.encode("utf-8"), hashlib.sha256
+    ).digest()
+
+
+def mint_token(
+    *,
+    secret: bytes,
+    tenant_id: str,
+    lead_id: str,
+    verdict: Verdict,
+    rater: str,
+    expires_at: datetime,
+) -> str:
+    """Build the token for one feedback link: ``fb1.<claim>.<mac>``.
+
+    The claim travels base64url-encoded rather than hashed because the server has no
+    database of outstanding tokens and must not need one: everything it needs to write the
+    row is in the URL, which is what makes the endpoint a single statement and the link
+    survive a deploy. The MAC is computed over the *encoded* claim exactly as it will be
+    presented, so verification never has to re-canonicalise attacker-supplied text.
+
+    Args:
+        secret: the process feedback secret. Per-tenant derivation happens here.
+        tenant_id: whose lead this is.
+        lead_id: the lead the verdict is about.
+        verdict: the one verdict this link can record. Mint one link per verdict.
+        rater: the opaque subject id to file the feedback under — see :func:`rater_id`.
+        expires_at: when the link stops working. Timezone-aware.
+
+    Raises:
+        ValueError: the secret is too short, or a field is blank, or ``expires_at`` is
+            naive. Every one of these is a wiring mistake that would otherwise become a
+            link nobody can use or a token signed with a placeholder.
+    """
+    check_token_secret(secret)
+    if not tenant_id or not lead_id or not rater:
+        raise ValueError("tenant_id, lead_id and rater must all be non-empty")
+    if expires_at.tzinfo is None:
+        raise ValueError("expires_at must be timezone-aware; a naive expiry is a guess")
+
+    claim = FeedbackClaim(
+        tenant_id=tenant_id,
+        lead_id=lead_id,
+        verdict=verdict,
+        rater=rater,
+        expires_at=expires_at,
+    )
+    encoded = _b64encode(claim.signing_string().encode("utf-8"))
+    mac = _mac(secret=secret, tenant_id=tenant_id, encoded_claim=encoded)
+    return f"{TOKEN_VERSION}.{encoded}.{mac}"
+
+
+def verify_token(*, secret: bytes, token: str, now: datetime) -> TokenResult:
+    """Check one token and return what it authorises, or why it was refused.
+
+    Order matters: shape, then signature, then expiry. The signature is checked before the
+    expiry so that an unsigned claim can never be *read* — an attacker who could learn
+    "this lead id is real, the link just expired" from a forged token would have an oracle
+    over lead ids.
+
+    Args:
+        secret: the process feedback secret.
+        token: the path segment as it arrived. Attacker-controlled in full.
+        now: current time, injected so the expiry window is testable without sleeping.
+    """
+    if not token or len(token) > MAX_TOKEN_CHARS:
+        return TokenRejected(TokenFailure.MALFORMED)
+
+    parts = token.split(".")
+    if len(parts) != 3:
+        return TokenRejected(TokenFailure.MALFORMED)
+    version, encoded, presented = parts
+    if version != TOKEN_VERSION or not encoded or not presented:
+        return TokenRejected(TokenFailure.MALFORMED)
+
+    try:
+        raw = _b64decode(encoded).decode("utf-8")
+    except (binascii.Error, ValueError, UnicodeDecodeError):
+        return TokenRejected(TokenFailure.MALFORMED)
+
+    lines = raw.split("\n")
+    if len(lines) != 7:
+        return TokenRejected(TokenFailure.MALFORMED)
+    algorithm, claimed_version, tenant_id, lead_id, verdict_value, rater, expiry = lines
+    if algorithm != TOKEN_ALGORITHM or claimed_version != TOKEN_VERSION:
+        return TokenRejected(TokenFailure.MALFORMED)
+    if not tenant_id or not lead_id or not rater or not expiry.isdigit():
+        return TokenRejected(TokenFailure.MALFORMED)
+    try:
+        verdict = Verdict(verdict_value)
+    except ValueError:
+        return TokenRejected(TokenFailure.MALFORMED)
+
+    # The claim is still unauthenticated here; the only thing taken from it so far is which
+    # tenant's key to try, and a wrong guess simply fails the comparison below.
+    expected = _mac(secret=secret, tenant_id=tenant_id, encoded_claim=encoded)
+    if not hmac.compare_digest(expected, presented):
+        return TokenRejected(TokenFailure.BAD_SIGNATURE)
+
+    expires_at = datetime.fromtimestamp(int(expiry), tz=UTC)
+    if now >= expires_at:
+        return TokenRejected(TokenFailure.EXPIRED)
+
+    return TokenAccepted(
+        FeedbackClaim(
+            tenant_id=tenant_id,
+            lead_id=lead_id,
+            verdict=verdict,
+            rater=rater,
+            expires_at=expires_at,
+        )
+    )
+
+
+def feedback_url(*, base_url: str, token: str) -> str:
+    """The absolute URL for one feedback link.
+
+    ``base_url`` is configuration (``FEEDBACK_BASE_URL``) rather than something derived from
+    an inbound request: the email is composed by a worker that has no request to derive a
+    host from, and a link built from a ``Host`` header is a link an attacker can point at
+    their own server. Any trailing slash on the configured value is normalised away so that
+    ``https://x.example`` and ``https://x.example/`` produce the same link.
+
+    Raises:
+        ValueError: the base URL is blank or is not absolute. A relative link in an email
+            is a link that does nothing.
+    """
+    trimmed = base_url.strip().rstrip("/")
+    if not trimmed.startswith(("http://", "https://")):
+        raise ValueError(
+            f"the feedback base URL must be absolute, got {base_url!r}; "
+            "an email link has no page to be relative to"
+        )
+    return f"{trimmed}{FEEDBACK_PATH_PREFIX}{token}"
+
+
+def load_token_secret(raw: str) -> bytes:
+    """Validate and encode the configured feedback secret.
+
+    Raises:
+        ValueError: shorter than :data:`MIN_TOKEN_SECRET_CHARS`. Checked at wiring time so
+            a placeholder is found by a failed start-up rather than by a rep whose link
+            stopped working after a rotation.
+    """
+    secret = raw.encode("utf-8")
+    check_token_secret(secret)
+    return secret
+
+
+def check_token_secret(secret: bytes) -> None:
+    """Raise unless ``secret`` is long enough to be a real one.
+
+    Public so that anything holding an already-encoded secret — the SES adapter, the API's
+    wiring — can fail at construction rather than at the first lead or the first click.
+
+    Raises:
+        ValueError: shorter than :data:`MIN_TOKEN_SECRET_CHARS`.
+    """
+    if len(secret) < MIN_TOKEN_SECRET_CHARS:
+        raise ValueError(
+            f"the feedback token secret must be at least {MIN_TOKEN_SECRET_CHARS} characters"
+        )
+
+
+def _mac(*, secret: bytes, tenant_id: str, encoded_claim: str) -> str:
+    material = f"{TOKEN_VERSION}.{encoded_claim}".encode()
+    digest = hmac.new(tenant_key(secret, tenant_id), material, hashlib.sha256).digest()
+    return _b64encode(digest)
+
+
+def _b64encode(raw: bytes) -> str:
+    """Unpadded base64url, so the token is one path segment with nothing to percent-encode."""
+    return base64.urlsafe_b64encode(raw).decode("ascii").rstrip("=")
+
+
+def _b64decode(encoded: str) -> bytes:
+    padding = "=" * (-len(encoded) % 4)
+    return base64.urlsafe_b64decode(encoded + padding)
+
+
+__all__ = [
+    "DEFAULT_TOKEN_TTL_DAYS",
+    "FEEDBACK_PATH_PREFIX",
+    "MAX_NOTES_CHARS",
+    "MAX_TOKEN_CHARS",
+    "MIN_TOKEN_SECRET_CHARS",
+    "TOKEN_ALGORITHM",
+    "TOKEN_VERSION",
+    "FeedbackClaim",
+    "TokenAccepted",
+    "TokenFailure",
+    "TokenRejected",
+    "TokenResult",
+    "UnknownLeadError",
+    "Verdict",
+    "check_token_secret",
+    "feedback_url",
+    "load_token_secret",
+    "mint_token",
+    "rater_id",
+    "tenant_key",
+    "verify_token",
+]

--- a/src/leadquali/app/lead_email.py
+++ b/src/leadquali/app/lead_email.py
@@ -1,0 +1,581 @@
+"""The routing email, rendered. No I/O, no SDK, no template engine.
+
+This is what the product looks like to the only person who uses it. A rep opens twenty of
+these at 9am, and the email has to answer *should I call this one, and what do I open with*
+in about five seconds, without them opening a dashboard they do not have a login for. So
+the order of the message is the order a decision gets made:
+
+1. **The banner, if there is one.** "System could not assess" and "low model confidence"
+   come first because they change how everything below is read — a score of 0 with no
+   banner would look like a judgement about the lead rather than a failure of ours.
+2. **Tier and score**, big, at the top.
+3. **The one question to open with**, because it is the only line that turns reading into
+   calling.
+4. **Who they are and how to reach them.**
+5. **Why the model said what it said**, then the five dimension scores, the facts it read
+   off the submission, and what it could not find. This is the audit trail, and it is what a
+   rep uses to disagree — which is the click this whole feature exists to collect.
+6. **Good lead / bad lead.**
+
+Both a plain-text and an HTML part are produced, and the plain-text one is not a courtesy:
+it is what a screen reader, a locked-down Outlook and a preview pane show, and a message
+with no text part is more likely to be scored as spam.
+
+**HTML written for 2005, deliberately.** Outlook renders with Word's engine: no flexbox, no
+grid, no ``<style>`` reliably, no external CSS, no web fonts. So the layout is nested
+tables with inline styles, the "buttons" are padded table cells with an anchor inside, and
+the whole thing is capped at 600px with ``width="100%"`` so it reflows on a phone. Colour
+is never the only carrier of meaning — the tier is spelled out in words as well — because a
+colourblind rep and a client that strips backgrounds must both still be able to read it.
+
+**Everything interpolated is escaped.** The lead's message is attacker-controlled text from
+a public form and the model's reasoning is model output; neither is trusted, both are
+escaped with :func:`html.escape` including quotes, and no rendered value is ever placed
+anywhere but in text content or in a fully-quoted attribute we constructed.
+"""
+
+from __future__ import annotations
+
+import html
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from typing import Final
+
+from leadquali.app.feedback import Verdict
+from leadquali.domain.models import (
+    MAX_TOTAL_SCORE,
+    DimensionScores,
+    ExtractedFacts,
+    LeadAssessment,
+    RoutingDecision,
+    Tier,
+)
+from leadquali.domain.routing import SYSTEM_FAILURE_BANNER
+from leadquali.domain.tenant_config import DIMENSION_MAXIMA
+from leadquali.prompts.lead import LeadSubmission
+
+#: Width every mail client agrees on. Wider than this and Outlook's preview pane clips.
+_BODY_WIDTH_PX: Final[int] = 600
+
+#: Tier colours, and their fallback words. The word is authoritative; the colour is decoration.
+_TIER_COLOURS: Final[Mapping[Tier, str]] = {
+    Tier.HOT: "#b42318",
+    Tier.WARM: "#b54708",
+    Tier.COLD: "#175cd3",
+    Tier.DISQUALIFIED: "#475467",
+}
+
+_GOOD_COLOUR: Final[str] = "#067647"
+_BAD_COLOUR: Final[str] = "#b42318"
+_BANNER_BACKGROUND: Final[str] = "#fef3f2"
+_BANNER_BORDER: Final[str] = "#f97066"
+_MUTED: Final[str] = "#475467"
+_RULE: Final[str] = "#e4e7ec"
+_FONT: Final[str] = "-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif"
+
+#: Longest single field rendered into the email. A form field can hold a novel; a routing
+#: email that is a novel does not get read, and the full payload is in the database.
+MAX_FIELD_CHARS: Final[int] = 2000
+
+#: What a rep sees where a fact is missing. A blank cell reads as a rendering bug.
+_ABSENT: Final[str] = "—"
+
+
+@dataclass(frozen=True, slots=True)
+class FeedbackLink:
+    """One feedback button: a verdict and the signed URL that records it."""
+
+    verdict: Verdict
+    url: str
+
+
+@dataclass(frozen=True, slots=True)
+class RenderedEmail:
+    """The three parts a multipart/alternative message is built from."""
+
+    subject: str
+    text_body: str
+    html_body: str
+
+
+def render_routing_email(
+    *,
+    submission: LeadSubmission,
+    decision: RoutingDecision,
+    assessment: LeadAssessment | None,
+    links: Sequence[FeedbackLink] = (),
+    lead_reference: str = "",
+) -> RenderedEmail:
+    """Render one routed lead as a subject line and two body parts.
+
+    Args:
+        submission: the lead as it was submitted. Untrusted text; escaped on the way in.
+        decision: tier, score, note and escalation reason. The note is rendered verbatim —
+            #9 owns that wording and an email that paraphrased it would drift from the
+            phrase sales has learned to recognise.
+        assessment: the model's judgment, or ``None`` for the system-failure path, which is
+            not an error: the lead is emailed unqualified, banner first, for a person to
+            qualify by hand.
+        links: the feedback buttons, already signed and expiring. Empty renders no
+            feedback section at all rather than a dead button.
+        lead_reference: an opaque id shown in the footer so a rep can quote it in a support
+            request. Never the submission's contents.
+    """
+    company = _clean(submission.company) or _clean(
+        assessment.extracted.company_name if assessment else None
+    )
+    person = _clean(submission.full_name)
+    return RenderedEmail(
+        subject=_subject(decision=decision, assessment=assessment, company=company, person=person),
+        text_body=_text_body(
+            submission=submission,
+            decision=decision,
+            assessment=assessment,
+            links=links,
+            lead_reference=lead_reference,
+        ),
+        html_body=_html_body(
+            submission=submission,
+            decision=decision,
+            assessment=assessment,
+            links=links,
+            lead_reference=lead_reference,
+        ),
+    )
+
+
+# -------------------------------------------------------------------------- the subject
+
+
+def _subject(
+    *,
+    decision: RoutingDecision,
+    assessment: LeadAssessment | None,
+    company: str,
+    person: str,
+) -> str:
+    """One line that sorts and triages an inbox on its own.
+
+    The tier and score lead because that is what a rep scans down the list for, and the
+    company follows because that is what they recognise. A failed assessment says so in the
+    first characters rather than showing a score of 0, which would read as a verdict.
+    """
+    who = company or person or "unknown company"
+    if assessment is None:
+        return f"[NEEDS REVIEW] Lead we could not assess — {who}"
+    marker = f"[{decision.tier.value.upper()} {decision.total_score:.0f}]"
+    if decision.escalated:
+        return f"{marker} {who} — human review"
+    return f"{marker} {who}"
+
+
+# ------------------------------------------------------------------------ the text part
+
+
+def _text_body(
+    *,
+    submission: LeadSubmission,
+    decision: RoutingDecision,
+    assessment: LeadAssessment | None,
+    links: Sequence[FeedbackLink],
+    lead_reference: str,
+) -> str:
+    lines: list[str] = []
+    banner = _banner_text(decision=decision, assessment=assessment)
+    if banner is not None:
+        headline, detail = banner
+        lines += ["!" * 60, headline.upper(), detail, "!" * 60, ""]
+
+    if assessment is None:
+        lines += ["This lead has NOT been scored. Qualify it by hand.", ""]
+    else:
+        # Only the headline. ``decision.note`` on a normally-scored lead is a restatement of
+        # exactly this line ("scored 87.00/100 — hot"), and the notes that say something a
+        # rep needs — the failure banner, the confidence gate — are rendered by the banner
+        # above, verbatim. Printing it twice trains people to skim past it.
+        lines += [
+            f"{decision.tier.value.upper()} — {decision.total_score:.0f}/{MAX_TOTAL_SCORE:.0f}",
+            "",
+        ]
+        question = _clean(assessment.suggested_first_question)
+        if question:
+            lines += ["OPEN WITH", f"  {question}", ""]
+
+    lines += ["CONTACT"]
+    lines += [f"  {label}: {value}" for label, value in _contact_rows(submission)]
+    lines.append("")
+
+    message = _clean(submission.message)
+    if message:
+        lines += ["WHAT THEY WROTE", _indent(message), ""]
+
+    if assessment is not None:
+        lines += ["WHY", _indent(_clean(assessment.reasoning)), ""]
+        lines += ["SCORES"]
+        lines += [
+            f"  {_dimension_label(name)}: {value}/{maximum}"
+            for name, value, maximum in _dimension_rows(assessment.dimension_scores)
+        ]
+        lines += [f"  confidence: {assessment.confidence:.0%}", ""]
+        lines += ["WHAT WE READ OFF THE FORM"]
+        lines += [f"  {label}: {value}" for label, value in _fact_rows(assessment.extracted)]
+        lines.append("")
+        missing = [_clean(item) for item in assessment.missing_information if _clean(item)]
+        if missing:
+            lines += ["WHAT WE DO NOT KNOW"]
+            lines += [f"  - {item}" for item in missing]
+            lines.append("")
+
+    if links:
+        lines += ["WAS THIS A GOOD LEAD? One click, no login — it tunes the scoring."]
+        lines += [f"  {link.verdict.label.capitalize()}: {link.url}" for link in links]
+        lines.append("")
+
+    if lead_reference:
+        lines.append(f"Lead reference: {lead_reference}")
+    return "\n".join(lines).strip() + "\n"
+
+
+# ------------------------------------------------------------------------ the HTML part
+
+
+def _html_body(
+    *,
+    submission: LeadSubmission,
+    decision: RoutingDecision,
+    assessment: LeadAssessment | None,
+    links: Sequence[FeedbackLink],
+    lead_reference: str,
+) -> str:
+    blocks: list[str] = []
+    banner = _banner_text(decision=decision, assessment=assessment)
+    if banner is not None:
+        headline, detail = banner
+        blocks.append(_html_banner(headline, detail))
+
+    blocks.append(_html_headline(decision=decision, assessment=assessment))
+
+    if assessment is not None:
+        question = _clean(assessment.suggested_first_question)
+        if question:
+            blocks.append(_html_callout("Open with", question))
+
+    blocks.append(_html_section("Contact", _html_definition_table(_contact_rows(submission))))
+
+    message = _clean(submission.message)
+    if message:
+        blocks.append(_html_section("What they wrote", _html_quote(message)))
+
+    if assessment is not None:
+        blocks.append(_html_section("Why", _html_paragraph(_clean(assessment.reasoning))))
+        blocks.append(
+            _html_section(
+                "Scores",
+                _html_score_table(assessment.dimension_scores, assessment.confidence),
+            )
+        )
+        blocks.append(
+            _html_section(
+                "What we read off the form",
+                _html_definition_table(_fact_rows(assessment.extracted)),
+            )
+        )
+        missing = [_clean(item) for item in assessment.missing_information if _clean(item)]
+        if missing:
+            blocks.append(_html_section("What we do not know", _html_list(missing)))
+
+    if links:
+        blocks.append(_html_feedback(links))
+    blocks.append(_html_footer(lead_reference))
+
+    body = "\n".join(blocks)
+    # A table-in-a-table with an explicit width: the outer one paints the page background in
+    # clients that ignore body styles, the inner one is the 600px column.
+    return (
+        '<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" '
+        '"http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">\n'
+        '<html xmlns="http://www.w3.org/1999/xhtml"><head>'
+        '<meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />'
+        '<meta name="viewport" content="width=device-width, initial-scale=1" />'
+        f"<title>{html.escape(_subject_placeholder(decision, assessment))}</title>"
+        "</head>"
+        '<body style="margin:0;padding:0;background-color:#f2f4f7;">'
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" '
+        'style="background-color:#f2f4f7;"><tr><td align="center" style="padding:16px;">'
+        f'<table role="presentation" width="{_BODY_WIDTH_PX}" cellpadding="0" cellspacing="0" '
+        f'border="0" style="width:100%;max-width:{_BODY_WIDTH_PX}px;background-color:#ffffff;'
+        f"border:1px solid {_RULE};border-radius:8px;font-family:{_FONT};font-size:15px;"
+        'line-height:1.5;color:#101828;">'
+        f"{body}"
+        "</table></td></tr></table></body></html>"
+    )
+
+
+def _subject_placeholder(decision: RoutingDecision, assessment: LeadAssessment | None) -> str:
+    if assessment is None:
+        return "Lead we could not assess"
+    return f"{decision.tier.value} lead — {decision.total_score:.0f}/100"
+
+
+def _html_banner(headline: str, detail: str) -> str:
+    return (
+        f'<tr><td style="padding:20px 24px;background-color:{_BANNER_BACKGROUND};'
+        f'border-bottom:3px solid {_BANNER_BORDER};border-radius:8px 8px 0 0;">'
+        f'<div style="font-size:17px;font-weight:700;color:{_BAD_COLOUR};">'
+        f"{html.escape(headline)}</div>"
+        f'<div style="padding-top:4px;color:{_MUTED};">{html.escape(detail)}</div>'
+        "</td></tr>"
+    )
+
+
+def _html_headline(*, decision: RoutingDecision, assessment: LeadAssessment | None) -> str:
+    colour = _TIER_COLOURS[decision.tier]
+    if assessment is None:
+        left = (
+            f'<div style="font-size:22px;font-weight:700;color:{_MUTED};">Not scored</div>'
+            f'<div style="padding-top:4px;color:{_MUTED};">Qualify this one by hand.</div>'
+        )
+    else:
+        left = (
+            f'<div style="font-size:26px;font-weight:700;color:{colour};">'
+            f"{html.escape(decision.tier.value.upper())} "
+            f'<span style="color:#101828;">{decision.total_score:.0f}</span>'
+            f'<span style="font-size:15px;color:{_MUTED};">/{MAX_TOTAL_SCORE:.0f}</span></div>'
+        )
+        # See ``_text_body``: the note is the banner's job, and on a normally-scored lead it
+        # only restates the two numbers directly above it.
+    return f'<tr><td style="padding:24px 24px 8px 24px;">{left}</td></tr>'
+
+
+def _html_callout(title: str, body: str) -> str:
+    return (
+        '<tr><td style="padding:8px 24px 16px 24px;">'
+        f'<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" '
+        f'style="background-color:#f8f9fc;border-left:4px solid {_MUTED};">'
+        '<tr><td style="padding:12px 16px;">'
+        f'<div style="font-size:12px;letter-spacing:.08em;text-transform:uppercase;'
+        f'color:{_MUTED};">{html.escape(title)}</div>'
+        f'<div style="padding-top:4px;font-size:16px;font-weight:600;">{html.escape(body)}</div>'
+        "</td></tr></table></td></tr>"
+    )
+
+
+def _html_section(title: str, inner: str) -> str:
+    return (
+        '<tr><td style="padding:12px 24px;">'
+        f'<div style="font-size:12px;letter-spacing:.08em;text-transform:uppercase;'
+        f'color:{_MUTED};border-top:1px solid {_RULE};padding-top:12px;">'
+        f"{html.escape(title)}</div>"
+        f'<div style="padding-top:8px;">{inner}</div>'
+        "</td></tr>"
+    )
+
+
+def _html_paragraph(text: str) -> str:
+    return f'<div style="margin:0;">{html.escape(text)}</div>'
+
+
+def _html_quote(text: str) -> str:
+    escaped = html.escape(text).replace("\n", "<br />")
+    return (
+        f'<div style="white-space:normal;color:#344054;background-color:#f8f9fc;'
+        f'padding:12px 16px;border-radius:6px;">{escaped}</div>'
+    )
+
+
+def _html_definition_table(rows: Sequence[tuple[str, str]]) -> str:
+    cells = "".join(
+        "<tr>"
+        f'<td style="padding:2px 12px 2px 0;color:{_MUTED};white-space:nowrap;'
+        f'vertical-align:top;">{html.escape(label)}</td>'
+        f'<td style="padding:2px 0;vertical-align:top;">{_html_value(label, value)}</td>'
+        "</tr>"
+        for label, value in rows
+    )
+    return (
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">'
+        f"{cells}</table>"
+    )
+
+
+def _html_value(label: str, value: str) -> str:
+    """Make an address or a URL clickable, and everything else plain escaped text.
+
+    Only the two labels this module produced itself become links, and the href is built from
+    the same escaped value — so a form field containing ``javascript:`` is rendered as the
+    text it is rather than becoming an attribute we constructed for an attacker.
+    """
+    escaped = html.escape(value)
+    if value == _ABSENT:
+        return f'<span style="color:{_MUTED};">{escaped}</span>'
+    if label == "email":
+        return f'<a href="mailto:{escaped}" style="color:#175cd3;">{escaped}</a>'
+    if label == "website" and value.startswith(("http://", "https://")):
+        return f'<a href="{escaped}" style="color:#175cd3;">{escaped}</a>'
+    return escaped
+
+
+def _html_score_table(scores: DimensionScores, confidence: float) -> str:
+    rows = ""
+    for name, value, maximum in _dimension_rows(scores):
+        filled = round((value / maximum) * 100) if maximum else 0
+        rows += (
+            "<tr>"
+            f'<td style="padding:3px 12px 3px 0;color:{_MUTED};white-space:nowrap;">'
+            f"{html.escape(_dimension_label(name))}</td>"
+            f'<td style="padding:3px 8px 3px 0;width:100%;">'
+            '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" '
+            f'border="0" style="background-color:{_RULE};border-radius:3px;">'
+            f'<tr><td width="{filled}%" style="background-color:#475467;border-radius:3px;'
+            'font-size:1px;line-height:6px;">&nbsp;</td>'
+            f'<td width="{100 - filled}%" style="font-size:1px;line-height:6px;">&nbsp;</td>'
+            "</tr></table></td>"
+            f'<td style="padding:3px 0;white-space:nowrap;font-variant-numeric:tabular-nums;">'
+            f"{value}/{maximum}</td></tr>"
+        )
+    rows += (
+        "<tr>"
+        f'<td style="padding:8px 12px 0 0;color:{_MUTED};">model confidence</td>'
+        f'<td colspan="2" style="padding:8px 0 0 0;">{confidence:.0%}</td></tr>'
+    )
+    return (
+        '<table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0">'
+        f"{rows}</table>"
+    )
+
+
+def _html_list(items: Sequence[str]) -> str:
+    entries = "".join(f'<li style="padding-bottom:2px;">{html.escape(item)}</li>' for item in items)
+    return f'<ul style="margin:0;padding-left:20px;">{entries}</ul>'
+
+
+def _html_feedback(links: Sequence[FeedbackLink]) -> str:
+    """The two buttons the whole feature exists for.
+
+    Bulletproof-button shape: a table cell carrying the background colour with a padded
+    anchor inside it, so a client that drops the background still shows a legible link and
+    Outlook still shows the block of colour.
+    """
+    buttons = ""
+    for link in links:
+        colour = _GOOD_COLOUR if link.verdict is Verdict.GOOD else _BAD_COLOUR
+        buttons += (
+            f'<td align="center" style="padding:0 6px;">'
+            f'<table role="presentation" cellpadding="0" cellspacing="0" border="0" '
+            f'style="background-color:{colour};border-radius:6px;"><tr>'
+            f'<td align="center" style="padding:12px 20px;">'
+            f'<a href="{html.escape(link.url, quote=True)}" '
+            f'style="color:#ffffff;font-weight:700;font-size:16px;text-decoration:none;'
+            f'display:inline-block;">{html.escape(link.verdict.label.capitalize())}</a>'
+            "</td></tr></table></td>"
+        )
+    return (
+        '<tr><td style="padding:20px 24px 8px 24px;">'
+        f'<div style="border-top:1px solid {_RULE};padding-top:16px;text-align:center;">'
+        '<div style="font-weight:600;padding-bottom:12px;">Was this a good lead?</div>'
+        '<table role="presentation" cellpadding="0" cellspacing="0" border="0" '
+        'align="center"><tr>'
+        f"{buttons}"
+        "</tr></table>"
+        f'<div style="padding-top:10px;font-size:13px;color:{_MUTED};">'
+        "One tap, no login. We ask you to confirm on the next screen, and you can change "
+        "your answer at any time.</div>"
+        "</div></td></tr>"
+    )
+
+
+def _html_footer(lead_reference: str) -> str:
+    reference = (
+        f"Lead reference {html.escape(lead_reference)}" if lead_reference else "Automated message"
+    )
+    return (
+        f'<tr><td style="padding:16px 24px 24px 24px;color:{_MUTED};font-size:12px;">'
+        f"{reference} · Scored automatically; the tier and score are computed from the "
+        "rubric, not written by the model.</td></tr>"
+    )
+
+
+# ------------------------------------------------------------------------------ shared
+
+
+def _banner_text(
+    *, decision: RoutingDecision, assessment: LeadAssessment | None
+) -> tuple[str, str] | None:
+    """The banner headline and its detail, or ``None`` when the lead was scored normally.
+
+    The detail is ``decision.note`` verbatim. #9 owns that wording — ``system could not
+    assess: …`` and ``low model confidence — human review`` — and an email that paraphrased
+    it would drift from the phrase a rep has learned to recognise.
+    """
+    if assessment is None:
+        return ("The system could not assess this lead", decision.note or SYSTEM_FAILURE_BANNER)
+    if decision.escalated:
+        return ("Needs a human look", decision.note)
+    return None
+
+
+def _contact_rows(submission: LeadSubmission) -> list[tuple[str, str]]:
+    """Name, role, company and the ways to reach them — in the order a rep reads them."""
+    return [
+        ("name", _clean(submission.full_name) or _ABSENT),
+        ("role", _clean(submission.role) or _ABSENT),
+        ("company", _clean(submission.company) or _ABSENT),
+        ("email", _clean(submission.email) or _ABSENT),
+        ("phone", _clean(submission.phone) or _ABSENT),
+        ("website", _clean(submission.website) or _ABSENT),
+    ]
+
+
+def _fact_rows(extracted: ExtractedFacts) -> list[tuple[str, str]]:
+    return [
+        ("company", _clean(extracted.company_name) or _ABSENT),
+        ("industry", _clean(extracted.industry) or _ABSENT),
+        ("size", _clean(extracted.company_size_estimate) or _ABSENT),
+        ("seniority", _clean(extracted.role_seniority) or _ABSENT),
+        ("use case", _clean(extracted.stated_use_case) or _ABSENT),
+        ("timeline", _clean(extracted.stated_timeline) or _ABSENT),
+    ]
+
+
+def _dimension_rows(scores: DimensionScores) -> list[tuple[str, int, int]]:
+    """Each dimension with its value and its own maximum, in schema order.
+
+    The maxima come from :data:`~leadquali.domain.tenant_config.DIMENSION_MAXIMA`, which is
+    read off the assessment schema, so a rubric change cannot leave this email showing
+    ``30/25``.
+    """
+    dumped = scores.model_dump()
+    return [(name, int(dumped[name]), DIMENSION_MAXIMA[name]) for name in dumped]
+
+
+def _dimension_label(name: str) -> str:
+    return name.replace("_", " ")
+
+
+def _clean(value: str | None) -> str:
+    """Collapse a submitted or generated field into one safe, bounded line of display text.
+
+    Control characters are dropped (a form field can carry them, and they corrupt both a
+    plain-text part and a header), runs of whitespace are collapsed except for newlines in
+    the lead's own message, and the result is truncated — the whole payload is in the
+    database, and an email is not the archive.
+    """
+    if value is None:
+        return ""
+    text = "".join(character for character in value if character >= " " or character == "\n")
+    text = "\n".join(" ".join(line.split()) for line in text.split("\n")).strip()
+    if len(text) > MAX_FIELD_CHARS:
+        text = text[:MAX_FIELD_CHARS].rstrip() + "…"
+    return text
+
+
+def _indent(text: str) -> str:
+    return "\n".join(f"  {line}" for line in text.split("\n"))
+
+
+__all__ = [
+    "MAX_FIELD_CHARS",
+    "FeedbackLink",
+    "RenderedEmail",
+    "render_routing_email",
+]

--- a/src/leadquali/app/ports.py
+++ b/src/leadquali/app/ports.py
@@ -15,6 +15,7 @@ from typing import Protocol, runtime_checkable
 
 from leadquali.app.assessment_result import AssessmentOutcome
 from leadquali.app.enrichment import Enrichment
+from leadquali.app.feedback import Verdict
 from leadquali.domain.models import Action, LeadAssessment, RoutingDecision
 from leadquali.domain.tenant_config import TenantConfig
 from leadquali.prompts.lead import LeadSubmission
@@ -266,6 +267,84 @@ class EnricherPort(Protocol):
         ...
 
 
+@dataclass(frozen=True, slots=True)
+class RecordedFeedback:
+    """What one feedback write did, in the terms the thank-you page has to speak.
+
+    The page a rep lands on says either "recorded" or "updated — you had said this was a
+    good lead", and it can only say the second if the write reports what was there before.
+    Returning it from the port rather than making the caller read the row back keeps the
+    click path to a single statement.
+    """
+
+    verdict: Verdict
+    """The verdict now on record — what was just written."""
+
+    created: bool
+    """``True`` when this click inserted a row, ``False`` when it updated an existing one."""
+
+    previous_verdict: Verdict | None = None
+    """What this rater had said before, or ``None`` on a first verdict."""
+
+    @property
+    def changed(self) -> bool:
+        """Whether this click actually changed the recorded verdict."""
+        return self.previous_verdict is not None and self.previous_verdict is not self.verdict
+
+
+@runtime_checkable
+class FeedbackStorePort(Protocol):
+    """The write side of the feedback loop, and the only thing that grows the golden set.
+
+    Separate from :class:`LeadStorePort` because the callers are separate: the pipeline
+    writes leads, assessments and routing events from a worker, and a rep's browser writes
+    feedback through the API. #16 deferred these writes because no port defined them; this
+    is that port, and it keeps the same conventions — ``tenant_id`` on every call
+    (invariant 4), keyword-only arguments, raise rather than swallow.
+
+    **A repeated click must not create a second row.** ``(tenant_id, lead_id, rater)``
+    identifies one person's verdict on one lead, and writing it again is an update: mail
+    clients prefetch, people double-tap on phones, and a rep who changes their mind must be
+    able to. Anything else would turn "how often does sales disagree with the model" into a
+    measure of how many times a link was clicked.
+    """
+
+    def record_feedback(
+        self,
+        *,
+        tenant_id: str,
+        lead_id: str,
+        rater: str,
+        verdict: Verdict,
+        notes: str | None,
+        recorded_at: datetime,
+    ) -> RecordedFeedback:
+        """Record ``rater``'s verdict on this lead, replacing any verdict they gave before.
+
+        Args:
+            tenant_id: whose lead this is. Filtered on, always.
+            lead_id: the lead being judged.
+            rater: an **opaque subject id**, never an email address — see
+                :func:`leadquali.app.feedback.rater_id`. This column is retained for longer
+                than the raw lead payload is (#37), so an address here would put personal
+                data outside the one place invariant 5 allows it to live.
+            verdict: good, bad or unsure.
+            notes: the rep's free text, or ``None``. ``None`` leaves any existing note
+                alone: a second click through a link that carries no notes must not erase
+                the sentence the rep typed the first time.
+            recorded_at: when the verdict was given, from the clock port.
+
+        Raises:
+            UnknownLeadError: this tenant has no such lead. Expected rather than
+                exceptional — a link in a mailbox outlives the row once #37's retention job
+                has run, and the rep deserves a page that says so.
+            Exception: any other store failure. The rep sees an honest error page and can
+                click again; returning success from a failed write would lose the one
+                signal this system exists to collect.
+        """
+        ...
+
+
 @runtime_checkable
 class ClockPort(Protocol):
     """Time, injected rather than ambient.
@@ -292,9 +371,11 @@ class ClockPort(Protocol):
 __all__ = [
     "ClockPort",
     "EnricherPort",
+    "FeedbackStorePort",
     "LeadAssessorPort",
     "LeadStorePort",
     "NotifierPort",
+    "RecordedFeedback",
     "RoutingOutcome",
     "StoredLead",
     "TenantConfigPort",

--- a/src/leadquali/config.py
+++ b/src/leadquali/config.py
@@ -14,6 +14,8 @@ from typing import Literal
 from pydantic import Field, SecretStr, field_validator
 from pydantic_settings import BaseSettings, SettingsConfigDict
 
+from leadquali.app.feedback import DEFAULT_TOKEN_TTL_DAYS
+
 LogLevel = Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"]
 
 
@@ -53,6 +55,51 @@ class Settings(BaseSettings):
         ),
     )
 
+    aws_region: str | None = Field(
+        default=None,
+        description=(
+            "AWS region for the SES client. Unset falls back to the ambient AWS chain, "
+            "which is what a Lambda already has."
+        ),
+    )
+    ses_sender: str | None = Field(
+        default=None,
+        description=(
+            "The From identity for routing email, e.g. 'LeadQuali <leads@mail.example.com>'. "
+            "The address must be a verified SES identity; see docs/runbooks/ses-setup.md."
+        ),
+    )
+    ses_configuration_set: str | None = Field(
+        default=None,
+        description=(
+            "SES configuration set routing bounce, complaint and delivery events. Optional "
+            "in that a send succeeds without one, and required in practice: without it "
+            "those events go nowhere."
+        ),
+    )
+    feedback_base_url: str | None = Field(
+        default=None,
+        description=(
+            "Public absolute origin the one-click feedback links point at, e.g. "
+            "'https://api.example.com/prod'. Configuration rather than a request header: "
+            "the worker composing the email has no request to derive a host from."
+        ),
+    )
+    feedback_token_secret: SecretStr | None = Field(
+        default=None,
+        description=(
+            "Signing secret for feedback link tokens, 32+ characters. Distinct from the "
+            "per-tenant ingest signing secrets: those are held by a customer's website, and "
+            "this one authorises writes to the training data. See leadquali.app.feedback."
+        ),
+    )
+    feedback_token_ttl_days: int = Field(
+        default=DEFAULT_TOKEN_TTL_DAYS,
+        gt=0,
+        le=365,
+        description="How long a feedback link stays usable, in days.",
+    )
+
     @field_validator("log_level", mode="before")
     @classmethod
     def _upper_log_level(cls, value: object) -> object:
@@ -85,6 +132,46 @@ class Settings(BaseSettings):
                 "local development)."
             )
         return self.ingest_credentials.get_secret_value()
+
+    def require_ses_sender(self) -> str:
+        """Return the SES sender identity, or raise if it was never configured.
+
+        No default and no guess. A notifier that invented a sender would send from an
+        unverified identity — every message rejected — or, if it happened to guess a
+        verified one, from another environment's domain.
+        """
+        if self.ses_sender is None or not self.ses_sender.strip():
+            raise RuntimeError(
+                "SES_SENDER is not set. Export the verified sender identity from "
+                "docs/runbooks/ses-setup.md (or add it to .env for local development)."
+            )
+        return self.ses_sender
+
+    def require_feedback_base_url(self) -> str:
+        """Return the public origin for feedback links, or raise if it was never configured.
+
+        Without it the routing email would carry either no feedback links or relative ones,
+        and the feedback table — the only source of the golden set — would never grow.
+        """
+        if self.feedback_base_url is None or not self.feedback_base_url.strip():
+            raise RuntimeError(
+                "FEEDBACK_BASE_URL is not set. Export the public origin the feedback "
+                "endpoint is served on, e.g. https://api.example.com/prod."
+            )
+        return self.feedback_base_url
+
+    def require_feedback_token_secret(self) -> str:
+        """Return the feedback signing secret, or raise if it was never configured.
+
+        There is deliberately no "unsigned links when no secret is set" fallback: that would
+        be a public URL that writes whatever it is given into the training data.
+        """
+        if self.feedback_token_secret is None:
+            raise RuntimeError(
+                "FEEDBACK_TOKEN_SECRET is not set. Feedback links are signed capabilities "
+                "and there is no unsigned mode; export 32+ characters of random material."
+            )
+        return self.feedback_token_secret.get_secret_value()
 
     def require_database_url(self) -> str:
         """Return the database URL, or raise if it was never configured."""

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -23,7 +23,8 @@ from leadquali.app.assessment_result import (
     AssessmentSucceeded,
 )
 from leadquali.app.enrichment import Enrichment
-from leadquali.app.ports import RoutingOutcome, StoredLead
+from leadquali.app.feedback import UnknownLeadError, Verdict
+from leadquali.app.ports import RecordedFeedback, RoutingOutcome, StoredLead
 from leadquali.domain.models import Action, LeadAssessment, RoutingDecision
 from leadquali.domain.tenant_config import TenantConfig, TenantNotFoundError
 from leadquali.prompts.lead import LeadSubmission
@@ -187,6 +188,71 @@ class InMemoryLeadStore:
             for event in self.routing_events
             if event.lead_id == lead_id and event.outcome is not RoutingOutcome.FAILED
         ]
+
+
+@dataclass
+class FeedbackRow:
+    """One row of the ``feedback`` table, as the in-memory store keeps it."""
+
+    tenant_id: str
+    lead_id: str
+    rater: str
+    verdict: Verdict
+    notes: str | None
+    created_at: datetime
+
+
+class InMemoryFeedbackStore:
+    """A ``FeedbackStorePort`` with the real one's uniqueness behaviour and none of its I/O.
+
+    ``(tenant_id, lead_id, rater)`` is unique, exactly as
+    ``uq_feedback_tenant_id_lead_id_rater`` makes it in #15's schema, so a prefetched link,
+    a double tap and a change of mind all land on one row. ``known_leads`` mirrors the
+    composite foreign key: a lead nobody has heard of raises ``UnknownLeadError`` here just
+    as the database raises it there, which is the path a link outliving #37's retention job
+    takes.
+    """
+
+    def __init__(
+        self, *, known_leads: Iterable[tuple[str, str]] | None = None, fail: bool = False
+    ) -> None:
+        self.rows: dict[tuple[str, str, str], FeedbackRow] = {}
+        self.known_leads = set(known_leads) if known_leads is not None else None
+        self.fail = fail
+        self.calls = 0
+
+    def record_feedback(
+        self,
+        *,
+        tenant_id: str,
+        lead_id: str,
+        rater: str,
+        verdict: Verdict,
+        notes: str | None,
+        recorded_at: datetime,
+    ) -> RecordedFeedback:
+        self.calls += 1
+        if self.fail:
+            raise FakeStoreError("store unavailable during record_feedback")
+        if self.known_leads is not None and (tenant_id, lead_id) not in self.known_leads:
+            raise UnknownLeadError(f"tenant '{tenant_id}' has no lead {lead_id}")
+
+        key = (tenant_id, lead_id, rater)
+        existing = self.rows.get(key)
+        self.rows[key] = FeedbackRow(
+            tenant_id=tenant_id,
+            lead_id=lead_id,
+            rater=rater,
+            verdict=verdict,
+            # A click with no note leaves the previous one alone, as COALESCE does.
+            notes=notes if notes is not None else (existing.notes if existing else None),
+            created_at=recorded_at,
+        )
+        return RecordedFeedback(
+            verdict=verdict,
+            created=existing is None,
+            previous_verdict=existing.verdict if existing is not None else None,
+        )
 
 
 class RecordingNotifier:

--- a/tests/integration/test_store_feedback.py
+++ b/tests/integration/test_store_feedback.py
@@ -1,0 +1,351 @@
+"""``PostgresFeedbackStore`` against a real Postgres.
+
+The in-memory double in ``tests/fakes.py`` mirrors this adapter's uniqueness behaviour, and
+that is exactly why the adapter needs its own tests: the double asserts what we *believe*
+the constraint does. These assert what the database does — that the unique index exists at
+all, that ``ON CONFLICT`` resolves against it, that the composite foreign key stops a
+verdict being filed against another tenant's lead, and that two simultaneous clicks produce
+one row rather than an ``IntegrityError`` at 9am.
+
+Skips rather than fails without ``DATABASE_URL``, like the rest of ``tests/integration``.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Iterator
+from concurrent.futures import ThreadPoolExecutor
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+from typing import Any
+
+import pytest
+from alembic import command
+from sqlalchemy import Connection, Engine, Row, create_engine, select
+from sqlalchemy.engine import URL
+from sqlalchemy.orm import Session, sessionmaker
+
+from leadquali.adapters.db_schema import Feedback
+from leadquali.adapters.seed import seed_tenant
+from leadquali.adapters.store_postgres import (
+    PostgresFeedbackStore,
+    PostgresLeadStore,
+    tenant_uuid,
+)
+from leadquali.app.feedback import UnknownLeadError, Verdict, rater_id
+from leadquali.prompts.lead import LeadSubmission
+from tests.integration.conftest import (
+    alembic_config,
+    database_url_in_environment,
+    temporary_database,
+)
+
+pytestmark = pytest.mark.integration
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+TENANT_A = "feedback-tenant-a"
+TENANT_B = "feedback-tenant-b"
+NOW = datetime(2026, 9, 3, 9, 0, tzinfo=UTC)
+RATER = rater_id("sales@example.com")
+OTHER_RATER = rater_id("escalations@example.com")
+
+
+@pytest.fixture(scope="session")
+def feedback_database(_database_url: URL) -> Iterator[URL]:
+    """A migrated throwaway database of this module's own."""
+    name = f"{_database_url.database}_feedback_test"
+    with temporary_database(_database_url, name) as url, database_url_in_environment(url):
+        command.upgrade(alembic_config(), "head")
+        yield url
+
+
+@pytest.fixture(scope="session")
+def feedback_engine(feedback_database: URL) -> Iterator[Engine]:
+    """A normally-pooled engine: one test needs two writers racing each other."""
+    engine = create_engine(feedback_database)
+    try:
+        yield engine
+    finally:
+        engine.dispose()
+
+
+@pytest.fixture(scope="session")
+def seeded_tenants(feedback_engine: Engine) -> tuple[str, str]:
+    document: dict[str, Any] = json.loads(
+        (REPO_ROOT / "tenants" / "default.json").read_text(encoding="utf-8")
+    )
+    with feedback_engine.begin() as connection:
+        for slug in (TENANT_A, TENANT_B):
+            seed_tenant(connection, {**document, "tenant_id": slug, "name": f"Tenant {slug}"})
+    return (TENANT_A, TENANT_B)
+
+
+@pytest.fixture
+def connection(feedback_engine: Engine) -> Iterator[Connection]:
+    with feedback_engine.connect() as conn:
+        transaction = conn.begin()
+        try:
+            yield conn
+        finally:
+            transaction.rollback()
+
+
+@pytest.fixture
+def sessions(connection: Connection) -> sessionmaker[Session]:
+    return sessionmaker(bind=connection, join_transaction_mode="create_savepoint")
+
+
+@pytest.fixture
+def store(
+    sessions: sessionmaker[Session], seeded_tenants: tuple[str, str]
+) -> PostgresFeedbackStore:
+    del seeded_tenants  # ordering only: a lead needs its tenant to exist first.
+    return PostgresFeedbackStore(sessions)
+
+
+@pytest.fixture
+def lead_id(sessions: sessionmaker[Session], seeded_tenants: tuple[str, str]) -> str:
+    del seeded_tenants
+    return (
+        PostgresLeadStore(sessions)
+        .upsert_lead(
+            tenant_id=TENANT_A,
+            submission_id="feedback-subject-1",
+            submission=LeadSubmission(full_name="Dana", email="dana@example.com"),
+            source="web_form",
+            received_at=NOW,
+        )
+        .lead_id
+    )
+
+
+def rows(connection: Connection, lead: str) -> list[Row[Any]]:
+    return list(connection.execute(select(Feedback).where(Feedback.lead_id == uuid.UUID(lead))))
+
+
+# --------------------------------------------------------------------------- the write
+
+
+def test_a_verdict_becomes_a_row_with_its_tenant_lead_rater_and_notes(
+    store: PostgresFeedbackStore, connection: Connection, lead_id: str
+) -> None:
+    recorded = store.record_feedback(
+        tenant_id=TENANT_A,
+        lead_id=lead_id,
+        rater=RATER,
+        verdict=Verdict.GOOD,
+        notes="Signed within the week.",
+        recorded_at=NOW,
+    )
+
+    assert recorded.created is True
+    assert recorded.previous_verdict is None
+    (row,) = rows(connection, lead_id)
+    assert row.tenant_id == tenant_uuid(TENANT_A), "the row is filed under the right tenant"
+    assert str(row.lead_id) == lead_id
+    assert row.rater == RATER
+    assert row.verdict == "good"
+    assert row.notes == "Signed within the week."
+    assert row.created_at == NOW
+
+
+def test_clicking_twice_updates_one_row(
+    store: PostgresFeedbackStore, connection: Connection, lead_id: str
+) -> None:
+    """The acceptance criterion, against the constraint that actually enforces it."""
+    for _ in range(3):
+        store.record_feedback(
+            tenant_id=TENANT_A,
+            lead_id=lead_id,
+            rater=RATER,
+            verdict=Verdict.GOOD,
+            notes=None,
+            recorded_at=NOW,
+        )
+    assert len(rows(connection, lead_id)) == 1
+
+
+def test_a_changed_verdict_replaces_the_old_one_and_reports_it(
+    store: PostgresFeedbackStore, connection: Connection, lead_id: str
+) -> None:
+    store.record_feedback(
+        tenant_id=TENANT_A,
+        lead_id=lead_id,
+        rater=RATER,
+        verdict=Verdict.GOOD,
+        notes="Looked promising.",
+        recorded_at=NOW,
+    )
+    later = NOW + timedelta(days=3)
+    recorded = store.record_feedback(
+        tenant_id=TENANT_A,
+        lead_id=lead_id,
+        rater=RATER,
+        verdict=Verdict.BAD,
+        notes=None,
+        recorded_at=later,
+    )
+
+    assert recorded.created is False
+    assert recorded.previous_verdict is Verdict.GOOD
+    assert recorded.changed is True
+    (row,) = rows(connection, lead_id)
+    assert row.verdict == "bad"
+    assert row.created_at == later, "the row is the current verdict, so it carries its time"
+    assert row.notes == "Looked promising.", "a click with no note must not erase one"
+
+
+def test_a_new_note_replaces_the_old_note(
+    store: PostgresFeedbackStore, connection: Connection, lead_id: str
+) -> None:
+    for note in ("First thought.", "Second thought."):
+        store.record_feedback(
+            tenant_id=TENANT_A,
+            lead_id=lead_id,
+            rater=RATER,
+            verdict=Verdict.BAD,
+            notes=note,
+            recorded_at=NOW,
+        )
+    (row,) = rows(connection, lead_id)
+    assert row.notes == "Second thought."
+
+
+def test_two_raters_on_one_lead_are_two_rows(
+    store: PostgresFeedbackStore, connection: Connection, lead_id: str
+) -> None:
+    """Uniqueness is per rater: two people disagreeing is data, not a duplicate."""
+    for rater, verdict in ((RATER, Verdict.GOOD), (OTHER_RATER, Verdict.BAD)):
+        store.record_feedback(
+            tenant_id=TENANT_A,
+            lead_id=lead_id,
+            rater=rater,
+            verdict=verdict,
+            notes=None,
+            recorded_at=NOW,
+        )
+    assert len(rows(connection, lead_id)) == 2
+
+
+@pytest.mark.parametrize("verdict", list(Verdict))
+def test_every_verdict_the_domain_defines_is_one_the_schema_accepts(
+    store: PostgresFeedbackStore, lead_id: str, verdict: Verdict
+) -> None:
+    """``Verdict`` and the ``verdict_known`` CHECK constraint must not drift apart."""
+    store.record_feedback(
+        tenant_id=TENANT_A,
+        lead_id=lead_id,
+        rater=RATER,
+        verdict=verdict,
+        notes=None,
+        recorded_at=NOW,
+    )
+
+
+# ------------------------------------------------------------------- tenant isolation
+
+
+def test_another_tenant_cannot_file_a_verdict_against_this_lead(
+    store: PostgresFeedbackStore, lead_id: str
+) -> None:
+    """Invariant 4, enforced by the composite foreign key rather than by good intentions."""
+    with pytest.raises(UnknownLeadError):
+        store.record_feedback(
+            tenant_id=TENANT_B,
+            lead_id=lead_id,
+            rater=RATER,
+            verdict=Verdict.GOOD,
+            notes=None,
+            recorded_at=NOW,
+        )
+
+
+def test_a_lead_that_does_not_exist_raises_unknown_lead(store: PostgresFeedbackStore) -> None:
+    """The path a link takes once #37's retention job has deleted the lead."""
+    with pytest.raises(UnknownLeadError):
+        store.record_feedback(
+            tenant_id=TENANT_A,
+            lead_id=str(uuid.uuid4()),
+            rater=RATER,
+            verdict=Verdict.BAD,
+            notes=None,
+            recorded_at=NOW,
+        )
+
+
+@pytest.mark.parametrize(
+    ("tenant_id", "lead", "match"),
+    [("not a tenant!", "irrelevant", "tenant"), (TENANT_A, "not-a-uuid", "lead id")],
+)
+def test_an_unusable_identifier_is_refused_before_the_query(
+    store: PostgresFeedbackStore, tenant_id: str, lead: str, match: str
+) -> None:
+    with pytest.raises(ValueError, match=match):
+        store.record_feedback(
+            tenant_id=tenant_id,
+            lead_id=lead,
+            rater=RATER,
+            verdict=Verdict.GOOD,
+            notes=None,
+            recorded_at=NOW,
+        )
+
+
+def test_a_blank_rater_is_refused(store: PostgresFeedbackStore, lead_id: str) -> None:
+    with pytest.raises(ValueError, match="rater"):
+        store.record_feedback(
+            tenant_id=TENANT_A,
+            lead_id=lead_id,
+            rater="",
+            verdict=Verdict.GOOD,
+            notes=None,
+            recorded_at=NOW,
+        )
+
+
+# ------------------------------------------------------------------------ concurrency
+
+
+def test_two_simultaneous_clicks_produce_one_row_and_no_error(
+    feedback_engine: Engine, seeded_tenants: tuple[str, str]
+) -> None:
+    """A double tap on a phone, or a client that retries a POST. Both must survive.
+
+    Committing writers, so this one cannot use the rolled-back connection fixture; it
+    cleans up after itself instead.
+    """
+    del seeded_tenants
+    sessions = sessionmaker(bind=feedback_engine)
+    lead = PostgresLeadStore(sessions).upsert_lead(
+        tenant_id=TENANT_A,
+        submission_id=f"feedback-race-{uuid.uuid4()}",
+        submission=LeadSubmission(full_name="Race"),
+        source="web_form",
+        received_at=NOW,
+    )
+    store = PostgresFeedbackStore(sessions)
+
+    def click() -> None:
+        store.record_feedback(
+            tenant_id=TENANT_A,
+            lead_id=lead.lead_id,
+            rater=RATER,
+            verdict=Verdict.GOOD,
+            notes=None,
+            recorded_at=NOW,
+        )
+
+    try:
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            for future in [pool.submit(click), pool.submit(click)]:
+                future.result()  # raises here if either writer hit a uniqueness error
+
+        with feedback_engine.connect() as connection:
+            assert len(rows(connection, lead.lead_id)) == 1
+    finally:
+        with feedback_engine.begin() as connection:
+            connection.exec_driver_sql(
+                "DELETE FROM leads WHERE id = %s", (uuid.UUID(lead.lead_id),)
+            )

--- a/tests/unit/test_api_feedback.py
+++ b/tests/unit/test_api_feedback.py
@@ -1,0 +1,345 @@
+"""The feedback endpoint, from a mail client's point of view.
+
+Three populations reach this URL and they must be told apart: a sales rep on a phone, a
+security scanner that follows every link in every message before the rep sees it, and
+somebody who found a link and would like to write whatever they want into the training set.
+The tests are organised that way.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi.testclient import TestClient
+
+# starlette's TestClient is built on httpx2 in this environment, and its Response is a
+# different class from httpx 0.28's; take the type from the client that produces it.
+from httpx2 import Response
+
+from leadquali.api.feedback import (
+    CONFIRM_FIELD,
+    FEEDBACK_ROUTE,
+    MAX_FORM_BYTES,
+    NOTES_FIELD,
+    FeedbackDeps,
+    confirmation_code,
+)
+from leadquali.api.main import create_app
+from leadquali.app.feedback import (
+    MAX_NOTES_CHARS,
+    MIN_TOKEN_SECRET_CHARS,
+    TOKEN_VERSION,
+    Verdict,
+    mint_token,
+    rater_id,
+)
+from tests.fakes import FakeClock, FeedbackRow, InMemoryFeedbackStore
+
+SECRET = b"f" * MIN_TOKEN_SECRET_CHARS
+OTHER_SECRET = b"g" * MIN_TOKEN_SECRET_CHARS
+NOW = datetime(2026, 9, 3, 9, 0, tzinfo=UTC)
+TENANT = "default"
+LEAD = "8f14e45f-ceea-467a-9575-1b1e0a4d3c11"
+OTHER_LEAD = "11111111-2222-3333-4444-555555555555"
+RATER = rater_id("sales@northwind.example")
+
+
+class Harness:
+    """An app with the feedback routes wired to in-memory doubles."""
+
+    def __init__(self, *, store: InMemoryFeedbackStore | None = None) -> None:
+        self.store = store if store is not None else InMemoryFeedbackStore()
+        self.deps = FeedbackDeps(
+            store=self.store,
+            token_secret=SECRET,
+            clock=FakeClock(start=NOW, step_ms=0),
+        )
+        self.client = TestClient(create_app(feedback_deps=self.deps))
+
+    def token(
+        self,
+        *,
+        verdict: Verdict = Verdict.GOOD,
+        lead_id: str = LEAD,
+        tenant_id: str = TENANT,
+        secret: bytes = SECRET,
+        expires_at: datetime | None = None,
+    ) -> str:
+        return mint_token(
+            secret=secret,
+            tenant_id=tenant_id,
+            lead_id=lead_id,
+            verdict=verdict,
+            rater=RATER,
+            expires_at=expires_at if expires_at is not None else NOW + timedelta(days=30),
+        )
+
+    def url(self, token: str) -> str:
+        return f"/feedback/{token}"
+
+    def confirm(self, token: str, **fields: str) -> Response:
+        form = {CONFIRM_FIELD: confirmation_code(secret=SECRET, token=token)}
+        form.update(fields)
+        return self.client.post(self.url(token), data=form)
+
+    @property
+    def rows(self) -> list[FeedbackRow]:
+        return list(self.store.rows.values())
+
+
+@pytest.fixture
+def harness() -> Harness:
+    return Harness()
+
+
+# --------------------------------------------------------------------------- the rep
+
+
+def test_the_link_lands_on_a_human_page_not_json(harness: Harness) -> None:
+    response = harness.client.get(harness.url(harness.token()))
+
+    assert response.status_code == 200
+    assert response.headers["content-type"].startswith("text/html")
+    assert "good lead" in response.text
+    assert "<form" in response.text and 'method="post"' in response.text
+    assert "{" not in response.text[:1], "a rep opens this in a browser, not a JSON viewer"
+
+
+def test_confirming_writes_exactly_one_row_for_the_right_lead_and_tenant(
+    harness: Harness,
+) -> None:
+    token = harness.token(verdict=Verdict.BAD)
+    response = harness.confirm(token)
+
+    assert response.status_code == 200
+    assert "Recorded" in response.text
+    assert len(harness.store.rows) == 1
+    row = harness.rows[0]
+    assert (row.tenant_id, row.lead_id, row.rater) == (TENANT, LEAD, RATER)
+    assert row.verdict is Verdict.BAD
+    assert row.created_at == NOW
+
+
+def test_the_notes_box_is_saved_and_shown_as_saved(harness: Harness) -> None:
+    token = harness.token()
+    response = harness.confirm(token, **{NOTES_FIELD: "Wrong industry, right size."})
+
+    assert "note was saved" in response.text
+    assert harness.rows[0].notes == "Wrong industry, right size."
+
+
+def test_clicking_the_same_link_twice_updates_rather_than_duplicates(harness: Harness) -> None:
+    token = harness.token()
+    harness.confirm(token)
+    second = harness.confirm(token)
+
+    assert len(harness.store.rows) == 1
+    assert "Still recorded" in second.text
+
+
+def test_a_rep_can_change_their_mind(harness: Harness) -> None:
+    harness.confirm(harness.token(verdict=Verdict.GOOD))
+    response = harness.confirm(harness.token(verdict=Verdict.BAD))
+
+    assert len(harness.store.rows) == 1
+    assert harness.rows[0].verdict is Verdict.BAD
+    assert "Changed from good lead to" in response.text
+
+
+def test_a_second_click_without_a_note_does_not_erase_the_first_one(harness: Harness) -> None:
+    token = harness.token()
+    harness.confirm(token, **{NOTES_FIELD: "Budget signed off."})
+    harness.confirm(token)
+    assert harness.rows[0].notes == "Budget signed off."
+
+
+def test_the_thank_you_page_offers_the_opposite_verdict_in_one_tap(harness: Harness) -> None:
+    """The change-of-mind path, and it must be a POST bound to the same lead and rater."""
+    response = harness.confirm(harness.token(verdict=Verdict.GOOD))
+    assert "Actually, this was a bad lead" in response.text
+
+    action = response.text.split('action="', 1)[1].split('"', 1)[0]
+    code = response.text.split(f'name="{CONFIRM_FIELD}" value="', 1)[1].split('"', 1)[0]
+    changed = harness.client.post(action, data={CONFIRM_FIELD: code})
+
+    assert changed.status_code == 200
+    assert len(harness.store.rows) == 1
+    assert harness.rows[0].verdict is Verdict.BAD
+
+
+def test_an_enormous_note_is_truncated_rather_than_refused(harness: Harness) -> None:
+    response = harness.confirm(harness.token(), **{NOTES_FIELD: "x" * (MAX_NOTES_CHARS * 2)})
+    assert response.status_code == 200
+    assert len(harness.rows[0].notes or "") == MAX_NOTES_CHARS
+
+
+# ------------------------------------------------------------------------ the scanner
+
+
+def test_a_scanner_prefetching_the_link_records_nothing(harness: Harness) -> None:
+    """Outlook Safe Links, Proofpoint, Gmail: they GET every URL before a human sees it."""
+    token = harness.token()
+    for _ in range(5):
+        assert harness.client.get(harness.url(token)).status_code == 200
+
+    assert harness.store.calls == 0
+    assert harness.store.rows == {}
+
+
+def test_a_blind_post_without_the_page_records_nothing(harness: Harness) -> None:
+    """The rarer scanner that POSTs a URL it has never rendered."""
+    token = harness.token()
+    response = harness.client.post(harness.url(token))
+
+    assert response.status_code == 200
+    assert "Confirm" in response.text, "it gets the button, not a write"
+    assert harness.store.rows == {}
+
+
+def test_a_post_with_a_forged_confirmation_records_nothing(harness: Harness) -> None:
+    token = harness.token()
+    response = harness.client.post(harness.url(token), data={CONFIRM_FIELD: "0" * 32})
+    assert response.status_code == 200
+    assert harness.store.rows == {}
+
+
+def test_a_confirmation_code_from_another_token_does_not_work(harness: Harness) -> None:
+    good = harness.token(verdict=Verdict.GOOD)
+    bad = harness.token(verdict=Verdict.BAD)
+    response = harness.client.post(
+        harness.url(bad), data={CONFIRM_FIELD: confirmation_code(secret=SECRET, token=good)}
+    )
+    assert harness.store.rows == {}
+    assert "Confirm" in response.text
+
+
+def test_an_oversized_body_cannot_confirm_anything(harness: Harness) -> None:
+    token = harness.token()
+    response = harness.client.post(
+        harness.url(token),
+        data={
+            CONFIRM_FIELD: confirmation_code(secret=SECRET, token=token),
+            NOTES_FIELD: "x" * MAX_FORM_BYTES,
+        },
+    )
+    assert response.status_code == 200
+    assert harness.store.rows == {}
+
+
+def test_the_pages_are_never_cached_or_indexed(harness: Harness) -> None:
+    """A single-purpose capability URL must not sit in a proxy cache or a search index."""
+    response = harness.client.get(harness.url(harness.token()))
+    assert "no-store" in response.headers["cache-control"]
+    assert "noindex" in response.headers["x-robots-tag"]
+    assert response.headers["referrer-policy"] == "no-referrer"
+
+
+# ---------------------------------------------------------------------- the attacker
+
+
+@pytest.mark.parametrize("method", ["get", "post"])
+def test_a_forged_token_is_refused_and_writes_nothing(harness: Harness, method: str) -> None:
+    token = harness.token(secret=OTHER_SECRET)
+    response = getattr(harness.client, method)(harness.url(token))
+
+    assert response.status_code == 400
+    assert "not valid" in response.text
+    assert harness.store.rows == {}
+
+
+def test_an_expired_token_is_refused_with_an_explanation(harness: Harness) -> None:
+    token = harness.token(expires_at=NOW - timedelta(seconds=1))
+    response = harness.client.get(harness.url(token))
+
+    assert response.status_code == 410
+    assert "expired" in response.text
+    assert harness.store.rows == {}
+
+
+def test_a_token_edited_to_name_another_lead_is_refused(harness: Harness) -> None:
+    """The lead id is inside the signature, so this is the only way to try it."""
+    valid = harness.token()
+    other = harness.token(lead_id=OTHER_LEAD)
+    spliced = f"{TOKEN_VERSION}.{other.split('.')[1]}.{valid.split('.')[2]}"
+
+    assert harness.client.get(harness.url(spliced)).status_code == 400
+    assert harness.confirm(spliced).status_code == 400
+    assert harness.store.rows == {}
+
+
+def test_a_token_edited_to_flip_the_verdict_is_refused(harness: Harness) -> None:
+    good = harness.token(verdict=Verdict.GOOD)
+    bad = harness.token(verdict=Verdict.BAD)
+    spliced = f"{TOKEN_VERSION}.{bad.split('.')[1]}.{good.split('.')[2]}"
+
+    assert harness.client.get(harness.url(spliced)).status_code == 400
+    assert harness.store.rows == {}
+
+
+@pytest.mark.parametrize("token", ["nonsense", "fb1.aaa", "fb9.aaa.bbb", "." * 10])
+def test_a_malformed_token_is_refused(harness: Harness, token: str) -> None:
+    assert harness.client.get(f"/feedback/{token}").status_code == 400
+
+
+# ------------------------------------------------------------------- store failures
+
+
+def test_a_lead_that_no_longer_exists_says_so_and_does_not_thank_anyone() -> None:
+    """#37's retention job deletes leads; the link in the mailbox outlives the row."""
+    harness = Harness(store=InMemoryFeedbackStore(known_leads=[(TENANT, OTHER_LEAD)]))
+    response = harness.confirm(harness.token())
+
+    assert response.status_code == 404
+    assert "could not find that lead" in response.text
+    assert "Thank" not in response.text
+
+
+def test_a_broken_store_is_not_reported_as_success() -> None:
+    """The rep must be able to try again: a lost verdict is unrecoverable signal."""
+    harness = Harness(store=InMemoryFeedbackStore(fail=True))
+    response = harness.confirm(harness.token())
+
+    assert response.status_code == 503
+    assert "not saved" in response.text
+    assert "Recorded" not in response.text
+
+
+# --------------------------------------------------------------------------- wiring
+
+
+def test_the_routes_are_registered_on_the_one_app() -> None:
+    """Extending the ingest app, not standing up a second one."""
+    routes = {getattr(route, "path", None) for route in create_app().routes}
+    assert FEEDBACK_ROUTE in routes
+    assert "/leads" in routes
+
+
+def test_a_short_secret_is_refused_when_the_endpoint_is_wired() -> None:
+    with pytest.raises(ValueError, match="at least"):
+        FeedbackDeps(store=InMemoryFeedbackStore(), token_secret=b"short", clock=FakeClock())
+
+
+def test_building_the_app_touches_no_database_and_needs_no_secret() -> None:
+    """Cold start imports the module; nothing may be resolved until a request arrives."""
+    assert create_app() is not None
+
+
+# ------------------------------------------------------------------------------ logs
+
+
+def test_the_click_is_logged_without_an_address_or_the_note(
+    harness: Harness, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Invariant 5. The note is a rep writing freely about a person; it never leaves the row."""
+    caplog.set_level(logging.DEBUG, logger="leadquali")
+    harness.confirm(harness.token(), **{NOTES_FIELD: "Spoke to dana@northwind.example already"})
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert logged
+    assert "@" not in logged
+    assert "dana@northwind.example" not in logged
+    assert "Spoke to" not in logged
+    assert LEAD in logged
+    assert RATER in logged

--- a/tests/unit/test_feedback_token.py
+++ b/tests/unit/test_feedback_token.py
@@ -1,0 +1,260 @@
+"""The feedback token: what it authorises, and everything it must refuse.
+
+The token is the only thing standing between a public URL and the table the golden set is
+built from, so these tests are written as attacks rather than as a happy path with a couple
+of negatives bolted on: take a valid link and try to make it write something else.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from leadquali.app.feedback import (
+    MIN_TOKEN_SECRET_CHARS,
+    TOKEN_VERSION,
+    FeedbackClaim,
+    TokenAccepted,
+    TokenFailure,
+    TokenRejected,
+    Verdict,
+    load_token_secret,
+    mint_token,
+    rater_id,
+    tenant_key,
+    verify_token,
+)
+
+SECRET = b"a" * MIN_TOKEN_SECRET_CHARS
+OTHER_SECRET = b"b" * MIN_TOKEN_SECRET_CHARS
+NOW = datetime(2026, 9, 3, 9, 0, tzinfo=UTC)
+LEAD = "8f14e45f-ceea-467a-9575-1b1e0a4d3c11"
+OTHER_LEAD = "11111111-2222-3333-4444-555555555555"
+RATER = rater_id("sales@example.com")
+
+
+def token_for(
+    *,
+    verdict: Verdict = Verdict.GOOD,
+    tenant_id: str = "default",
+    lead_id: str = LEAD,
+    rater: str = RATER,
+    expires_at: datetime | None = None,
+    secret: bytes = SECRET,
+) -> str:
+    return mint_token(
+        secret=secret,
+        tenant_id=tenant_id,
+        lead_id=lead_id,
+        verdict=verdict,
+        rater=rater,
+        expires_at=expires_at if expires_at is not None else NOW + timedelta(days=30),
+    )
+
+
+def claim_of(token: str) -> FeedbackClaim:
+    result = verify_token(secret=SECRET, token=token, now=NOW)
+    assert isinstance(result, TokenAccepted)
+    return result.claim
+
+
+def failure_of(token: str, *, now: datetime = NOW, secret: bytes = SECRET) -> TokenFailure:
+    result = verify_token(secret=secret, token=token, now=now)
+    assert isinstance(result, TokenRejected), "this token was supposed to be refused"
+    return result.failure
+
+
+# ------------------------------------------------------------------------ the happy path
+
+
+def test_a_minted_token_verifies_and_carries_its_whole_claim() -> None:
+    claim = claim_of(token_for(verdict=Verdict.BAD))
+    assert claim.tenant_id == "default"
+    assert claim.lead_id == LEAD
+    assert claim.verdict is Verdict.BAD
+    assert claim.rater == RATER
+    assert claim.expires_at == NOW + timedelta(days=30)
+
+
+def test_the_token_is_one_url_safe_path_segment() -> None:
+    """It goes in a path, in an email, on a phone. Nothing to percent-encode, no padding."""
+    token = token_for()
+    assert token.startswith(f"{TOKEN_VERSION}.")
+    assert set(token) <= set("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_.")
+    assert len(token) < 400, "a link this long gets broken across lines by mail clients"
+
+
+def test_each_verdict_gets_a_different_token() -> None:
+    assert token_for(verdict=Verdict.GOOD) != token_for(verdict=Verdict.BAD)
+
+
+# --------------------------------------------------------------------------- forgery
+
+
+def test_a_token_signed_with_another_key_is_refused() -> None:
+    assert failure_of(token_for(secret=OTHER_SECRET)) is TokenFailure.BAD_SIGNATURE
+
+
+def test_swapping_the_lead_id_inside_a_valid_token_is_refused() -> None:
+    """The lead id is signed, so a leaked link cannot be aimed at somebody else's lead."""
+    valid = token_for()
+    other = token_for(lead_id=OTHER_LEAD)
+    _, other_claim, _ = other.split(".")
+    _, _, valid_mac = valid.split(".")
+    assert failure_of(f"{TOKEN_VERSION}.{other_claim}.{valid_mac}") is TokenFailure.BAD_SIGNATURE
+
+
+def test_swapping_the_verdict_inside_a_valid_token_is_refused() -> None:
+    """One token, one verdict: a 'good lead' link cannot be turned into a 'bad lead' one."""
+    good = token_for(verdict=Verdict.GOOD)
+    bad = token_for(verdict=Verdict.BAD)
+    _, bad_claim, _ = bad.split(".")
+    _, _, good_mac = good.split(".")
+    assert failure_of(f"{TOKEN_VERSION}.{bad_claim}.{good_mac}") is TokenFailure.BAD_SIGNATURE
+
+
+def test_a_token_cannot_be_moved_sideways_onto_another_tenant() -> None:
+    """Keys are derived per tenant, so one tenant's MAC does not authorise another's claim."""
+    assert tenant_key(SECRET, "acme") != tenant_key(SECRET, "other")
+    acme = token_for(tenant_id="acme")
+    other = token_for(tenant_id="other")
+    _, other_claim, _ = other.split(".")
+    _, _, acme_mac = acme.split(".")
+    assert failure_of(f"{TOKEN_VERSION}.{other_claim}.{acme_mac}") is TokenFailure.BAD_SIGNATURE
+
+
+def test_truncating_the_mac_is_refused() -> None:
+    version, claim, mac = token_for().split(".")
+    assert failure_of(f"{version}.{claim}.{mac[:-4]}") is TokenFailure.BAD_SIGNATURE
+
+
+@pytest.mark.parametrize(
+    "token",
+    [
+        "",
+        "not-a-token",
+        "fb1.onlytwo",
+        "fb2.abc.def",
+        "fb1..abc",
+        "fb1.abc.",
+        "fb1.!!!!.abc",
+        "fb1." + "A" * 2000 + ".abc",
+    ],
+    ids=[
+        "empty",
+        "no-parts",
+        "two-parts",
+        "wrong-version",
+        "empty-claim",
+        "empty-mac",
+        "undecodable",
+        "oversized",
+    ],
+)
+def test_a_token_that_is_not_one_is_refused_as_malformed(token: str) -> None:
+    assert failure_of(token) is TokenFailure.MALFORMED
+
+
+def test_an_unknown_verdict_is_malformed_not_a_signature_failure() -> None:
+    """A verdict outside the schema's CHECK constraint never reaches the database."""
+    from leadquali.app.feedback import _b64encode
+
+    claim = "\n".join(
+        (
+            "LEADQUALI-FEEDBACK-HMAC-SHA256",
+            TOKEN_VERSION,
+            "default",
+            LEAD,
+            "excellent",
+            RATER,
+            str(int((NOW + timedelta(days=1)).timestamp())),
+        )
+    )
+    assert (
+        failure_of(f"{TOKEN_VERSION}.{_b64encode(claim.encode())}.zzzz") is TokenFailure.MALFORMED
+    )
+
+
+# ---------------------------------------------------------------------------- expiry
+
+
+def test_an_expired_token_is_refused() -> None:
+    token = token_for(expires_at=NOW + timedelta(minutes=1))
+    assert failure_of(token, now=NOW + timedelta(minutes=2)) is TokenFailure.EXPIRED
+
+
+def test_expiry_is_exclusive_at_the_instant_it_names() -> None:
+    expires = NOW + timedelta(minutes=1)
+    assert failure_of(token_for(expires_at=expires), now=expires) is TokenFailure.EXPIRED
+    assert isinstance(
+        verify_token(
+            secret=SECRET, token=token_for(expires_at=expires), now=expires - timedelta(seconds=1)
+        ),
+        TokenAccepted,
+    )
+
+
+def test_a_forged_token_never_reports_expiry_first() -> None:
+    """Signature before expiry: a forged claim must not become an oracle over lead ids."""
+    forged = token_for(secret=OTHER_SECRET, expires_at=NOW - timedelta(days=1))
+    assert failure_of(forged) is TokenFailure.BAD_SIGNATURE
+
+
+# ------------------------------------------------------------------ wiring mistakes
+
+
+def test_a_short_secret_is_refused_at_mint_time() -> None:
+    with pytest.raises(ValueError, match="at least"):
+        token_for(secret=b"too-short")
+
+
+def test_a_naive_expiry_is_refused() -> None:
+    with pytest.raises(ValueError, match="timezone-aware"):
+        mint_token(
+            secret=SECRET,
+            tenant_id="default",
+            lead_id=LEAD,
+            verdict=Verdict.GOOD,
+            rater=RATER,
+            expires_at=datetime(2026, 10, 1),
+        )
+
+
+@pytest.mark.parametrize("blank", ["tenant_id", "lead_id", "rater"])
+def test_a_blank_identity_field_is_refused(blank: str) -> None:
+    fields: dict[str, str] = {"tenant_id": "default", "lead_id": LEAD, "rater": RATER}
+    fields[blank] = ""
+    with pytest.raises(ValueError, match="non-empty"):
+        mint_token(secret=SECRET, verdict=Verdict.GOOD, expires_at=NOW, **fields)
+
+
+def test_the_configured_secret_is_validated_when_it_is_loaded() -> None:
+    assert load_token_secret("x" * MIN_TOKEN_SECRET_CHARS) == b"x" * MIN_TOKEN_SECRET_CHARS
+    with pytest.raises(ValueError, match="at least"):
+        load_token_secret("short")
+
+
+# -------------------------------------------------------------------------- rater ids
+
+
+def test_a_rater_id_is_stable_and_carries_no_address() -> None:
+    """Invariant 5, and the reason a second click updates rather than inserts."""
+    assert rater_id("Sales@Example.com ") == rater_id("sales@example.com")
+    assert "example.com" not in rater_id("sales@example.com")
+    assert "@" not in rater_id("sales@example.com")
+
+
+def test_different_destinations_get_different_rater_ids() -> None:
+    assert rater_id("sales@example.com") != rater_id("escalations@example.com")
+
+
+def test_a_blank_destination_has_no_rater_id() -> None:
+    with pytest.raises(ValueError, match="blank"):
+        rater_id("   ")
+
+
+def test_the_opposite_verdict_is_what_a_change_of_mind_wants() -> None:
+    assert Verdict.GOOD.opposite is Verdict.BAD
+    assert Verdict.BAD.opposite is Verdict.GOOD
+    assert Verdict.UNSURE.opposite is Verdict.UNSURE

--- a/tests/unit/test_layering.py
+++ b/tests/unit/test_layering.py
@@ -63,3 +63,21 @@ def test_domain_and_app_import_no_third_party_sdk() -> None:
             continue
         leaked = forbidden & imported_modules(path)
         assert not leaked, f"{relative} imports {sorted(leaked)}"
+
+
+def test_only_the_ses_adapter_imports_boto3() -> None:
+    """``CLAUDE.md``: one file per external system, and ``boto3`` belongs to that one.
+
+    Stated separately from the rule above because it binds the *adapters* too: SES is
+    reached from ``adapters/notify_ses.py`` and nowhere else, so swapping email for a Slack
+    notifier is a wiring change and an operator can find every AWS call by opening one file.
+    """
+    owner = "adapters/notify_ses.py"
+    assert "boto3" in imported_modules(SRC / owner), "the adapter is supposed to own the SDK"
+    for path in python_sources():
+        relative = path.relative_to(SRC).as_posix()
+        if relative == owner:
+            continue
+        assert "boto3" not in imported_modules(path), (
+            f"{relative} imports boto3; AWS belongs in {owner} alone"
+        )

--- a/tests/unit/test_lead_email.py
+++ b/tests/unit/test_lead_email.py
@@ -1,0 +1,316 @@
+"""The routing email: what a rep must be able to see, and what must never reach them.
+
+Never an assertion on model prose — the reasoning is passed through, so what is asserted is
+that it *is* passed through, not what it says. Everything else here is about the five
+seconds a rep spends deciding whether to call, and about the fact that both the lead's words
+and the model's words are untrusted text going into HTML.
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from leadquali.app.feedback import Verdict
+from leadquali.app.lead_email import (
+    MAX_FIELD_CHARS,
+    FeedbackLink,
+    render_routing_email,
+)
+from leadquali.domain.models import (
+    Action,
+    DimensionScores,
+    EscalationReason,
+    ExtractedFacts,
+    LeadAssessment,
+    RoutingDecision,
+    Tier,
+)
+from leadquali.domain.routing import LOW_CONFIDENCE_NOTE, SYSTEM_FAILURE_BANNER, system_failure
+from leadquali.prompts.lead import LeadSubmission
+
+LINKS = (
+    FeedbackLink(verdict=Verdict.GOOD, url="https://leads.example.com/feedback/fb1.good.mac"),
+    FeedbackLink(verdict=Verdict.BAD, url="https://leads.example.com/feedback/fb1.bad.mac"),
+)
+
+
+def submission(**overrides: object) -> LeadSubmission:
+    fields: dict[str, object] = {
+        "full_name": "Dana Whitfield",
+        "email": "dana@northwind.example",
+        "company": "Northwind Logistics",
+        "role": "VP Operations",
+        "phone": "+44 20 7946 0000",
+        "website": "https://northwind.example",
+        "message": "We are replacing our routing spreadsheet before the Q4 peak.",
+    }
+    fields.update(overrides)
+    return LeadSubmission(**fields)  # type: ignore[arg-type]
+
+
+def assessment(**overrides: object) -> LeadAssessment:
+    fields: dict[str, object] = {
+        "dimension_scores": DimensionScores(
+            icp_fit=27, intent=22, authority=12, urgency=13, budget_signal=11
+        ),
+        "extracted": ExtractedFacts(
+            company_name="Northwind Logistics",
+            industry="freight",
+            company_size_estimate="200-500",
+            role_seniority="vp",
+            stated_use_case="replace a routing spreadsheet",
+            stated_timeline="before Q4",
+        ),
+        "reasoning": "States a deadline and owns the budget line.",
+        "confidence": 0.86,
+        "missing_information": ["current tooling spend"],
+        "suggested_first_question": "What breaks first when the spreadsheet is wrong?",
+        "spam_or_test_submission": False,
+    }
+    fields.update(overrides)
+    return LeadAssessment(**fields)  # type: ignore[arg-type]
+
+
+HOT = RoutingDecision(
+    tier=Tier.HOT, action=Action.EMAIL_SALES, total_score=87.0, note="scored 87.00/100 — hot"
+)
+
+
+# --------------------------------------------------------------------- the hot-lead email
+
+
+def test_a_hot_lead_renders_both_parts_with_everything_a_rep_needs() -> None:
+    email = render_routing_email(
+        submission=submission(),
+        decision=HOT,
+        assessment=assessment(),
+        links=LINKS,
+        lead_reference="8f14e45f",
+    )
+    for part in (email.text_body, email.html_body):
+        assert "HOT" in part or "hot" in part
+        assert "87" in part
+        assert "Northwind Logistics" in part
+        assert "Dana Whitfield" in part
+        assert "dana@northwind.example" in part
+        assert "VP Operations" in part
+        # the model's reasoning, its suggested opener, and what it could not find
+        assert "States a deadline and owns the budget line." in part
+        assert "What breaks first when the spreadsheet is wrong?" in part
+        assert "current tooling spend" in part
+        # every dimension, with its own maximum
+        for label in ("icp", "intent", "authority", "urgency", "budget"):
+            assert label in part
+        assert "8f14e45f" in part
+
+
+def test_the_subject_line_triages_the_inbox_on_its_own() -> None:
+    email = render_routing_email(submission=submission(), decision=HOT, assessment=assessment())
+    assert email.subject == "[HOT 87] Northwind Logistics"
+
+
+def test_the_subject_falls_back_to_the_person_then_to_a_placeholder() -> None:
+    named = render_routing_email(
+        submission=submission(company=None), decision=HOT, assessment=assessment()
+    )
+    assert "Northwind Logistics" in named.subject, "the model's extracted company still names it"
+
+    anonymous = render_routing_email(
+        submission=LeadSubmission(full_name="Dana Whitfield"),
+        decision=HOT,
+        assessment=assessment(
+            extracted=ExtractedFacts(**dict.fromkeys(ExtractedFacts.model_fields))
+        ),
+    )
+    assert anonymous.subject == "[HOT 87] Dana Whitfield"
+
+    nameless = render_routing_email(
+        submission=LeadSubmission(),
+        decision=HOT,
+        assessment=assessment(
+            extracted=ExtractedFacts(**dict.fromkeys(ExtractedFacts.model_fields))
+        ),
+    )
+    assert nameless.subject == "[HOT 87] unknown company"
+
+
+def test_the_scores_are_shown_against_their_own_maxima() -> None:
+    email = render_routing_email(submission=submission(), decision=HOT, assessment=assessment())
+    assert "icp fit: 27/30" in email.text_body
+    assert "authority: 12/15" in email.text_body
+    assert "27/30" in email.html_body
+
+
+def test_a_missing_field_reads_as_missing_rather_than_blank() -> None:
+    email = render_routing_email(
+        submission=submission(phone=None, website=None), decision=HOT, assessment=assessment()
+    )
+    assert "phone: —" in email.text_body
+
+
+# ------------------------------------------------------------------- the failure banner
+
+
+def test_the_system_failure_email_carries_the_banner_and_no_score() -> None:
+    """``assessment=None`` is the system-failure path, and it must not look like a verdict."""
+    decision = system_failure(EscalationReason.API_ERROR, detail="connection reset")
+    email = render_routing_email(
+        submission=submission(), decision=decision, assessment=None, links=LINKS
+    )
+
+    assert "NEEDS REVIEW" in email.subject
+    assert "Northwind Logistics" in email.subject
+    for part in (email.text_body, email.html_body):
+        assert SYSTEM_FAILURE_BANNER in part.lower()
+        assert "could not assess" in part.lower()
+        # the lead is still fully readable — that is the point of sending it
+        assert "dana@northwind.example" in part
+        assert "routing spreadsheet" in part
+    assert "0/100" not in email.text_body, "an unscored lead must not be shown as scoring zero"
+    assert "[HOT" not in email.subject
+
+
+def test_the_low_confidence_gate_shows_its_note_verbatim() -> None:
+    decision = RoutingDecision(
+        tier=Tier.WARM,
+        action=Action.EMAIL_SALES,
+        total_score=64.0,
+        note=LOW_CONFIDENCE_NOTE,
+        escalation_reason=EscalationReason.LOW_CONFIDENCE,
+    )
+    email = render_routing_email(
+        submission=submission(), decision=decision, assessment=assessment(confidence=0.31)
+    )
+    for part in (email.text_body, email.html_body):
+        assert LOW_CONFIDENCE_NOTE in part
+    assert "human review" in email.subject
+
+
+def test_an_unscored_lead_says_so_where_the_score_would_be() -> None:
+    decision = system_failure(EscalationReason.TIMEOUT)
+    email = render_routing_email(submission=submission(), decision=decision, assessment=None)
+    assert "NOT been scored" in email.text_body
+    assert "Not scored" in email.html_body
+
+
+# ---------------------------------------------------------------------- untrusted text
+
+
+@pytest.mark.parametrize(
+    "hostile",
+    [
+        "<script>alert(1)</script>",
+        '" onmouseover="alert(1)',
+        "<img src=x onerror=alert(1)>",
+    ],
+)
+def test_the_leads_own_words_cannot_become_markup(hostile: str) -> None:
+    email = render_routing_email(
+        submission=submission(message=hostile, full_name=hostile),
+        decision=HOT,
+        assessment=assessment(),
+    )
+    # The payload must survive only as text: never as the bytes it was submitted as, which
+    # is what would let it close an attribute or open a tag.
+    assert hostile not in email.html_body
+    assert "<script>" not in email.html_body
+    assert ("&lt;" in email.html_body) or ("&quot;" in email.html_body)
+    assert hostile in email.text_body, "the plain part is text, and a rep should see it"
+
+
+def test_model_output_is_escaped_too() -> None:
+    email = render_routing_email(
+        submission=submission(),
+        decision=HOT,
+        assessment=assessment(reasoning="<b>very</b> promising"),
+    )
+    assert "<b>very</b>" not in email.html_body
+    assert "&lt;b&gt;very&lt;/b&gt;" in email.html_body
+
+
+def test_a_hostile_website_field_never_becomes_an_href() -> None:
+    email = render_routing_email(
+        submission=submission(website="javascript:alert(1)"), decision=HOT, assessment=assessment()
+    )
+    assert 'href="javascript:' not in email.html_body
+
+
+def test_an_enormous_field_is_truncated_rather_than_sent_whole() -> None:
+    email = render_routing_email(
+        submission=submission(message="x" * (MAX_FIELD_CHARS * 3)),
+        decision=HOT,
+        assessment=assessment(),
+    )
+    assert len(email.text_body) < MAX_FIELD_CHARS * 2
+    assert "…" in email.text_body
+
+
+def test_control_characters_are_stripped_from_the_rendered_fields() -> None:
+    email = render_routing_email(
+        submission=submission(full_name="Dana\x00\x07 Whitfield"),
+        decision=HOT,
+        assessment=assessment(),
+    )
+    assert "\x00" not in email.text_body
+    assert "\x07" not in email.html_body
+
+
+# ------------------------------------------------------------------- the feedback links
+
+
+def test_both_feedback_links_appear_in_both_parts() -> None:
+    email = render_routing_email(
+        submission=submission(), decision=HOT, assessment=assessment(), links=LINKS
+    )
+    for link in LINKS:
+        assert link.url in email.text_body
+        assert f'href="{link.url}"' in email.html_body
+    assert "Was this a good lead?" in email.html_body
+    assert "Good lead" in email.html_body
+    assert "Bad lead" in email.html_body
+
+
+def test_no_links_means_no_dead_feedback_section() -> None:
+    email = render_routing_email(submission=submission(), decision=HOT, assessment=assessment())
+    assert "Was this a good lead?" not in email.html_body
+    assert "good lead" not in email.text_body.lower()
+
+
+# ----------------------------------------------------------- rendering in real clients
+
+
+def test_the_html_is_table_based_and_inline_styled_for_outlook() -> None:
+    """Word's rendering engine: no <style>, no flexbox, no floats, no external assets."""
+    html_body = render_routing_email(
+        submission=submission(), decision=HOT, assessment=assessment(), links=LINKS
+    ).html_body
+    assert "<table" in html_body
+    assert "<style" not in html_body
+    assert "display:flex" not in html_body
+    assert "<link" not in html_body
+    assert "<img" not in html_body, "no remote images: they are blocked and they track people"
+    assert re.search(r"max-width:\s*600px", html_body), "must reflow on a phone"
+
+
+def test_the_html_declares_a_doctype_and_a_charset() -> None:
+    html_body = render_routing_email(
+        submission=submission(message="Prêt à démarrer — 5 000 €"),
+        decision=HOT,
+        assessment=assessment(),
+    ).html_body
+    assert html_body.startswith("<!DOCTYPE html")
+    assert "charset=UTF-8" in html_body
+    assert "Prêt à démarrer" in html_body
+
+
+def test_the_text_part_is_readable_on_its_own() -> None:
+    """The alternative part is what a preview pane and a screen reader get."""
+    text = render_routing_email(
+        submission=submission(), decision=HOT, assessment=assessment(), links=LINKS
+    ).text_body
+    assert "<" not in text and ">" not in text
+    assert text.endswith("\n")
+    assert "CONTACT" in text
+    assert "OPEN WITH" in text

--- a/tests/unit/test_notify_ses.py
+++ b/tests/unit/test_notify_ses.py
@@ -1,0 +1,418 @@
+"""The SES notifier: what goes on the wire, and what happens when Amazon says no.
+
+Two kinds of double, on purpose. ``moto`` stands in for SES itself where the question is
+"does this request work against the real API" — an unverified identity, a real ``MessageId``
+coming back — because that is the part a hand-written stub would happily get wrong forever.
+A recording stub is used where the question is "what did we put in the request", because
+reading the message back out of moto's internals would couple these tests to moto's
+private model.
+
+There are no AWS credentials in this environment, and there is no test here that needs
+any: everything is offline.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError, EndpointConnectionError
+from moto import mock_aws
+
+from leadquali.adapters.notify_ses import (
+    OFFERED_VERDICTS,
+    SesDispatchError,
+    SesIdentity,
+    SesNotifier,
+    SesThrottledError,
+)
+from leadquali.app.feedback import (
+    MIN_TOKEN_SECRET_CHARS,
+    TokenAccepted,
+    rater_id,
+    verify_token,
+)
+from leadquali.domain.models import (
+    Action,
+    DimensionScores,
+    EscalationReason,
+    ExtractedFacts,
+    LeadAssessment,
+    RoutingDecision,
+    Tier,
+)
+from leadquali.domain.routing import system_failure
+from leadquali.prompts.lead import LeadSubmission
+from tests.fakes import FakeClock
+
+REGION = "eu-west-1"
+SENDER = "LeadQuali <leads@mail.example.com>"
+SENDER_ADDRESS = "leads@mail.example.com"
+DESTINATION = "sales@northwind.example"
+CONFIGURATION_SET = "leadquali-prod"
+SECRET = b"s" * MIN_TOKEN_SECRET_CHARS
+BASE_URL = "https://api.example.com/prod"
+TENANT = "default"
+LEAD = "8f14e45f-ceea-467a-9575-1b1e0a4d3c11"
+
+SUBMISSION = LeadSubmission(
+    full_name="Dana Whitfield",
+    email="dana@northwind.example",
+    company="Northwind Logistics",
+    role="VP Operations",
+    message="Replacing our routing spreadsheet before the Q4 peak.",
+)
+ASSESSMENT = LeadAssessment(
+    dimension_scores=DimensionScores(
+        icp_fit=27, intent=22, authority=12, urgency=13, budget_signal=11
+    ),
+    extracted=ExtractedFacts(
+        company_name="Northwind Logistics",
+        industry="freight",
+        company_size_estimate="200-500",
+        role_seniority="vp",
+        stated_use_case="replace a routing spreadsheet",
+        stated_timeline="before Q4",
+    ),
+    reasoning="States a deadline and owns the budget line.",
+    confidence=0.86,
+    missing_information=["current tooling spend"],
+    suggested_first_question="What breaks first when the spreadsheet is wrong?",
+    spam_or_test_submission=False,
+)
+HOT = RoutingDecision(
+    tier=Tier.HOT, action=Action.EMAIL_SALES, total_score=87.0, note="scored 87.00/100 — hot"
+)
+
+
+@pytest.fixture(autouse=True)
+def _no_real_aws(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Credentials that only moto will ever see, and a region that is not anyone's default."""
+    for name, value in {
+        "AWS_ACCESS_KEY_ID": "testing",
+        "AWS_SECRET_ACCESS_KEY": "testing",
+        "AWS_SECURITY_TOKEN": "testing",
+        "AWS_SESSION_TOKEN": "testing",
+        "AWS_DEFAULT_REGION": REGION,
+    }.items():
+        monkeypatch.setenv(name, value)
+
+
+class RecordingSes:
+    """Captures the ``SendEmail`` request, or raises whatever it was told to raise."""
+
+    def __init__(self, *, raises: Exception | None = None, response: Any = None) -> None:
+        self.raises = raises
+        self.response = response if response is not None else {"MessageId": "ses-message-1"}
+        self.requests: list[dict[str, Any]] = []
+
+    def send_email(self, **request: Any) -> Any:
+        self.requests.append(request)
+        if self.raises is not None:
+            raise self.raises
+        return self.response
+
+    @property
+    def request(self) -> dict[str, Any]:
+        assert len(self.requests) == 1, f"expected exactly one send, got {len(self.requests)}"
+        return self.requests[0]
+
+
+def client_error(code: str) -> ClientError:
+    return ClientError(
+        {
+            "Error": {
+                "Code": code,
+                # Deliberately quoting the recipient, exactly as SES does. Nothing from
+                # this string may reach the exception we raise (invariant 5).
+                "Message": f"Maximum sending rate exceeded for {DESTINATION}",
+            }
+        },
+        "SendEmail",
+    )
+
+
+def notifier(client: Any, **overrides: Any) -> SesNotifier:
+    settings: dict[str, Any] = {
+        "identity": SesIdentity(sender=SENDER, configuration_set=CONFIGURATION_SET),
+        "feedback_base_url": BASE_URL,
+        "token_secret": SECRET,
+        "clock": FakeClock(start=datetime(2026, 9, 3, 9, 0, tzinfo=UTC), step_ms=0),
+    }
+    settings.update(overrides)
+    return SesNotifier(client=client, **settings)
+
+
+def dispatch(client: Any, **overrides: Any) -> str | None:
+    call: dict[str, Any] = {
+        "tenant_id": TENANT,
+        "lead_id": LEAD,
+        "destination": DESTINATION,
+        "submission": SUBMISSION,
+        "decision": HOT,
+        "assessment": ASSESSMENT,
+    }
+    call.update(overrides)
+    return notifier(client).dispatch(**call)
+
+
+# --------------------------------------------------------------------- against real SES
+
+
+@mock_aws
+def test_a_hot_lead_is_accepted_by_ses_and_returns_a_message_id() -> None:
+    client = boto3.client("sesv2", region_name=REGION)
+    client.create_email_identity(EmailIdentity=SENDER_ADDRESS)
+
+    message_id = dispatch(client)
+
+    assert message_id, "the provider message id is what routing_events traces a bounce with"
+    assert isinstance(message_id, str)
+
+
+@mock_aws
+def test_an_unverified_sender_is_a_dispatch_error_not_a_silent_success() -> None:
+    """Nothing was created, so SES has no verified identity to send from."""
+    client = boto3.client("sesv2", region_name=REGION)
+    with pytest.raises(SesDispatchError):
+        dispatch(client)
+
+
+@mock_aws
+def test_the_system_failure_email_also_reaches_ses() -> None:
+    """``assessment=None`` must send, not raise: an unassessed lead still needs a human."""
+    client = boto3.client("sesv2", region_name=REGION)
+    client.create_email_identity(EmailIdentity=SENDER_ADDRESS)
+
+    message_id = dispatch(
+        client, assessment=None, decision=system_failure(EscalationReason.API_ERROR)
+    )
+    assert message_id
+
+
+# ------------------------------------------------------------------- what we send
+
+
+def test_the_request_carries_both_parts_the_sender_and_the_configuration_set() -> None:
+    client = RecordingSes()
+    dispatch(client)
+    request = client.request
+
+    assert request["FromEmailAddress"] == SENDER
+    assert request["Destination"]["ToAddresses"] == [DESTINATION]
+    assert request["ConfigurationSetName"] == CONFIGURATION_SET
+    body = request["Content"]["Simple"]["Body"]
+    assert body["Text"]["Data"].strip()
+    assert body["Html"]["Data"].startswith("<!DOCTYPE html")
+    assert body["Text"]["Charset"] == "UTF-8"
+    assert body["Html"]["Charset"] == "UTF-8"
+    assert "HOT" in request["Content"]["Simple"]["Subject"]["Data"]
+
+
+def test_the_reply_goes_to_the_lead() -> None:
+    client = RecordingSes()
+    dispatch(client)
+    assert client.request["ReplyToAddresses"] == ["dana@northwind.example"]
+
+
+def test_a_lead_with_no_address_simply_has_no_reply_to() -> None:
+    client = RecordingSes()
+    dispatch(client, submission=LeadSubmission(full_name="Anonymous"))
+    assert "ReplyToAddresses" not in client.request
+
+
+def test_no_configuration_set_is_configured_means_none_is_sent() -> None:
+    client = RecordingSes()
+    notifier(client, identity=SesIdentity(sender=SENDER)).dispatch(
+        tenant_id=TENANT,
+        lead_id=LEAD,
+        destination=DESTINATION,
+        submission=SUBMISSION,
+        decision=HOT,
+        assessment=ASSESSMENT,
+    )
+    assert "ConfigurationSetName" not in client.request
+
+
+def test_the_message_is_tagged_for_the_event_destination() -> None:
+    client = RecordingSes()
+    dispatch(client)
+    tags = {tag["Name"]: tag["Value"] for tag in client.request["EmailTags"]}
+    assert tags == {"tenant": "default", "tier": "hot", "escalated": "no"}
+
+
+def test_a_tenant_id_that_ses_would_reject_as_a_tag_is_sanitised() -> None:
+    """A tag SES refuses rejects the whole send; a metric label must not cost a lead."""
+    client = RecordingSes()
+    dispatch(client, tenant_id="acme.co uk")
+    tags = {tag["Name"]: tag["Value"] for tag in client.request["EmailTags"]}
+    assert tags["tenant"] == "acme_co_uk"
+
+
+# ------------------------------------------------------------------- the feedback links
+
+
+def test_every_email_carries_one_signed_link_per_offered_verdict() -> None:
+    client = RecordingSes()
+    dispatch(client)
+    text = client.request["Content"]["Simple"]["Body"]["Text"]["Data"]
+
+    tokens = [
+        line.rsplit("/feedback/", 1)[1].strip()
+        for line in text.splitlines()
+        if "/feedback/" in line
+    ]
+    assert len(tokens) == len(OFFERED_VERDICTS)
+
+    verdicts = set()
+    for token in tokens:
+        result = verify_token(
+            secret=SECRET, token=token, now=datetime(2026, 9, 3, 9, 1, tzinfo=UTC)
+        )
+        assert isinstance(result, TokenAccepted), "the link we send must be one we accept"
+        assert result.claim.lead_id == LEAD
+        assert result.claim.tenant_id == TENANT
+        assert result.claim.rater == rater_id(DESTINATION)
+        verdicts.add(result.claim.verdict)
+    assert verdicts == set(OFFERED_VERDICTS)
+
+
+def test_the_links_expire_on_the_configured_horizon() -> None:
+    client = RecordingSes()
+    start = datetime(2026, 9, 3, 9, 0, tzinfo=UTC)
+    notifier(client, clock=FakeClock(start=start, step_ms=0), token_ttl_days=7).dispatch(
+        tenant_id=TENANT,
+        lead_id=LEAD,
+        destination=DESTINATION,
+        submission=SUBMISSION,
+        decision=HOT,
+        assessment=ASSESSMENT,
+    )
+    text = client.request["Content"]["Simple"]["Body"]["Text"]["Data"]
+    token = next(line for line in text.splitlines() if "/feedback/" in line).rsplit("/", 1)[1]
+    result = verify_token(secret=SECRET, token=token, now=start)
+    assert isinstance(result, TokenAccepted)
+    assert result.claim.expires_at == start + timedelta(days=7)
+
+
+def test_the_system_failure_email_still_carries_feedback_links() -> None:
+    """An unassessed lead is exactly the one whose verdict is worth the most."""
+    client = RecordingSes()
+    dispatch(client, assessment=None, decision=system_failure(EscalationReason.TIMEOUT))
+    assert "/feedback/" in client.request["Content"]["Simple"]["Body"]["Text"]["Data"]
+
+
+def test_two_destinations_get_different_rater_ids() -> None:
+    first, second = RecordingSes(), RecordingSes()
+    dispatch(first)
+    dispatch(second, destination="escalations@example.com")
+
+    def rater_of(client: RecordingSes) -> str:
+        text = client.request["Content"]["Simple"]["Body"]["Text"]["Data"]
+        token = next(line for line in text.splitlines() if "/feedback/" in line).rsplit("/", 1)[1]
+        result = verify_token(secret=SECRET, token=token, now=datetime(2026, 9, 3, 9, tzinfo=UTC))
+        assert isinstance(result, TokenAccepted)
+        return result.claim.rater
+
+    assert rater_of(first) != rater_of(second)
+
+
+# ---------------------------------------------------------------------------- failure
+
+
+@pytest.mark.parametrize(
+    "code",
+    ["Throttling", "ThrottlingException", "TooManyRequestsException", "SendingPausedException"],
+)
+def test_throttling_raises_its_own_type_so_the_queue_redelivers(code: str) -> None:
+    with pytest.raises(SesThrottledError):
+        dispatch(RecordingSes(raises=client_error(code)))
+
+
+def test_a_rejected_message_raises_a_dispatch_error() -> None:
+    with pytest.raises(SesDispatchError) as raised:
+        dispatch(RecordingSes(raises=client_error("MessageRejected")))
+    assert not isinstance(raised.value, SesThrottledError)
+
+
+def test_a_network_failure_raises_rather_than_returning_none() -> None:
+    """Returning ``None`` would let the pipeline record a lead as delivered to nobody."""
+    with pytest.raises(SesDispatchError):
+        dispatch(RecordingSes(raises=EndpointConnectionError(endpoint_url="https://ses")))
+
+
+def test_a_response_without_a_message_id_is_treated_as_a_failure() -> None:
+    with pytest.raises(SesDispatchError, match="MessageId"):
+        dispatch(RecordingSes(response={}))
+
+
+def test_a_failure_message_never_quotes_the_recipient() -> None:
+    """Invariant 5: botocore's message names the address; ours must not repeat it."""
+    with pytest.raises(SesDispatchError) as raised:
+        dispatch(RecordingSes(raises=client_error("Throttling")))
+    assert DESTINATION not in str(raised.value)
+    assert "northwind" not in str(raised.value).lower()
+    assert "Throttling" in str(raised.value)
+
+
+def test_a_blank_destination_is_refused_before_anything_is_sent() -> None:
+    client = RecordingSes()
+    with pytest.raises(ValueError, match="destination"):
+        dispatch(client, destination="   ")
+    assert client.requests == []
+
+
+# ------------------------------------------------------------------------ wiring errors
+
+
+@pytest.mark.parametrize(
+    ("overrides", "match"),
+    [
+        ({"feedback_base_url": "/feedback"}, "absolute"),
+        ({"token_secret": b"short"}, "at least"),
+        ({"token_ttl_days": 0}, "positive"),
+    ],
+    ids=["relative-base-url", "short-secret", "zero-ttl"],
+)
+def test_a_misconfigured_notifier_fails_at_construction(
+    overrides: dict[str, Any], match: str
+) -> None:
+    """Not on the first lead, and not as a link nobody can use."""
+    with pytest.raises(ValueError, match=match):
+        notifier(RecordingSes(), **overrides)
+
+
+def test_a_blank_sender_identity_is_refused() -> None:
+    with pytest.raises(ValueError, match="sender"):
+        SesIdentity(sender="  ")
+
+
+# ------------------------------------------------------------------------------- logs
+
+
+def test_no_address_of_any_kind_reaches_the_logs(caplog: pytest.LogCaptureFixture) -> None:
+    """Invariant 5, on the one adapter that necessarily handles addresses."""
+    caplog.set_level(logging.DEBUG, logger="leadquali")
+    dispatch(RecordingSes())
+
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert logged, "the send is supposed to be logged"
+    assert DESTINATION not in logged
+    assert "dana@northwind.example" not in logged
+    assert "Dana Whitfield" not in logged
+    assert "@" not in logged
+    # ...and what is there instead: identifiers and the opaque destination hash.
+    assert LEAD in logged
+    assert rater_id(DESTINATION) in logged
+
+
+def test_a_failed_send_logs_nothing_about_the_lead(caplog: pytest.LogCaptureFixture) -> None:
+    caplog.set_level(logging.DEBUG, logger="leadquali")
+    with pytest.raises(SesDispatchError):
+        dispatch(RecordingSes(raises=client_error("MessageRejected")))
+    logged = "\n".join(record.getMessage() for record in caplog.records)
+    assert DESTINATION not in logged
+    assert "dana@northwind.example" not in logged

--- a/tests/unit/test_store_postgres.py
+++ b/tests/unit/test_store_postgres.py
@@ -396,8 +396,12 @@ def test_importing_the_module_creates_no_engine() -> None:
 
 def test_no_sql_is_assembled_from_strings() -> None:
     """Acceptance criterion: no SQL string interpolation of user input anywhere. Every
-    statement is a Core construct, so ids and payloads travel as bound parameters; the one
-    textual fragment in the module is a constant with no input in it."""
+    statement is a Core construct, so ids and payloads travel as bound parameters; the only
+    textual fragments in the module are constants with no input in them.
+
+    There are two, and both are the same one: ``(xmax = 0)``, the Postgres idiom for "did my
+    ``ON CONFLICT`` insert or update", once in ``upsert_lead`` (#16) and once in
+    ``record_feedback`` (#19). Neither contains anything that came from a caller."""
     module = ast.parse(MODULE_PATH.read_text(encoding="utf-8"))
     textual = {"text", "literal_column", "column", "table"}
     found = 0
@@ -410,7 +414,7 @@ def test_no_sql_is_assembled_from_strings() -> None:
         assert isinstance(first, ast.Constant) and isinstance(first.value, str), (
             f"line {call.lineno}: {name}() is given something other than a literal string"
         )
-    assert found == 1, "expected exactly the (xmax = 0) fragment; a new one needs a look"
+    assert found == 2, "expected only the two (xmax = 0) fragments; a new one needs a look"
 
 
 def test_the_engine_is_shaped_for_a_lambda_container() -> None:


### PR DESCRIPTION
Closes #19. On top of #59 (ingest) → #57 → #50 → #56.

**This PR builds the product's only source of ground truth.** Per the decision record in #42, there is no historical lead data with outcomes, so the golden set (#22) can only ever grow from the `feedback` table — fed by these links. If reps don't click, #23 measures nothing and the rubric can never be calibrated. Click-through is the feature; the email is the delivery mechanism.

## ⚠️ Deliberate deviation: two taps, not one

The issue says "one-click". This ships **`GET /feedback/{token}` renders a confirmation page and writes nothing**; **`POST` writes**. The POST requires a `confirm` value derived server-side, so a blind POST gets the button, not a write.

Why: mail security scanners and link-prefetchers follow every URL in an inbound email. A GET that records a verdict means **your first "data" is a robot's opinion**, silently poisoning the only dataset this product will ever have. That failure is invisible — the rows look real.

This is the same reasoning behind **RFC 8058** (`List-Unsubscribe-Post`), which exists because GET-based unsubscribe links were being fired by scanners. Reversing this to a true single click is possible, but only by accepting scanner-written feedback rows. Your call — I'd keep it.

## The route and token

- `GET /feedback/{token}` → confirmation page. `POST /feedback/{token}` + `confirm` → writes, then returns a thank-you page carrying a server-minted one-tap link to the **opposite** verdict, so a misclick is one tap to fix.
- 200 / 400 forged / 410 expired / 404 lead gone / 503 store down. HTML, `no-store`, `noindex`.
- Token: `fb1.<base64url(claim)>.<base64url(HMAC-SHA256)>`, the claim being tenant, lead, verdict, rater and expiry. Per-tenant derived key. **Signature is checked before expiry**, so a forgery attempt is never an oracle over lead ids.

## Two things needing your decision

1. **A `UNIQUE (tenant_id, lead_id, rater)` constraint was added to #50's initial migration, edited in place** — consistent with that revision's own stated policy while nothing is deployed, but it changes a migration another PR presents as final. Worth a look when reviewing both together.
2. **A changed verdict moves `created_at`**, because `feedback` has no `updated_at`; the first-recorded time is lost. Fine for counting, wrong if you ever want to measure how long a rep took to change their mind. One column in #50 fixes it.

Also: `unsure` exists in the schema but isn't offered as a button, and `rater` is a hash of the destination inbox until reps have real identities — #16 flagged that `rater` must stay an opaque subject id, and it does.

## Config #26/#28 must supply

`SES_SENDER` (required), `SES_CONFIGURATION_SET`, `AWS_REGION`, `FEEDBACK_BASE_URL` (required, absolute, **must include the API Gateway stage prefix**), `FEEDBACK_TOKEN_SECRET` (required, 32+ chars, **distinct from any ingest signing secret**), `FEEDBACK_TOKEN_TTL_DAYS` (default 30). All in `.env.example`, all with `require_*` accessors that fail at wiring time rather than at 9am.

## Verification

121 new tests (979 passing offline; 1097 with Postgres up, so the new constraint is verified against a real database rather than only the fake). Covers both email parts rendering, the system-failure banner, send failures propagating so SQS can redeliver, forged/expired/wrong-lead/wrong-verdict tokens rejected, the scanner-prefetch case, repeated clicks, changed verdicts, and no raw address in any log line. A layering test now enforces that `notify_ses.py` is the only file importing `boto3` for SES.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_