### PR TITLE
[P2.8] Observability: structured JSON logs, trace IDs, PII hashing, per-assessment metrics

### DIFF
--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,166 @@
+# Observability: log fields, metric names, and what to alarm on
+
+Plan §8, issue #21. This is the reference #29 writes alarms against and #33 meters billing
+from, so treat the names below as a published contract: renaming a metric orphans every
+alarm that mentions it, and renaming a log field breaks every saved Logs Insights query.
+
+Everything here is emitted by `leadquali.observability`. One function per event lives in
+`observability/events.py`; nothing else in the codebase builds a log field dict by hand.
+
+## Configuring it
+
+`configure_logging()` — once per process, at the entry point. It is already called by
+`leadquali.api.main` (at import, so a request cannot be served before logging exists) and
+by `leadquali.cli` (to **stderr**, so `--json` on stdout stays parseable). #26's worker
+handler must call it too.
+
+- `LOG_LEVEL` sets the root level. Third-party loggers (`botocore`, `sqlalchemy.engine`,
+  `anthropic`, `httpx`, …) are pinned no lower than `WARNING`, which at `DEBUG` is what
+  keeps SQLAlchemy's echo of bound parameters — a lead's email address — out of the log.
+- `ENV` picks the format: `local` gets one readable line per record, every deployed
+  environment gets JSON. The fields are identical either way.
+- It is **safe to call twice**. A Lambda container is reused across invocations, and a
+  handler added per invocation would double every line and every metric derived from it, so
+  the function converges on exactly one handler instead of accumulating. It also detaches
+  the handler the Lambda runtime pre-installs, which would otherwise print every line a
+  second time in its own format.
+
+## The log field set
+
+One JSON object per line. Nothing is nested except `exception`.
+
+| Field | On | Meaning |
+|---|---|---|
+| `timestamp` | every record | ISO-8601 UTC, milliseconds, trailing `Z`. Sortable as a string. |
+| `level` | every record | `DEBUG` … `CRITICAL`. |
+| `logger` | every record | The emitting module, e.g. `leadquali.app.qualify`. |
+| `message` | every record | Human text. Equals `event` for structured events. |
+| `service` | every record | `leadquali`. |
+| `env` | every record | `local` / `dev` / `staging` / `prod`. |
+| `event` | our records | Stable dotted name (see below). Absent on third-party records. |
+| `trace_id` | every record in a lead's scope | 32 hex chars. **The join key for a lead's whole journey.** |
+| `tenant_id`, `submission_id` | in a lead's scope | Bound to the context, so they ride on records written by code that was never handed them. |
+| `lead_id` | from the edge onwards | The `leads` row. |
+| `exception` | error records | `{type, message, stack}`. Redacted; never carries frame locals. |
+
+### Events and their own fields
+
+| `event` | Emitted by | Fields beyond the core set |
+|---|---|---|
+| `lead.accepted` | `app.ingest` | `disposition` (queued/suppressed/duplicate), `source`, `is_new_lead`, `contact_email_hash`, `spam_reason` |
+| `assessment.completed` | `app.qualify` | `assessed`, `tier`, `action`, `total_score`, `confidence`, `escalation_reason`, `enrichment_available`, `model_id`, `prompt_version`, `effort`, `input_tokens`, `output_tokens`, `cache_read_tokens`, `cache_creation_tokens`, `cost_usd`, `model_latency_ms` |
+| `lead.routed` | `app.qualify` | `tier`, `action`, `destination_hash`, `used_fallback_destination`, `provider_message_id`, `latency_ms` |
+| `lead.suppressed` | `app.qualify` | `tier`, `suppression_cause` (`spam` / `below_threshold`), `total_score`, `latency_ms` |
+| `lead.duplicate` | `app.qualify` | `latency_ms` |
+| `lead.dispatch_failed` | `app.qualify` | `tier`, `destination_hash`, `error_type`, `exception` |
+| `http.ingest` | `api.main` | `disposition`, `status`, `latency_ms` |
+| `ingest.rejected` | `api.main` | `reason`, `claimed_tenant`, `client`, `status` |
+| `ingest.rate_limited` | `api.main` | `retry_after_seconds` |
+
+### PII
+
+Invariant 5, and it is enforced by a test rather than by this paragraph
+(`tests/unit/test_observability_pipeline.py`): a lead with a distinctive address and a
+distinctive message goes through the real pipeline with logging captured, and neither
+string appears in any record — on the happy path **and** on the exception path, where a
+traceback that formats a `LeadSubmission` would otherwise leak the lot.
+
+- Addresses appear only as `contact_email_hash` / `destination_hash` — SHA-256 of the
+  normalised address, the same value in `leads.contact_email_hash`, so a log line joins to
+  a row.
+- `LeadSubmission` declares every field `repr=False`, so no traceback can render one.
+- Both formatters redact address-shaped runs from messages and tracebacks as a last resort.
+  That net catches what arrives from outside (a bounce quoted by SES, a library echoing its
+  input); it cannot recognise a lead's prose, so it is not a substitute for discipline.
+
+## Metrics: CloudWatch EMF
+
+Namespace **`LeadQuali`**. Metrics ride on the log line as an Embedded Metric Format
+document, so there is no `PutMetricData` call in the path of a customer's lead: no added
+latency, no extra IAM, no per-call cost, and nothing that can fail and silently stop
+feeding an alarm. Off AWS the same line is ordinary JSON and the numbers stay queryable.
+
+| Metric | Unit | Dimension sets | Emitted on |
+|---|---|---|---|
+| `Assessments` | Count | `[TenantId, Tier]`, `[TenantId]` | `assessment.completed` |
+| `AssessmentFailures` | Count | `[TenantId]` | `assessment.completed` (1 when the model returned nothing) |
+| `Escalations` | Count | `[TenantId, EscalationReason]` | `assessment.completed` when a reason exists |
+| `InputTokens`, `OutputTokens`, `CacheReadTokens`, `CacheCreationTokens` | Count | `[TenantId]` | `assessment.completed` when the call was billed |
+| `CostUsd` | None | `[TenantId]` | `assessment.completed` when the call was billed |
+| `ModelLatencyMs` | Milliseconds | `[TenantId]` | `assessment.completed` when the call was billed |
+| `EnrichmentUnavailable` | Count | `[TenantId]` | `assessment.completed` |
+| `Dispatches` | Count | `[TenantId, Tier]`, `[TenantId]` | `lead.routed` |
+| `FallbackDestinations` | Count | `[TenantId]` | `lead.routed` |
+| `PipelineLatencyMs` | Milliseconds | `[TenantId]` | `lead.routed`, `lead.suppressed`, `lead.duplicate` |
+| `Suppressions` | Count | `[TenantId, SuppressionCause]` | `lead.suppressed` |
+| `Duplicates` | Count | `[TenantId]` | `lead.duplicate` |
+| `DispatchFailures` | Count | `[TenantId]` | `lead.dispatch_failed` |
+| `IngestedLeads` | Count | `[TenantId, Disposition]` | `lead.accepted` |
+| `IngestSuppressions` | Count | `[TenantId, SpamReason]` | `lead.accepted` when a pre-filter fired |
+
+Dimension values are all bounded — `Tier` has four, `EscalationReason` five,
+`SuppressionCause` two, `Disposition` three — which keeps this at roughly twenty custom
+metrics per tenant. `lead_id` and `trace_id` are deliberately **fields, not dimensions**:
+free to query in Logs Insights, and unbounded as a dimension.
+
+## What #29 should alarm on
+
+Ordered by how likely the page is to be real.
+
+1. **DLQ depth > 0** (SQS metric, #26's queue). The backstop; everything below is an
+   earlier warning of it.
+2. **`DispatchFailures` sum > 0 over 5 minutes**, per tenant. A lead that could not be
+   delivered is still on the queue; this fires before the DLQ does.
+3. **`AssessmentFailures` / `Assessments` > 0.05 over 15 minutes.** Break down by
+   `EscalationReason` via `Escalations` to route it: `api_error` / `timeout` is
+   operational, `parse_error` / `model_refusal` is a prompt problem.
+4. **p99 `PipelineLatencyMs`**, with p99 `ModelLatencyMs` on the same dashboard. The gap
+   between them says whether it is Anthropic or us.
+5. **`CostUsd` sum per day** above roughly 2× the plan's $25/1,000-leads baseline, and
+   **`CacheReadTokens` sum per day dropping to ~0**, which is the only visible symptom of a
+   broken cache prefix and shows up as a cost rise first.
+6. **Tier-distribution drift** — the one plan §8 singles out:
+
+   > alarm on `Assessments` with dimensions `[TenantId, Tier="hot"]` as a **ratio** of
+   > `Assessments` with dimensions `[TenantId]`, using a CloudWatch metric math expression
+   > (`m_hot / m_all`), evaluated hourly per tenant, against a band derived from the
+   > previous 7 days (anomaly detection, or a static band once a baseline exists).
+
+   `Assessments` is emitted for **every decision, before the suppress/dispatch branch**,
+   which is what makes this a distribution over decisions rather than over the leads that
+   happened to be emailed — a distribution over dispatches would move whenever a tenant
+   edited its routing table, and that false positive is how a drift alarm gets switched
+   off. A sudden jump in `hot` is a prompt change or an upstream form change far more often
+   than it is a good sales week.
+7. **`EnrichmentUnavailable` sustained above ~10% over an hour** (#58). Not an outage —
+   every lead was still assessed — but every lead is being judged on less than it should
+   be, and nothing else in the product looks different.
+8. **`Suppressions` by `SuppressionCause`**, per tenant, daily. A rise in `spam` is a bot
+   campaign; a rise in `below_threshold` is our rubric rejecting real leads. #52 separated
+   the two notes so that these could be different alarms with different owners.
+
+## Useful queries
+
+Cost per lead, without opening the database:
+
+```
+fields cost_usd
+| filter event = "assessment.completed" and tenant_id = "acme"
+| stats sum(cost_usd) as spend, count(*) as leads, spend / leads as cost_per_lead by bin(1d)
+```
+
+One lead's whole journey:
+
+```
+fields @timestamp, event, tier, message
+| filter trace_id = "0d2288cddb204fa990b5e15f73fc2d2c"
+| sort @timestamp asc
+```
+
+Tier distribution, per tenant per hour (the drift signal, as a query rather than an alarm):
+
+```
+fields tier
+| filter event = "assessment.completed"
+| stats count(*) by tenant_id, tier, bin(1h)
+```

--- a/src/leadquali/adapters/store_postgres.py
+++ b/src/leadquali/adapters/store_postgres.py
@@ -78,7 +78,6 @@ convenience that reads ``DATABASE_URL`` through :class:`~leadquali.config.Settin
 
 from __future__ import annotations
 
-import hashlib
 import logging
 import re
 import uuid
@@ -116,6 +115,12 @@ from leadquali.domain.tenant_config import (
     TenantConfigError,
     TenantNotFoundError,
 )
+
+# Re-exported (it is in ``__all__``) so callers keep importing it from the store that
+# writes it. The definition lives in ``observability`` because a log line and a ``leads``
+# row must agree on the hash to be joinable, and two definitions of "the hash" is exactly
+# how they stop agreeing.
+from leadquali.observability.pii import contact_email_hash
 from leadquali.prompts.lead import LeadSubmission
 
 __all__ = [
@@ -226,26 +231,6 @@ def lead_uuid(lead_id: str) -> uuid.UUID:
         return uuid.UUID(lead_id)
     except ValueError:
         raise ValueError(f"lead id {lead_id!r} is not a UUID") from None
-
-
-def contact_email_hash(email: str | None) -> str | None:
-    """SHA-256 of the normalised contact address, or ``None`` when there is no address.
-
-    Invariant 5: this is what a log line or a metric carries so one person's leads can be
-    correlated without their address ever leaving ``leads.raw_payload``. Normalised —
-    stripped and lowercased — so that ``Ada@Example.com`` and ``ada@example.com`` correlate
-    to the same person, which is the entire point of storing it.
-
-    Not a secret and not reversible-proof: an email address has little entropy, so this
-    defends against casual disclosure in logs, not against a determined attacker with the
-    hash. It is never returned to a caller and never logged next to the address.
-    """
-    if email is None:
-        return None
-    normalised = email.strip().lower()
-    if not normalised:
-        return None
-    return hashlib.sha256(normalised.encode("utf-8")).hexdigest()
 
 
 # ------------------------------------------------------------------- engine & sessions

--- a/src/leadquali/api/main.py
+++ b/src/leadquali/api/main.py
@@ -52,7 +52,7 @@ from pydantic import ValidationError
 
 from leadquali.adapters.clock_system import SystemClock
 from leadquali.adapters.queue_inprocess import InProcessLeadQueue
-from leadquali.adapters.store_postgres import PostgresLeadStore, contact_email_hash
+from leadquali.adapters.store_postgres import PostgresLeadStore
 from leadquali.api.feedback import FeedbackDeps, register_feedback_routes
 from leadquali.api.ratelimit import NoRateLimit, RateLimiterPort
 from leadquali.api.schemas import (
@@ -75,6 +75,7 @@ from leadquali.app.ingest import IngestRequest, IngestService
 from leadquali.app.ports import ClockPort
 from leadquali.config import Settings, get_settings
 from leadquali.domain.spam import DEFAULT_SPAM_POLICY, SpamPolicy
+from leadquali.observability import configure_logging, log_context, log_event, new_trace_id
 
 LOGGER = logging.getLogger(__name__)
 
@@ -231,6 +232,20 @@ def create_app(
 
 async def _handle_ingest(request: Request, deps: IngestDeps) -> Response:
     """The ingest handler, outside the closure so it can be read and tested on its own."""
+    trace_id = new_trace_id()
+    with log_context(trace_id=trace_id):
+        return await _handle_ingest_traced(request, deps, trace_id)
+
+
+async def _handle_ingest_traced(request: Request, deps: IngestDeps, trace_id: str) -> Response:
+    """The handler proper, under a bound trace id.
+
+    The id is minted *here* rather than in
+    :meth:`~leadquali.app.ingest.IngestService.accept` so that a request refused before the
+    service is ever reached — 413, 401, 429, 422 — still logs under an id. A stranger's
+    rejected probe and a customer's accepted lead are then the same kind of thing in the
+    log, which is what makes "what happened to this request" answerable at all.
+    """
     started_ms = deps.clock.monotonic_ms()
 
     body = await _read_bounded_body(request, deps.max_body_bytes)
@@ -252,7 +267,13 @@ async def _handle_ingest(request: Request, deps: IngestDeps) -> Response:
 
     limit = deps.rate_limiter.check(tenant_id=auth.tenant_id, now=deps.clock.now())
     if not limit.allowed:
-        LOGGER.warning("ingest rate limited tenant=%s", auth.tenant_id)
+        log_event(
+            LOGGER,
+            "ingest.rate_limited",
+            level=logging.WARNING,
+            tenant_id=auth.tenant_id,
+            retry_after_seconds=limit.retry_after_seconds,
+        )
         return _error(
             429,
             "too many submissions; retry later",
@@ -272,21 +293,23 @@ async def _handle_ingest(request: Request, deps: IngestDeps) -> Response:
             source=payload.source,
             honeypot=payload.honeypot,
             elapsed_ms=payload.elapsed_ms,
+            trace_id=trace_id,
         )
     )
 
-    # Invariant 5: identifiers, a hash and a disposition. Never the address, never the
-    # lead's own words, never the raw payload.
-    LOGGER.info(
-        "lead accepted tenant=%s submission=%s lead=%s disposition=%s reason=%s "
-        "contact=%s latency_ms=%d",
-        receipt.tenant_id,
-        receipt.submission_id,
-        receipt.lead_id,
-        receipt.disposition.value,
-        receipt.spam_reason.value if receipt.spam_reason is not None else "-",
-        contact_email_hash(payload.form.email) or "-",
-        deps.clock.monotonic_ms() - started_ms,
+    # The lead's own event — identifiers, a hash and a disposition — is emitted by the
+    # ingest service, so that #26's producer and a replay script emit it too. This line is
+    # about the *request*: what the endpoint answered and how long it took, which is the
+    # 200 ms budget in plan section 3 made observable.
+    log_event(
+        LOGGER,
+        "http.ingest",
+        tenant_id=receipt.tenant_id,
+        submission_id=receipt.submission_id,
+        lead_id=receipt.lead_id,
+        disposition=receipt.disposition.value,
+        status=202,
+        latency_ms=deps.clock.monotonic_ms() - started_ms,
     )
 
     accepted = IngestAccepted(submission_id=receipt.submission_id, received_at=receipt.received_at)
@@ -326,11 +349,14 @@ def _log_rejection(failure: AuthFailure, request: Request) -> None:
     and it is the only handle an operator has on "a customer's form has the wrong key"
     versus "someone is probing us".
     """
-    LOGGER.warning(
-        "ingest rejected reason=%s claimed_tenant=%s client=%s",
-        failure.value,
-        request.headers.get("x-leadquali-tenant", "-")[:64],
-        request.client.host if request.client is not None else "-",
+    log_event(
+        LOGGER,
+        "ingest.rejected",
+        level=logging.WARNING,
+        reason=failure.value,
+        claimed_tenant=request.headers.get("x-leadquali-tenant", "-")[:64],
+        client=request.client.host if request.client is not None else "-",
+        status=401,
     )
 
 
@@ -363,6 +389,13 @@ def _validation_error(error: ValidationError) -> JSONResponse:
     ).model_dump()
     return JSONResponse(status_code=422, content=body, headers=_NO_STORE)
 
+
+# Logging is configured at import, before the app object exists, because uvicorn, Mangum
+# and `run_local.py` all import this module and none of them gives us a startup hook we can
+# rely on — and a request served before logging is configured is a request with no record.
+# `configure_logging` converges rather than accumulating, so the reload child process, the
+# Lambda cold start and a test that reconfigures afterwards are all safe.
+configure_logging()
 
 #: The ASGI application. ``uvicorn leadquali.api.main:app`` and ``run_local.py`` serve this
 #: one; ``api/handlers.py`` wraps the same object for Lambda.

--- a/src/leadquali/app/ingest.py
+++ b/src/leadquali/app/ingest.py
@@ -26,7 +26,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
 from enum import StrEnum
 from typing import Any, Final, Protocol, runtime_checkable
@@ -34,6 +34,7 @@ from typing import Any, Final, Protocol, runtime_checkable
 from leadquali.app.ports import ClockPort, LeadStorePort, RoutingOutcome
 from leadquali.domain.models import Action
 from leadquali.domain.spam import DEFAULT_SPAM_POLICY, SpamPolicy, SpamReason, screen
+from leadquali.observability import ensure_trace_id, log_context, log_lead_accepted, new_trace_id
 from leadquali.prompts.lead import LeadSubmission
 
 LOGGER = logging.getLogger(__name__)
@@ -45,6 +46,15 @@ DEFAULT_SOURCE: Final[str] = "web_form"
 #: Version stamped on every queue message. #26 puts these on SQS, where a message written
 #: by yesterday's deploy is read by today's worker; an unrecognised version is refused
 #: rather than partially understood.
+#:
+#: Still ``1`` after #21 added ``trace_id``, and deliberately so. A version bump would have
+#: been a breaking change in the middle of a rolling deploy: the old worker refuses any
+#: version it does not know, so every message the new ingest wrote while both were running
+#: would have gone to the DLQ. The field is *additive and optional in both directions*
+#: instead — an old worker reads the keys it knows and ignores ``trace_id``; a new worker
+#: reading an old message finds none and mints one (see :meth:`QueuedLead.from_message`).
+#: Neither side can be broken by the other's deploy order, which is the only property that
+#: makes a version number worth keeping for the change that does need it.
 QUEUE_MESSAGE_VERSION: Final[int] = 1
 
 
@@ -64,6 +74,10 @@ class QueuedLead:
     submission: LeadSubmission
     source: str
     received_at: datetime
+    trace_id: str = field(default_factory=new_trace_id)
+    """The id that makes this lead's ingest half and its worker half the same journey.
+    Defaulted rather than required so that a caller who has not thought about tracing still
+    produces a traceable lead — an unset trace id is the one value that helps nobody."""
 
     def to_message(self) -> dict[str, Any]:
         """The JSON-safe form that goes on the wire (an SQS message body in #26)."""
@@ -74,12 +88,19 @@ class QueuedLead:
             "submission_id": self.submission_id,
             "source": self.source,
             "received_at": self.received_at.isoformat(),
+            "trace_id": self.trace_id,
             "submission": self.submission.model_dump(mode="json"),
         }
 
     @classmethod
     def from_message(cls, message: Mapping[str, Any]) -> QueuedLead:
         """Rebuild a queued lead from :meth:`to_message`.
+
+        A message written before ``trace_id`` existed — one already on the queue when this
+        shipped — is not an error and is not refused: it loads with a freshly minted id, so
+        the worker half of its journey is still greppable under a single id and only the
+        ingest half sits under none. Refusing it would have meant sending real leads to the
+        DLQ to protect a log field, which is the wrong trade by a wide margin.
 
         Raises:
             ValueError: the message is not a version this code understands, or a required
@@ -100,6 +121,7 @@ class QueuedLead:
                 submission=LeadSubmission.model_validate(message["submission"]),
                 source=str(message["source"]),
                 received_at=datetime.fromisoformat(str(message["received_at"])),
+                trace_id=ensure_trace_id(_optional_str(message.get("trace_id"))),
             )
         except KeyError as error:
             raise ValueError(f"queue message is missing {error.args[0]!r}") from None
@@ -159,12 +181,21 @@ class IngestRequest:
     elapsed_ms: int | None = None
     """Client-reported milliseconds from form render to submit; ``None`` if not reported."""
 
+    trace_id: str | None = None
+    """The id to trace this lead by, when the caller already has one — the HTTP layer mints
+    it so that a request rejected before this point still logs under an id. ``None`` means
+    "mint one here", which is what a CLI replay or a test gets."""
+
 
 @dataclass(frozen=True, slots=True)
 class IngestReceipt:
     """What happened to one submission, for the response, the log and the tests."""
 
     tenant_id: str
+    trace_id: str
+    """Echoed back so the caller can put it on its own log line — and, in #26, on the SQS
+    message and the HTTP response header — without re-deriving it."""
+
     submission_id: str
     lead_id: str
     disposition: IngestDisposition
@@ -208,6 +239,12 @@ class IngestService:
         duplicate, or an exception on the way to the queue — leaves a row a person can
         find.
 
+        This is also where a lead's trace id is minted (or adopted from the caller) and
+        bound to the logging context, so that everything written from here down — the
+        store's own lines, the queue's, and the exception if one escapes — carries it. The
+        binding is a wrapper rather than a ``with`` inside the body so that the body reads
+        as the sequence of steps it is.
+
         Raises:
             ValueError: the submission id is blank. It is the idempotency key, and a blank
                 one would make every post the same lead.
@@ -215,6 +252,14 @@ class IngestService:
                 the form retries with the same ``submission_id``, which is why the retry
                 path is the tested one.
         """
+        trace_id = ensure_trace_id(request.trace_id)
+        with log_context(
+            trace_id=trace_id, tenant_id=request.tenant_id, submission_id=request.submission_id
+        ):
+            return self._accept(request, trace_id)
+
+    def _accept(self, request: IngestRequest, trace_id: str) -> IngestReceipt:
+        """The body of :meth:`accept`, inside the trace context it binds."""
         submission_id = request.submission_id.strip()
         if not submission_id:
             raise ValueError("submission_id must not be blank; it is the idempotency key")
@@ -231,13 +276,17 @@ class IngestService:
         if not stored.is_new and self._store.already_routed(
             tenant_id=request.tenant_id, lead_id=stored.lead_id
         ):
-            return self._receipt(
+            return self._announce(
+                self._receipt(
+                    request,
+                    trace_id,
+                    submission_id,
+                    stored.lead_id,
+                    IngestDisposition.DUPLICATE,
+                    received_at,
+                    is_new=False,
+                ),
                 request,
-                submission_id,
-                stored.lead_id,
-                IngestDisposition.DUPLICATE,
-                received_at,
-                is_new=False,
             )
 
         verdict = screen(
@@ -248,14 +297,18 @@ class IngestService:
         )
         if verdict.reason is not None:
             self._suppress(request, stored.lead_id, verdict.reason, verdict.detail, received_at)
-            return self._receipt(
+            return self._announce(
+                self._receipt(
+                    request,
+                    trace_id,
+                    submission_id,
+                    stored.lead_id,
+                    IngestDisposition.SUPPRESSED,
+                    received_at,
+                    is_new=stored.is_new,
+                    spam_reason=verdict.reason,
+                ),
                 request,
-                submission_id,
-                stored.lead_id,
-                IngestDisposition.SUPPRESSED,
-                received_at,
-                is_new=stored.is_new,
-                spam_reason=verdict.reason,
             )
 
         self._queue.enqueue(
@@ -266,15 +319,20 @@ class IngestService:
                 submission=request.submission,
                 source=request.source or self._source,
                 received_at=received_at,
+                trace_id=trace_id,
             )
         )
-        return self._receipt(
+        return self._announce(
+            self._receipt(
+                request,
+                trace_id,
+                submission_id,
+                stored.lead_id,
+                IngestDisposition.QUEUED,
+                received_at,
+                is_new=stored.is_new,
+            ),
             request,
-            submission_id,
-            stored.lead_id,
-            IngestDisposition.QUEUED,
-            received_at,
-            is_new=stored.is_new,
         )
 
     def _suppress(
@@ -298,8 +356,30 @@ class IngestService:
         )
 
     @staticmethod
+    def _announce(receipt: IngestReceipt, request: IngestRequest) -> IngestReceipt:
+        """Emit the first line of this lead's journey, then hand the receipt back.
+
+        Emitted here rather than in the HTTP handler so that every caller of this service
+        — the endpoint, #26's producer, a replay script — produces the same event with the
+        same fields. The submission goes no further than
+        :func:`~leadquali.observability.pii.contact_email_hash`.
+        """
+        log_lead_accepted(
+            LOGGER,
+            tenant_id=receipt.tenant_id,
+            lead_id=receipt.lead_id,
+            disposition=receipt.disposition.value,
+            source=request.source,
+            is_new_lead=receipt.is_new_lead,
+            email=request.submission.email,
+            spam_reason=receipt.spam_reason.value if receipt.spam_reason is not None else None,
+        )
+        return receipt
+
+    @staticmethod
     def _receipt(
         request: IngestRequest,
+        trace_id: str,
         submission_id: str,
         lead_id: str,
         disposition: IngestDisposition,
@@ -310,6 +390,7 @@ class IngestService:
     ) -> IngestReceipt:
         return IngestReceipt(
             tenant_id=request.tenant_id,
+            trace_id=trace_id,
             submission_id=submission_id,
             lead_id=lead_id,
             disposition=disposition,
@@ -317,6 +398,11 @@ class IngestService:
             is_new_lead=is_new,
             spam_reason=spam_reason,
         )
+
+
+def _optional_str(value: Any) -> str | None:
+    """A trimmed string, or ``None`` for a key the message did not carry."""
+    return None if value is None else str(value)
 
 
 __all__ = [

--- a/src/leadquali/app/qualify.py
+++ b/src/leadquali/app/qualify.py
@@ -43,6 +43,7 @@ make the signature that #17, #21 and #26 call three times as wide as the thing i
 
 from __future__ import annotations
 
+import logging
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum
@@ -67,7 +68,18 @@ from leadquali.app.ports import (
 from leadquali.domain.models import Action, EscalationReason, RoutingDecision, Tier
 from leadquali.domain.routing import decide, system_failure
 from leadquali.domain.tenant_config import TenantConfig
+from leadquali.observability import (
+    ensure_trace_id,
+    log_assessment,
+    log_context,
+    log_dispatch_failed,
+    log_lead_duplicate,
+    log_lead_routed,
+    log_lead_suppressed,
+)
 from leadquali.prompts.lead import LeadSubmission, render_lead_detailed
+
+LOGGER = logging.getLogger(__name__)
 
 #: Where a lead came from when the caller does not say. Recorded on the lead row so a
 #: tenant with a web form, a webhook and a CSV import can tell them apart later.
@@ -107,13 +119,27 @@ class QualificationRequest:
     """When ingest accepted the lead. The clock is read when this is ``None``, so a message
     that sat in the queue for an hour is not recorded as having arrived an hour late."""
 
+    trace_id: str | None = None
+    """The id minted at ingest and carried on the queue message, so that the worker's half
+    of this lead's journey is greppable together with the edge's. ``None`` — a CLI replay,
+    a test, a message written before #21 — mints a fresh one rather than going untraced."""
+
 
 @dataclass(frozen=True, slots=True)
 class QualificationResult:
     """What happened, in the terms #21's metrics and #26's worker need.
 
-    Returned rather than logged: this module has no logger, because a pipeline that decides
-    its own log format cannot be reused by a CLI, a test and a Lambda.
+    Still returned rather than *only* logged, and for the original reason: a caller needs
+    the outcome as a value — #26's worker acknowledges the SQS message on it, and the CLI
+    prints from it — and a caller that had to parse its own log output would be absurd.
+
+    What changed with #21 is that the pipeline also *emits* the outcome, which is not the
+    same thing as deciding a log format. It calls
+    :mod:`leadquali.observability.events`, which names the events and owns the field set;
+    whether that becomes a JSON line or a human one is
+    :func:`~leadquali.observability.logs.configure_logging`'s business, chosen once per
+    process by the entry point. The pipeline is still reusable by a CLI, a test and a
+    Lambda, and all three now produce the same events.
     """
 
     tenant_id: str
@@ -143,6 +169,10 @@ class QualificationResult:
     latency_ms: int
     """Wall-clock cost of the whole pipeline, from a monotonic reading. Not the model's
     latency, which rides on :attr:`metering`."""
+
+    trace_id: str
+    """The id every log record from this run carries. Returned so the worker can put it on
+    an SQS batch-item failure, where the log line and the failed message meet."""
 
     @property
     def dispatched(self) -> bool:
@@ -230,6 +260,20 @@ class QualificationPipeline:
             delivery was a repeat of one already routed and nothing was done — no model
             call, no email, no second row.
         """
+        trace_id = ensure_trace_id(request.trace_id)
+        with log_context(
+            trace_id=trace_id,
+            tenant_id=request.tenant_id,
+            submission_id=request.submission_id,
+        ):
+            return self._qualify(request, trace_id)
+
+    def _qualify(self, request: QualificationRequest, trace_id: str) -> QualificationResult:
+        """The body of :meth:`qualify`, inside the trace context it binds.
+
+        Split out rather than indenting the whole method under a ``with``: the sequence of
+        steps is the readable thing about this code, and the binding is not one of them.
+        """
         started_ms = self._clock.monotonic_ms()
         config = self._config_source.get(request.tenant_id)
         lead = self._store.upsert_lead(
@@ -246,9 +290,10 @@ class QualificationPipeline:
         if not lead.is_new and self._store.already_routed(
             tenant_id=request.tenant_id, lead_id=lead.lead_id
         ):
-            return self._result(
+            duplicate = self._result(
                 request=request,
                 lead=lead,
+                trace_id=trace_id,
                 disposition=Disposition.DUPLICATE,
                 decision=None,
                 destination=None,
@@ -258,11 +303,32 @@ class QualificationPipeline:
                 metering=None,
                 started_ms=started_ms,
             )
+            log_lead_duplicate(
+                LOGGER,
+                tenant_id=request.tenant_id,
+                lead_id=lead.lead_id,
+                latency_ms=duplicate.latency_ms,
+            )
+            return duplicate
 
         enrichment = self._enrich(request)
         rendered = render_lead_detailed(request.submission)
         outcome = self._assess(config, _compose_user_turn(enrichment, rendered.text))
         decision = self._decide(outcome, config)
+
+        # Before the branch, so that `Assessments` by `Tier` is the distribution over every
+        # decision rather than over the ones that happened to be emailed. That completeness
+        # is the whole basis of plan section 8's tier-distribution drift signal.
+        log_assessment(
+            LOGGER,
+            tenant_id=request.tenant_id,
+            lead_id=lead.lead_id,
+            decision=decision,
+            metering=outcome.metering,
+            assessed=outcome.ok,
+            confidence=outcome.assessment.confidence if outcome.ok else None,
+            enrichment_available=enrichment.available,
+        )
 
         self._store.record_assessment(
             tenant_id=request.tenant_id,
@@ -286,9 +352,10 @@ class QualificationPipeline:
                 occurred_at=self._clock.now(),
                 detail=decision.note,
             )
-            return self._result(
+            suppressed = self._result(
                 request=request,
                 lead=lead,
+                trace_id=trace_id,
                 disposition=Disposition.SUPPRESSED,
                 decision=decision,
                 destination=None,
@@ -298,6 +365,14 @@ class QualificationPipeline:
                 metering=outcome.metering,
                 started_ms=started_ms,
             )
+            log_lead_suppressed(
+                LOGGER,
+                tenant_id=request.tenant_id,
+                lead_id=lead.lead_id,
+                decision=decision,
+                latency_ms=suppressed.latency_ms,
+            )
+            return suppressed
 
         destination, used_fallback = self._destination_for(config, decision)
         try:
@@ -311,6 +386,14 @@ class QualificationPipeline:
             )
         except Exception as error:
             self._record_failed_dispatch(request, lead, decision, destination, error)
+            log_dispatch_failed(
+                LOGGER,
+                tenant_id=request.tenant_id,
+                lead_id=lead.lead_id,
+                tier=decision.tier,
+                destination=destination,
+                error=error,
+            )
             raise
 
         self._store.record_routing_event(
@@ -323,9 +406,10 @@ class QualificationPipeline:
             occurred_at=self._clock.now(),
             detail=decision.note,
         )
-        return self._result(
+        dispatched = self._result(
             request=request,
             lead=lead,
+            trace_id=trace_id,
             disposition=Disposition.DISPATCHED,
             decision=decision,
             destination=destination,
@@ -335,6 +419,18 @@ class QualificationPipeline:
             metering=outcome.metering,
             started_ms=started_ms,
         )
+        log_lead_routed(
+            LOGGER,
+            tenant_id=request.tenant_id,
+            lead_id=lead.lead_id,
+            tier=decision.tier,
+            action=decision.action,
+            destination=destination,
+            used_fallback_destination=used_fallback,
+            provider_message_id=provider_message_id,
+            latency_ms=dispatched.latency_ms,
+        )
+        return dispatched
 
     # ------------------------------------------------------------------------- steps
 
@@ -435,6 +531,7 @@ class QualificationPipeline:
         *,
         request: QualificationRequest,
         lead: StoredLead,
+        trace_id: str,
         disposition: Disposition,
         decision: RoutingDecision | None,
         destination: str | None,
@@ -457,6 +554,7 @@ class QualificationPipeline:
             is_new_lead=lead.is_new,
             metering=metering,
             latency_ms=max(0, self._clock.monotonic_ms() - started_ms),
+            trace_id=trace_id,
         )
 
 

--- a/src/leadquali/cli.py
+++ b/src/leadquali/cli.py
@@ -42,6 +42,7 @@ from leadquali.config import get_settings
 from leadquali.domain.models import RoutingDecision
 from leadquali.domain.routing import decide, system_failure
 from leadquali.domain.tenant_config import TenantConfig, TenantConfigError
+from leadquali.observability import configure_logging
 from leadquali.prompts.lead import LeadSubmission, render_lead_detailed
 
 #: Exit code for a usage or input problem. Reserved so a caller can tell "you gave me a
@@ -90,6 +91,11 @@ def main(
     argv: Sequence[str] | None = None, *, assessor_factory: AssessorFactory | None = None
 ) -> int:
     """Run the CLI. Returns the process exit code."""
+    # Logs go to stderr, never stdout. `--json` writes a machine-readable record on stdout
+    # that #23's eval harness pipes into a file, and one interleaved log line would make it
+    # unparseable. Configured at all — rather than left to Python's "no handler" default —
+    # so that an adapter's retry or a slow call is visible while a person waits for it.
+    configure_logging(stream=sys.stderr)
     parser = build_parser()
     raw = list(sys.argv[1:] if argv is None else argv)
     # `score` is the only subcommand, so allow it to be omitted for everyday use.

--- a/src/leadquali/observability/__init__.py
+++ b/src/leadquali/observability/__init__.py
@@ -1,0 +1,111 @@
+"""Structured logs, trace ids and CloudWatch metrics — the things #29 alarms on.
+
+Plan §8 and issue #21. The field set, the metric names and the alarms #29 should build on
+them are written up in ``docs/observability.md``; that file is the contract, and this
+package is its implementation. Five modules, each with one job:
+
+* :mod:`~leadquali.observability.context` — the trace id and the ambient identifiers every
+  record inherits, on a ``ContextVar``.
+* :mod:`~leadquali.observability.logs` — :func:`configure_logging` and the two formatters.
+  JSON in every deployed environment, prose locally, the same fields either way.
+* :mod:`~leadquali.observability.metrics` — CloudWatch Embedded Metric Format, so a metric
+  is a field on a log line rather than an API call in the path of a customer's lead.
+* :mod:`~leadquali.observability.pii` — the hash that may be logged, and the redaction net
+  for what arrives from outside.
+* :mod:`~leadquali.observability.events` — the event catalogue: one function per emitted
+  event, so the field set and the metric names are a contract in one file rather than a
+  convention spread over six.
+
+**Where this sits in the layering.** ``CLAUDE.md`` puts ``domain`` below ``app`` below
+``adapters``/``api``. This package sits beside all of them, like the standard library's
+``logging`` that it wraps: it is pure Python, it performs no I/O beyond writing a line to a
+stream, it imports no SDK, and it reads value types (``RoutingDecision``, ``CallMetering``)
+without ever calling back into the layers that own them. That is what lets the pipeline,
+the ingest service and the adapters all emit the same field set — and it is checked, not
+asserted: ``tests/unit/test_layering.py`` fails if this package ever imports ``adapters``
+or ``api``.
+"""
+
+from __future__ import annotations
+
+from leadquali.observability.context import (
+    CONTEXT_FIELDS,
+    TRACE_ID,
+    current_context,
+    current_trace_id,
+    ensure_trace_id,
+    log_context,
+    new_trace_id,
+)
+from leadquali.observability.events import (
+    EVENT_ASSESSMENT,
+    EVENT_DISPATCH_FAILED,
+    EVENT_LEAD_ACCEPTED,
+    EVENT_LEAD_DUPLICATE,
+    EVENT_LEAD_ROUTED,
+    EVENT_LEAD_SUPPRESSED,
+    SuppressionCause,
+    log_assessment,
+    log_dispatch_failed,
+    log_lead_accepted,
+    log_lead_duplicate,
+    log_lead_routed,
+    log_lead_suppressed,
+    suppression_cause,
+)
+from leadquali.observability.logs import (
+    LOG_FORMAT_HUMAN,
+    LOG_FORMAT_JSON,
+    SERVICE_NAME,
+    HumanLogFormatter,
+    JsonLogFormatter,
+    configure_logging,
+    log_event,
+)
+from leadquali.observability.metrics import (
+    METRIC_NAMESPACE,
+    Metric,
+    MetricPayload,
+    MetricSet,
+    Unit,
+)
+from leadquali.observability.pii import EMAIL_REDACTION, contact_email_hash, redact_emails
+
+__all__ = [
+    "CONTEXT_FIELDS",
+    "EMAIL_REDACTION",
+    "EVENT_ASSESSMENT",
+    "EVENT_DISPATCH_FAILED",
+    "EVENT_LEAD_ACCEPTED",
+    "EVENT_LEAD_DUPLICATE",
+    "EVENT_LEAD_ROUTED",
+    "EVENT_LEAD_SUPPRESSED",
+    "LOG_FORMAT_HUMAN",
+    "LOG_FORMAT_JSON",
+    "METRIC_NAMESPACE",
+    "SERVICE_NAME",
+    "TRACE_ID",
+    "HumanLogFormatter",
+    "JsonLogFormatter",
+    "Metric",
+    "MetricPayload",
+    "MetricSet",
+    "SuppressionCause",
+    "Unit",
+    "configure_logging",
+    "contact_email_hash",
+    "current_context",
+    "current_trace_id",
+    "ensure_trace_id",
+    "log_assessment",
+    "log_context",
+    "log_dispatch_failed",
+    "log_event",
+    "log_lead_accepted",
+    "log_lead_duplicate",
+    "log_lead_routed",
+    "log_lead_suppressed",
+    "new_trace_id",
+    "redact_emails",
+    "suppression_cause",
+]

--- a/src/leadquali/observability/context.py
+++ b/src/leadquali/observability/context.py
@@ -1,0 +1,119 @@
+"""The ambient fields every log record inherits, and the trace id at the head of them.
+
+A lead's journey crosses four modules that know nothing about each other: the ingest
+endpoint, the queue, the pipeline, and the store and notifier adapters underneath it. The
+acceptance criterion for #21 is that the whole journey is reconstructable *by trace id
+alone*, which means the id has to be on records written by code that was never handed it.
+
+Threading a ``trace_id`` parameter into every adapter method would have put an
+observability concern into six port signatures — and it would still have missed the log
+lines inside SQLAlchemy and botocore. A :class:`~contextvars.ContextVar` carries it
+instead: whoever owns the lead binds it once, and
+:class:`~leadquali.observability.logs.JsonLogFormatter` reads it off the context on every
+record, from any logger, at any depth.
+
+``ContextVar`` rather than a thread local because it is correct in all three places this
+code runs: a synchronous worker thread, FastAPI's event loop (where one thread serves many
+requests concurrently, and a thread local would leak one lead's id onto another's log
+line), and ``asyncio`` tasks, which inherit a copy of the context at creation. The copy is
+also why binding inside a task cannot corrupt its parent.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
+from contextvars import ContextVar
+from types import MappingProxyType
+from typing import Final
+
+#: The context field that identifies one lead's journey.
+TRACE_ID: Final[str] = "trace_id"
+
+#: The other identifiers worth carrying ambiently. Kept as a documented tuple because the
+#: field set is a contract: #29 alarms on these names and Logs Insights queries filter on
+#: them, so a rename is a breaking change rather than a tidy-up.
+CONTEXT_FIELDS: Final[tuple[str, ...]] = (TRACE_ID, "tenant_id", "lead_id", "submission_id")
+
+#: The default, shared by every context that has bound nothing. Genuinely immutable rather
+#: than a bare ``{}``: a mutable default on a ``ContextVar`` is one accidental ``update()``
+#: away from leaking one lead's identifiers into every other context in the process.
+_NO_CONTEXT: Final[Mapping[str, str]] = MappingProxyType({})
+
+_CONTEXT: ContextVar[Mapping[str, str]] = ContextVar("leadquali_log_context", default=_NO_CONTEXT)
+
+
+def new_trace_id() -> str:
+    """A fresh trace id: 32 lowercase hex characters, unique per lead.
+
+    Hex without dashes because the id is grepped and pasted far more often than it is
+    parsed — ``fields @message | filter trace_id = "..."`` in Logs Insights, or a bare
+    ``grep`` over a downloaded log — and a format with no punctuation survives both a
+    double-click and a shell without quoting.
+    """
+    return uuid.uuid4().hex
+
+
+def current_context() -> Mapping[str, str]:
+    """The fields currently bound, or an empty mapping. Never ``None``."""
+    return _CONTEXT.get()
+
+
+def current_trace_id() -> str | None:
+    """The trace id bound to this context, if any."""
+    return _CONTEXT.get().get(TRACE_ID)
+
+
+def ensure_trace_id(candidate: str | None = None) -> str:
+    """Return the trace id to use: the candidate, the bound one, or a new one.
+
+    The precedence is the propagation rule in one function. A lead that arrives carrying an
+    id keeps it — that is what makes the ingest half and the worker half of the journey the
+    same journey. A lead that arrives without one (a queue message written before this
+    change shipped, a CLI replay, a direct call from a test) gets a new id rather than none,
+    because a journey under a fresh id is still greppable and an unset field is not.
+
+    Args:
+        candidate: an id supplied by the caller, e.g. off a queue message. Blank counts as
+            absent, since a serialised empty string is indistinguishable from a missing key
+            to everyone downstream.
+    """
+    if candidate is not None and candidate.strip():
+        return candidate.strip()
+    bound = current_trace_id()
+    return bound if bound else new_trace_id()
+
+
+@contextmanager
+def log_context(**fields: str | None) -> Iterator[Mapping[str, str]]:
+    """Bind fields onto every log record emitted inside the block, then restore.
+
+    Nested blocks extend rather than replace, so the pipeline can add ``lead_id`` to the
+    ``trace_id`` and ``tenant_id`` the worker already bound. ``None`` values are ignored
+    rather than bound as ``"None"``, which keeps call sites free of conditionals.
+
+    Restoration goes through the ``ContextVar`` token rather than by re-binding the old
+    mapping, so an exception inside the block cannot leave one lead's identifiers attached
+    to the next one.
+
+    Yields:
+        The merged mapping now in force.
+    """
+    merged = {**_CONTEXT.get(), **{key: value for key, value in fields.items() if value}}
+    token = _CONTEXT.set(merged)
+    try:
+        yield merged
+    finally:
+        _CONTEXT.reset(token)
+
+
+__all__ = [
+    "CONTEXT_FIELDS",
+    "TRACE_ID",
+    "current_context",
+    "current_trace_id",
+    "ensure_trace_id",
+    "log_context",
+    "new_trace_id",
+]

--- a/src/leadquali/observability/events.py
+++ b/src/leadquali/observability/events.py
@@ -1,0 +1,383 @@
+"""The event catalogue: every log line and every metric this system emits, in one file.
+
+There is one function per event, and no caller anywhere builds a field dict by hand. That
+is the point of the module: the field set and the metric set are a published contract —
+#29 writes alarms against these metric names, #33 meters ``CostUsd`` for billing, and a
+Logs Insights query saved in a runbook filters on these field names — and a contract
+scattered across six call sites is a contract that drifts. Adding a field here is a
+deliberate change to a documented surface; adding one at a call site would not be.
+
+The functions take a ``logger`` so the ``logger`` field still names the module the event
+came from rather than this one, and they take ``tenant_id`` and ``lead_id`` explicitly —
+the first because it is a metric dimension, the second because it is only known halfway
+through the pipeline and threading it through beats re-binding the context mid-method.
+Everything else rides on :func:`~leadquali.observability.context.log_context`: ``trace_id``
+and ``submission_id`` are bound once by whoever owns the lead and appear on every record,
+including the ones written by SQLAlchemy and botocore underneath.
+
+Nothing here takes a ``LeadSubmission``, an address or a note written by a lead. The
+signatures are the enforcement: a function that cannot be passed PII cannot log it.
+"""
+
+from __future__ import annotations
+
+import logging
+from decimal import Decimal
+from enum import StrEnum
+from typing import Final
+
+from leadquali.app.assessment_result import CallMetering
+from leadquali.domain.models import Action, RoutingDecision, Tier
+from leadquali.domain.routing import LOW_SCORE_SUPPRESSION_NOTE, SPAM_NOTE
+from leadquali.observability.logs import log_event
+from leadquali.observability.metrics import (
+    ASSESSMENT_FAILURES,
+    ASSESSMENTS,
+    CACHE_CREATION_TOKENS,
+    CACHE_READ_TOKENS,
+    COST_USD,
+    DIM_DISPOSITION,
+    DIM_ESCALATION_REASON,
+    DIM_SPAM_REASON,
+    DIM_SUPPRESSION_CAUSE,
+    DIM_TENANT,
+    DIM_TIER,
+    DISPATCH_FAILURES,
+    DISPATCHES,
+    DUPLICATES,
+    ENRICHMENT_UNAVAILABLE,
+    ESCALATIONS,
+    FALLBACK_DESTINATIONS,
+    INGEST_SUPPRESSIONS,
+    INGESTED_LEADS,
+    INPUT_TOKENS,
+    MODEL_LATENCY_MS,
+    OUTPUT_TOKENS,
+    PIPELINE_LATENCY_MS,
+    SUPPRESSIONS,
+    Metric,
+    MetricPayload,
+    MetricSet,
+    Unit,
+)
+from leadquali.observability.pii import contact_email_hash
+
+#: A submission was accepted at the public edge and queued, suppressed or recognised as a
+#: redelivery. The first line of every lead's journey and where its trace id is minted.
+EVENT_LEAD_ACCEPTED: Final[str] = "lead.accepted"
+
+#: One assessment finished — successfully or not — and a routing decision was reached.
+#: This is the per-assessment metrics line: tokens, cost, latency, tier, provenance.
+EVENT_ASSESSMENT: Final[str] = "assessment.completed"
+
+#: A person was notified.
+EVENT_LEAD_ROUTED: Final[str] = "lead.routed"
+
+#: A lead was recorded and deliberately not contacted, with the cause.
+EVENT_LEAD_SUPPRESSED: Final[str] = "lead.suppressed"
+
+#: A redelivery of a lead already routed. Nothing was done, on purpose.
+EVENT_LEAD_DUPLICATE: Final[str] = "lead.duplicate"
+
+#: Dispatch raised. The lead is still on the queue and will be retried.
+EVENT_DISPATCH_FAILED: Final[str] = "lead.dispatch_failed"
+
+
+class SuppressionCause(StrEnum):
+    """Why a lead was never contacted. The two answers are not interchangeable.
+
+    A rise in :attr:`SPAM` is a bot campaign, and a rise in :attr:`BELOW_THRESHOLD` is a
+    rubric or a form change — the first is somebody else's problem and the second is ours.
+    #52 gave the two suppressions distinguishable notes so this distinction could survive
+    into a metric dimension; :func:`suppression_cause` is where that is cashed in.
+    """
+
+    SPAM = "spam"
+    BELOW_THRESHOLD = "below_threshold"
+    UNKNOWN = "unknown"
+    """A suppression reached by a path that did not exist when this was written. Emitted
+    rather than guessed at: a metric that quietly attributes a new cause to an old bucket
+    is worse than one that says it does not know."""
+
+
+def suppression_cause(decision: RoutingDecision) -> SuppressionCause:
+    """Classify a suppression by the note ``domain.routing`` stamped on it."""
+    if decision.note.startswith(SPAM_NOTE):
+        return SuppressionCause.SPAM
+    if decision.note.startswith(LOW_SCORE_SUPPRESSION_NOTE):
+        return SuppressionCause.BELOW_THRESHOLD
+    return SuppressionCause.UNKNOWN
+
+
+def log_lead_accepted(
+    logger: logging.Logger,
+    *,
+    tenant_id: str,
+    lead_id: str,
+    disposition: str,
+    source: str,
+    is_new_lead: bool,
+    email: str | None,
+    spam_reason: str | None,
+) -> None:
+    """The edge accepted one submission.
+
+    Args:
+        email: the contact address, hashed here and never emitted. Taking the address and
+            hashing it in one place is what keeps every call site from having to remember;
+            the parameter exists so no caller is tempted to pass the address as a field.
+    """
+    sets = [
+        MetricSet((DIM_TENANT, DIM_DISPOSITION), (Metric(INGESTED_LEADS, 1),)),
+    ]
+    dimensions = {DIM_TENANT: tenant_id, DIM_DISPOSITION: disposition}
+    if spam_reason is not None:
+        dimensions[DIM_SPAM_REASON] = spam_reason
+        sets.append(MetricSet((DIM_TENANT, DIM_SPAM_REASON), (Metric(INGEST_SUPPRESSIONS, 1),)))
+
+    log_event(
+        logger,
+        EVENT_LEAD_ACCEPTED,
+        lead_id=lead_id,
+        disposition=disposition,
+        source=source,
+        is_new_lead=is_new_lead,
+        contact_email_hash=contact_email_hash(email),
+        spam_reason=spam_reason,
+        metrics=MetricPayload(dimensions=dimensions, metric_sets=tuple(sets)),
+    )
+
+
+def log_assessment(
+    logger: logging.Logger,
+    *,
+    tenant_id: str,
+    lead_id: str,
+    decision: RoutingDecision,
+    metering: CallMetering | None,
+    assessed: bool,
+    confidence: float | None,
+    enrichment_available: bool,
+) -> None:
+    """One assessment and the decision it produced — the per-assessment metrics line.
+
+    Emitted for *every* decision, successful or not, before the suppress/dispatch branch,
+    which is what makes ``Assessments`` by ``Tier`` a complete tier distribution rather
+    than a distribution over the leads that happened to be emailed.
+
+    ``metering`` is emitted exactly as :mod:`leadquali.adapters.llm_anthropic` computed it.
+    Nothing here recomputes a token count or a cost: two definitions of what a lead cost
+    is a billing dispute with a customer.
+
+    Args:
+        assessed: whether the model returned a judgement. ``False`` still produces a full
+            line — a refusal is billed, and a failure that is not counted is an outage
+            nobody is paged for.
+        confidence: the model's own confidence, or ``None`` when there is no assessment.
+    """
+    reason = decision.escalation_reason
+    dimensions = {DIM_TENANT: tenant_id, DIM_TIER: decision.tier.value}
+    totals: list[Metric] = [
+        Metric(ASSESSMENTS, 1),
+        Metric(ASSESSMENT_FAILURES, 0 if assessed else 1),
+        Metric(ENRICHMENT_UNAVAILABLE, 0 if enrichment_available else 1),
+    ]
+    if metering is not None:
+        totals.extend(
+            (
+                Metric(INPUT_TOKENS, metering.input_tokens),
+                Metric(OUTPUT_TOKENS, metering.output_tokens),
+                Metric(CACHE_READ_TOKENS, metering.cache_read_tokens),
+                Metric(CACHE_CREATION_TOKENS, metering.cache_creation_tokens),
+                Metric(COST_USD, metering.cost_usd, Unit.NONE),
+                Metric(MODEL_LATENCY_MS, metering.latency_ms, Unit.MILLISECONDS),
+            )
+        )
+    sets = [
+        MetricSet((DIM_TENANT, DIM_TIER), (Metric(ASSESSMENTS, 1),)),
+        MetricSet((DIM_TENANT,), tuple(totals)),
+    ]
+    if reason is not None:
+        dimensions[DIM_ESCALATION_REASON] = reason.value
+        sets.append(MetricSet((DIM_TENANT, DIM_ESCALATION_REASON), (Metric(ESCALATIONS, 1),)))
+
+    log_event(
+        logger,
+        EVENT_ASSESSMENT,
+        lead_id=lead_id,
+        assessed=assessed,
+        tier=decision.tier.value,
+        action=decision.action.value,
+        total_score=decision.total_score,
+        confidence=confidence,
+        escalation_reason=reason.value if reason is not None else None,
+        enrichment_available=enrichment_available,
+        fields=_metering_fields(metering),
+        metrics=MetricPayload(dimensions=dimensions, metric_sets=tuple(sets)),
+    )
+
+
+def log_lead_routed(
+    logger: logging.Logger,
+    *,
+    tenant_id: str,
+    lead_id: str,
+    tier: Tier,
+    action: Action,
+    destination: str,
+    used_fallback_destination: bool,
+    provider_message_id: str | None,
+    latency_ms: int,
+) -> None:
+    """A person was notified.
+
+    ``destination`` is hashed on the way in for the same reason a contact address is: it is
+    an individual salesperson's mailbox, and an operator needs to tell two destinations
+    apart far more often than they need to read one.
+    """
+    log_event(
+        logger,
+        EVENT_LEAD_ROUTED,
+        lead_id=lead_id,
+        tier=tier.value,
+        action=action.value,
+        destination_hash=contact_email_hash(destination),
+        used_fallback_destination=used_fallback_destination,
+        provider_message_id=provider_message_id,
+        latency_ms=latency_ms,
+        metrics=MetricPayload(
+            dimensions={DIM_TENANT: tenant_id, DIM_TIER: tier.value},
+            metric_sets=(
+                MetricSet((DIM_TENANT, DIM_TIER), (Metric(DISPATCHES, 1),)),
+                MetricSet(
+                    (DIM_TENANT,),
+                    (
+                        Metric(DISPATCHES, 1),
+                        Metric(FALLBACK_DESTINATIONS, 1 if used_fallback_destination else 0),
+                        Metric(PIPELINE_LATENCY_MS, latency_ms, Unit.MILLISECONDS),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def log_lead_suppressed(
+    logger: logging.Logger,
+    *,
+    tenant_id: str,
+    lead_id: str,
+    decision: RoutingDecision,
+    latency_ms: int,
+) -> None:
+    """A lead was recorded and deliberately not contacted."""
+    cause = suppression_cause(decision)
+    log_event(
+        logger,
+        EVENT_LEAD_SUPPRESSED,
+        lead_id=lead_id,
+        tier=decision.tier.value,
+        suppression_cause=cause.value,
+        total_score=decision.total_score,
+        latency_ms=latency_ms,
+        metrics=MetricPayload(
+            dimensions={DIM_TENANT: tenant_id, DIM_SUPPRESSION_CAUSE: cause.value},
+            metric_sets=(
+                MetricSet((DIM_TENANT, DIM_SUPPRESSION_CAUSE), (Metric(SUPPRESSIONS, 1),)),
+                MetricSet(
+                    (DIM_TENANT,), (Metric(PIPELINE_LATENCY_MS, latency_ms, Unit.MILLISECONDS),)
+                ),
+            ),
+        ),
+    )
+
+
+def log_lead_duplicate(
+    logger: logging.Logger, *, tenant_id: str, lead_id: str, latency_ms: int
+) -> None:
+    """A redelivery of a lead that was already routed. No model call, no email, no row."""
+    log_event(
+        logger,
+        EVENT_LEAD_DUPLICATE,
+        lead_id=lead_id,
+        latency_ms=latency_ms,
+        metrics=MetricPayload(
+            dimensions={DIM_TENANT: tenant_id},
+            metric_sets=(
+                MetricSet(
+                    (DIM_TENANT,),
+                    (
+                        Metric(DUPLICATES, 1),
+                        Metric(PIPELINE_LATENCY_MS, latency_ms, Unit.MILLISECONDS),
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def log_dispatch_failed(
+    logger: logging.Logger,
+    *,
+    tenant_id: str,
+    lead_id: str,
+    tier: Tier,
+    destination: str,
+    error: BaseException,
+) -> None:
+    """Dispatch raised; the lead stays on the queue.
+
+    Logged at ``ERROR`` with the traceback attached, because this is the line an operator
+    is looking at when the DLQ alarm fires. The traceback goes through the formatter's
+    redaction and carries no locals — see
+    :meth:`~leadquali.observability.logs._BaseFormatter._exception`.
+    """
+    log_event(
+        logger,
+        EVENT_DISPATCH_FAILED,
+        level=logging.ERROR,
+        lead_id=lead_id,
+        exc_info=error,
+        tier=tier.value,
+        destination_hash=contact_email_hash(destination),
+        error_type=type(error).__name__,
+        metrics=MetricPayload(
+            dimensions={DIM_TENANT: tenant_id},
+            metric_sets=(MetricSet((DIM_TENANT,), (Metric(DISPATCH_FAILURES, 1),)),),
+        ),
+    )
+
+
+def _metering_fields(metering: CallMetering | None) -> dict[str, str | int | Decimal | None]:
+    """The metering, flattened into log fields under the names the plan uses."""
+    if metering is None:
+        return {}
+    return {
+        "model_id": metering.model_id,
+        "prompt_version": metering.prompt_version,
+        "effort": metering.effort,
+        "input_tokens": metering.input_tokens,
+        "output_tokens": metering.output_tokens,
+        "cache_read_tokens": metering.cache_read_tokens,
+        "cache_creation_tokens": metering.cache_creation_tokens,
+        "cost_usd": metering.cost_usd,
+        "model_latency_ms": metering.latency_ms,
+    }
+
+
+__all__ = [
+    "EVENT_ASSESSMENT",
+    "EVENT_DISPATCH_FAILED",
+    "EVENT_LEAD_ACCEPTED",
+    "EVENT_LEAD_DUPLICATE",
+    "EVENT_LEAD_ROUTED",
+    "EVENT_LEAD_SUPPRESSED",
+    "SuppressionCause",
+    "log_assessment",
+    "log_dispatch_failed",
+    "log_lead_accepted",
+    "log_lead_duplicate",
+    "log_lead_routed",
+    "log_lead_suppressed",
+    "suppression_cause",
+]

--- a/src/leadquali/observability/logs.py
+++ b/src/leadquali/observability/logs.py
@@ -1,0 +1,370 @@
+"""One JSON object per line, configured once, safe to configure again.
+
+**The field set is the contract.** Every record carries ``timestamp``, ``level``,
+``logger``, ``message``, ``service`` and ``env``; every record written by our own code also
+carries ``event`` (a stable dotted name) and whatever identifiers are bound to the context
+— ``trace_id`` first among them. Event-specific fields sit flat at the root next to those,
+in ``snake_case``, because ``fields @message | filter tier = "hot"`` in Logs Insights is
+one line and ``json_parse`` gymnastics over a nested object is not. Nothing is nested
+except ``exception``, which has to be.
+
+**Why ``configure_logging`` is idempotent rather than guarded by a module flag.** A Lambda
+container is reused across invocations and a handler added per invocation is a line
+duplicated per invocation — by the hundredth call the log bill is two orders of magnitude
+off and every metric is counted a hundred times. A flag would fix that and break the other
+case: the same process may legitimately reconfigure (a test, a CLI that reads its settings
+after import, ``uvicorn --reload``). So the function is written to *converge* — it removes
+the handler it installed before and installs exactly one — which is correct however many
+times it is called, in whatever order.
+
+It also takes the root logger over rather than adding alongside. In Lambda the runtime
+pre-installs its own handler, and leaving it in place means every line appears twice: once
+as JSON and once with a request-id prefix. Anything already on the root logger is a
+formatter we did not choose, which by definition is not the format this module exists to
+guarantee.
+
+**Local development gets prose.** ``ENV=local`` selects
+:class:`HumanLogFormatter` — the same fields, on one readable line — because a person
+tailing a terminal reads ``lead.routed tenant_id=acme tier=hot`` and does not read a JSON
+object. Every deployed environment gets JSON. Nothing about *what* is emitted changes with
+the format; only how it is rendered.
+
+Both formatters run every rendered message and every traceback through
+:func:`~leadquali.observability.pii.redact_emails` on the way out (invariant 5).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+import traceback
+from collections.abc import Mapping
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any, Final, Literal, TextIO
+
+from leadquali.config import Environment, Settings, get_settings
+from leadquali.observability.context import current_context
+from leadquali.observability.metrics import MetricPayload, to_emf, to_text
+from leadquali.observability.pii import redact_emails
+
+#: Rendered as JSON, one object per line. Every deployed environment.
+LOG_FORMAT_JSON: Final[str] = "json"
+
+#: Rendered for a person. The default when ``ENV=local``.
+LOG_FORMAT_HUMAN: Final[str] = "human"
+
+type LogFormat = Literal["json", "human"]
+
+#: Stamped on every record so one log group can hold more than one service.
+SERVICE_NAME: Final[str] = "leadquali"
+
+#: Fields the formatter owns. An event field of the same name is overwritten rather than
+#: honoured: a caller must not be able to move a record's own timestamp or level.
+RESERVED_FIELDS: Final[frozenset[str]] = frozenset(
+    {"timestamp", "level", "logger", "message", "event", "service", "env", "exception", "_aws"}
+)
+
+#: Third-party loggers pinned no lower than ``WARNING``. At ``LOG_LEVEL=DEBUG`` these emit
+#: every SQL statement, every HTTP request and every retry, which buries our own lines and
+#: — for SQLAlchemy's echo of bound parameters — would put a lead's email address in the
+#: log, through a code path no amount of discipline at our own call sites can reach.
+QUIET_LOGGERS: Final[tuple[str, ...]] = (
+    "anthropic",
+    "boto3",
+    "botocore",
+    "httpcore",
+    "httpx",
+    "s3transfer",
+    "sqlalchemy.engine",
+    "urllib3",
+)
+
+#: Attribute the payload of a structured event is stashed on. One key, rather than
+#: splatting fields onto the record, because ``extra=`` silently corrupts a record when a
+#: field happens to be called ``name``, ``msg``, ``args`` or ``levelname``.
+_PAYLOAD_ATTR: Final[str] = "_lq"
+
+#: Marks the handler this module installed, so a second call can find and replace it.
+_HANDLER_MARK: Final[str] = "_leadquali_handler"
+
+
+@dataclass(frozen=True, slots=True)
+class EventPayload:
+    """The structured half of one log record: its event name, fields and metrics."""
+
+    event: str
+    fields: dict[str, Any] = field(default_factory=dict)
+    metrics: MetricPayload | None = None
+
+
+def log_event(
+    logger: logging.Logger,
+    event: str,
+    *,
+    level: int = logging.INFO,
+    message: str | None = None,
+    exc_info: BaseException | bool | None = None,
+    metrics: MetricPayload | None = None,
+    fields: Mapping[str, Any] | None = None,
+    **inline_fields: Any,
+) -> None:
+    """Emit one structured record.
+
+    Args:
+        logger: the module's logger, so the ``logger`` field says where this came from.
+        event: the stable dotted event name, e.g. ``lead.routed``. Doubles as the message
+            when none is given — a name is more useful than a sentence to filter on, and
+            two spellings of the same event is how a dashboard quietly stops matching.
+        level: the log level.
+        message: a human sentence, when the event name alone is not enough.
+        exc_info: an exception to attach. Its type, its redacted message and its traceback
+            are recorded; nothing else from the frame is.
+        metrics: what this event publishes to CloudWatch, if anything.
+        fields: event-specific fields built programmatically — a flattened
+            :class:`~leadquali.app.assessment_result.CallMetering`, say. Exists alongside
+            ``**inline_fields`` because splatting a ``dict[str, Any]`` into a signature
+            with typed keyword-only parameters is not something a type checker can accept,
+            and losing the typing on ``level`` and ``metrics`` to save this parameter would
+            be the wrong trade.
+        **inline_fields: the same thing, written out at the call site. Merged over
+            ``fields`` on a clash. ``None`` values are dropped rather than emitted as
+            ``null``, so a query for "records with an escalation reason" means what it
+            says.
+
+    Note:
+        Fields must be PII-free by construction — ``contact_email_hash``, never ``email``;
+        a decision's note, never the lead's message. The formatter's redaction is a net for
+        what arrives from outside, not a licence to log a submission.
+    """
+    logger.log(
+        level,
+        message if message is not None else event,
+        exc_info=exc_info,
+        # So that `record.pathname`, `funcName` and `lineno` name the call site rather than
+        # this line. Nothing in the JSON format uses them, but pytest's log capture and any
+        # `%(lineno)d` formatter do, and a whole codebase whose logs all claim to come from
+        # `logs.py` is a debugging tax paid forever to save one argument here.
+        stacklevel=2,
+        extra={
+            _PAYLOAD_ATTR: EventPayload(
+                event=event,
+                fields={**(fields or {}), **inline_fields},
+                metrics=metrics,
+            )
+        },
+    )
+
+
+class _BaseFormatter(logging.Formatter):
+    """Shared record → fields mapping. Rendering is the subclass's business."""
+
+    def __init__(self, *, env: str) -> None:
+        super().__init__()
+        self._env = env
+
+    def _payload(self, record: logging.LogRecord) -> EventPayload | None:
+        candidate = getattr(record, _PAYLOAD_ATTR, None)
+        return candidate if isinstance(candidate, EventPayload) else None
+
+    def _core(self, record: logging.LogRecord, payload: EventPayload | None) -> dict[str, Any]:
+        """The record as a flat mapping, in the order a person reads it.
+
+        The formatter's own fields go first — a line starts with when, how bad, and what
+        happened — then the ambient identifiers, then the event's own fields. Precedence
+        runs the other way and is enforced by filtering rather than by ordering: neither
+        the context nor an event field can occupy a name in :data:`RESERVED_FIELDS`, so a
+        caller cannot move a record's timestamp or relabel its level, and an explicit field
+        still beats the ambient context because it is merged afterwards.
+        """
+        merged: dict[str, Any] = {
+            "timestamp": _timestamp(record.created),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": redact_emails(record.getMessage()),
+            "service": SERVICE_NAME,
+            "env": self._env,
+        }
+        if payload is not None:
+            merged["event"] = payload.event
+        merged.update(
+            {
+                key: _redact_value(value)
+                for key, value in current_context().items()
+                if key not in RESERVED_FIELDS
+            }
+        )
+        if payload is not None:
+            merged.update(
+                {
+                    key: _redact_value(value)
+                    for key, value in payload.fields.items()
+                    if value is not None and key not in RESERVED_FIELDS
+                }
+            )
+        return merged
+
+    def _exception(self, record: logging.LogRecord) -> dict[str, str] | None:
+        """The exception, flattened and redacted.
+
+        Only the type, the message and the formatted traceback. Local variables are never
+        rendered — a frame in this codebase holds a ``LeadSubmission``, and a traceback
+        that printed locals would put a stranger's name, address and free text in the log
+        on the one path nobody rehearses. The message and the traceback text still go
+        through the redactor, because the message is written by whatever raised.
+        """
+        if record.exc_info is None or record.exc_info[1] is None:
+            return None
+        _, error, tb = record.exc_info
+        stack = "".join(traceback.format_exception(type(error), error, tb))
+        return {
+            "type": type(error).__name__,
+            "message": redact_emails(str(error)),
+            "stack": redact_emails(stack),
+        }
+
+
+class JsonLogFormatter(_BaseFormatter):
+    """One JSON object per line, with EMF metrics merged into the same object."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = self._payload(record)
+        document = self._core(record, payload)
+        exception = self._exception(record)
+        if exception is not None:
+            document["exception"] = exception
+        if payload is not None and payload.metrics is not None:
+            document.update(to_emf(payload.metrics, timestamp_ms=int(record.created * 1000)))
+        return json.dumps(document, default=_json_default, ensure_ascii=False)
+
+
+class HumanLogFormatter(_BaseFormatter):
+    """The same fields on one readable line. Local development only."""
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload = self._payload(record)
+        document = self._core(record, payload)
+        head = f"{document['timestamp']} {record.levelname:<7} {record.name}"
+        title = payload.event if payload is not None else document["message"]
+        rest = " ".join(
+            f"{key}={_json_default(value) if not isinstance(value, str | int | float) else value}"
+            for key, value in document.items()
+            if key not in RESERVED_FIELDS
+        )
+        line = f"{head} {title}"
+        if payload is not None and document["message"] != payload.event:
+            line = f"{line} {document['message']!r}"
+        if rest:
+            line = f"{line} {rest}"
+        if payload is not None and payload.metrics is not None:
+            line = f"{line} {to_text(payload.metrics)}"
+        exception = self._exception(record)
+        if exception is not None:
+            line = f"{line}\n{exception['stack'].rstrip()}"
+        return line
+
+
+def configure_logging(
+    settings: Settings | None = None,
+    *,
+    stream: TextIO | None = None,
+    log_format: LogFormat | str | None = None,
+    replace_existing: bool = True,
+) -> logging.Handler:
+    """Install exactly one handler on the root logger. Safe to call any number of times.
+
+    Args:
+        settings: where ``LOG_LEVEL`` and ``ENV`` come from. ``None`` reads the process
+            settings, which is what an entry point wants; the tests pass their own.
+        stream: where lines go. Defaults to ``stdout``, which is what CloudWatch Logs and
+            ``docker logs`` read. ``stderr`` would work equally in Lambda and would
+            interleave badly everywhere else.
+        log_format: ``"json"`` or ``"human"``. ``None`` — the default — derives it from
+            ``ENV``: prose locally, JSON in every deployed environment.
+        replace_existing: also detach handlers this module did not install. True by
+            default, because the AWS Lambda runtime pre-installs one and leaving it
+            produces every line twice. Pass ``False`` when logging must coexist with a
+            harness that owns the root logger.
+
+    Returns:
+        The installed handler, so a caller (or a test) can address it directly.
+    """
+    resolved = settings if settings is not None else get_settings()
+    chosen = log_format or (
+        LOG_FORMAT_HUMAN if resolved.env is Environment.LOCAL else LOG_FORMAT_JSON
+    )
+    formatter: logging.Formatter = (
+        HumanLogFormatter(env=resolved.env.value)
+        if chosen == LOG_FORMAT_HUMAN
+        else JsonLogFormatter(env=resolved.env.value)
+    )
+
+    root = logging.getLogger()
+    for existing in list(root.handlers):
+        if replace_existing or getattr(existing, _HANDLER_MARK, False):
+            root.removeHandler(existing)
+
+    handler = logging.StreamHandler(stream if stream is not None else sys.stdout)
+    handler.setFormatter(formatter)
+    setattr(handler, _HANDLER_MARK, True)
+    root.addHandler(handler)
+    root.setLevel(resolved.log_level)
+
+    floor = max(logging.WARNING, root.level)
+    for name in QUIET_LOGGERS:
+        logging.getLogger(name).setLevel(floor)
+    return handler
+
+
+def _timestamp(created: float) -> str:
+    """UTC, milliseconds, trailing ``Z``. Sortable as a string, which is how it is read."""
+    moment = datetime.fromtimestamp(created, UTC)
+    return moment.isoformat(timespec="milliseconds").replace("+00:00", "Z")
+
+
+def _redact_value(value: Any) -> Any:
+    """Redact addresses anywhere in a field value, however deeply it is nested.
+
+    Applied to every field of every record rather than trusted to call sites. A field is
+    the *likeliest* place for an address to appear — a destination, a bounce reason, an
+    error string quoted from a provider — and ``json.dumps`` would emit a plain ``str``
+    without ever consulting the serialiser hook below.
+    """
+    if isinstance(value, str):
+        return redact_emails(value)
+    if isinstance(value, Mapping):
+        return {key: _redact_value(item) for key, item in value.items()}
+    if isinstance(value, list | tuple | set | frozenset):
+        return [_redact_value(item) for item in value]
+    return value
+
+
+def _json_default(value: Any) -> Any:
+    """Serialise what ``json`` will not, and redact whatever comes out as text."""
+    if isinstance(value, Decimal):
+        return float(value)
+    if isinstance(value, datetime):
+        return value.isoformat()
+    if isinstance(value, Enum):
+        return value.value
+    if isinstance(value, set | frozenset | tuple):
+        return list(value)
+    return redact_emails(str(value))
+
+
+__all__ = [
+    "LOG_FORMAT_HUMAN",
+    "LOG_FORMAT_JSON",
+    "QUIET_LOGGERS",
+    "RESERVED_FIELDS",
+    "SERVICE_NAME",
+    "EventPayload",
+    "HumanLogFormatter",
+    "JsonLogFormatter",
+    "LogFormat",
+    "configure_logging",
+    "log_event",
+]

--- a/src/leadquali/observability/metrics.py
+++ b/src/leadquali/observability/metrics.py
@@ -1,0 +1,293 @@
+"""Metrics that ride on the log line: CloudWatch Embedded Metric Format.
+
+**Why EMF and not ``PutMetricData``.** The alternative is an API call per lead from inside
+the worker, and it is worse on every axis that matters here. It costs 20-80 ms of Lambda
+wall time that the customer's lead is waiting on; it costs money per call on top of the
+metric itself; it needs ``cloudwatch:PutMetricData`` on a role that otherwise touches only
+SQS, SES and Postgres; and — the part that decides it — it *can fail*, which means either
+swallowing the failure (an alarm that silently stops being fed is worse than no alarm) or
+failing a lead because telemetry was unavailable. EMF has none of that: the metric is a
+field on a log line the process was writing anyway, CloudWatch Logs extracts it
+server-side, and the numbers stay queryable in Logs Insights as raw fields even where no
+metric was ever created. Emitting costs one ``json.dumps`` and cannot fail.
+
+**It degrades honestly off AWS.** The document is ordinary JSON. Locally, and in the tests,
+the same call renders as a readable ``Assessments=1 CostUsd=0.0213`` line
+(:func:`to_text`) and nothing is lost but the server-side aggregation.
+
+**The shape.** One log line carries a ``_aws.CloudWatchMetrics`` list of *directives*, each
+naming a namespace, a dimension set and the metrics published under it; the dimension and
+metric values themselves sit at the root of the same object. Publishing one metric under
+two dimension sets — ``Assessments`` by ``(TenantId, Tier)`` for the drift signal and by
+``(TenantId)`` for the total — is two directives reading one root value, which is why the
+tier breakdown costs no extra emission.
+
+**Cardinality is a bill.** Every (metric, dimension-value) combination is a custom metric,
+charged monthly. The directives here are deliberately narrow: no dimension takes an
+unbounded value, ``lead_id`` and ``trace_id`` stay ordinary log fields (queryable in
+Logs Insights, free) rather than dimensions, and the per-tenant total is around twenty
+metrics. Adding a dimension is a pricing decision, not a formatting one.
+
+Names are ``PascalCase`` because CloudWatch's console, the ``aws cloudwatch`` CLI and every
+alarm definition show them verbatim — and because it keeps them from ever colliding with
+the ``snake_case`` log field set they share a line with.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from decimal import Decimal
+from enum import StrEnum
+from typing import Any, Final
+
+#: The CloudWatch namespace every metric below is published into. #29 alarms are written
+#: against this string; changing it orphans every alarm and every dashboard.
+METRIC_NAMESPACE: Final[str] = "LeadQuali"
+
+# --------------------------------------------------------------------------- dimensions
+
+#: Present on every directive. Metrics are per tenant first, because "is this broken" is
+#: almost always "is this broken for one customer".
+DIM_TENANT: Final[str] = "TenantId"
+
+#: The decided tier. The tier-distribution drift signal (plan §8) is this dimension on
+#: :data:`ASSESSMENTS`, and nothing else is needed to compute it.
+DIM_TIER: Final[str] = "Tier"
+
+#: Why a lead went to a human: ``low_confidence``, ``model_refusal``, ``parse_error``,
+#: ``api_error``, ``timeout``. Five values; a rise in each wakes a different person.
+DIM_ESCALATION_REASON: Final[str] = "EscalationReason"
+
+#: Why a lead was never contacted: ``spam`` or ``below_threshold``. #52 gave the two
+#: suppressions distinguishable notes precisely so this dimension could exist.
+DIM_SUPPRESSION_CAUSE: Final[str] = "SuppressionCause"
+
+#: Which deterministic pre-filter caught a submission at the edge.
+DIM_SPAM_REASON: Final[str] = "SpamReason"
+
+#: What ingest did with a submission: ``queued``, ``suppressed``, ``duplicate``.
+DIM_DISPOSITION: Final[str] = "Disposition"
+
+# ------------------------------------------------------------------------ metric names
+
+#: Assessments completed, whether or not the model answered. The tier breakdown of this
+#: metric is the drift signal.
+ASSESSMENTS: Final[str] = "Assessments"
+
+#: Assessments where no judgement was obtained (refusal, timeout, 5xx, parse error). The
+#: lead was still routed to a human — this counts *our* failures, not lost leads.
+ASSESSMENT_FAILURES: Final[str] = "AssessmentFailures"
+
+#: Leads that reached a human because the system was unsure or broken, by reason.
+ESCALATIONS: Final[str] = "Escalations"
+
+INPUT_TOKENS: Final[str] = "InputTokens"
+OUTPUT_TOKENS: Final[str] = "OutputTokens"
+CACHE_READ_TOKENS: Final[str] = "CacheReadTokens"
+CACHE_CREATION_TOKENS: Final[str] = "CacheCreationTokens"
+
+#: Dollars for one model call. Summed over a day, this is the token-spend alarm and #33's
+#: billing meter; averaged over a day it is cost per lead, without opening the database.
+COST_USD: Final[str] = "CostUsd"
+
+#: The model call, retries included. Distinct from :data:`PIPELINE_LATENCY_MS`, which is
+#: the whole lead: when p99 rises, the gap between them says whether it is Anthropic or us.
+MODEL_LATENCY_MS: Final[str] = "ModelLatencyMs"
+
+#: Wall clock for one lead through the pipeline: config, enrich, assess, persist, dispatch.
+PIPELINE_LATENCY_MS: Final[str] = "PipelineLatencyMs"
+
+#: Leads assessed without enrichment because the enricher failed (#18). Not an error — the
+#: lead was assessed anyway — but a sustained rise means every lead is being judged on less.
+ENRICHMENT_UNAVAILABLE: Final[str] = "EnrichmentUnavailable"
+
+#: Leads a person was actually notified about.
+DISPATCHES: Final[str] = "Dispatches"
+
+#: Dispatch attempts that raised. These are redelivered by SQS and land in the DLQ if they
+#: keep failing, so this metric is the early warning the DLQ alarm confirms.
+DISPATCH_FAILURES: Final[str] = "DispatchFailures"
+
+#: Dispatches that had to fall back because the tenant's routing table had no destination
+#: for the decided tier. A configuration bug, visible before a customer reports it.
+FALLBACK_DESTINATIONS: Final[str] = "FallbackDestinations"
+
+#: Leads recorded and never contacted, by cause.
+SUPPRESSIONS: Final[str] = "Suppressions"
+
+#: Redeliveries of a lead already routed. Normal at a low rate (SQS is at-least-once);
+#: a spike means the idempotency guard is doing work something else should have done.
+DUPLICATES: Final[str] = "Duplicates"
+
+#: Submissions accepted at the public edge, by disposition.
+INGESTED_LEADS: Final[str] = "IngestedLeads"
+
+#: Submissions the deterministic pre-filters stopped before any model call, by filter.
+INGEST_SUPPRESSIONS: Final[str] = "IngestSuppressions"
+
+
+class Unit(StrEnum):
+    """The CloudWatch units this system uses. Not the full list — the full list is noise.
+
+    :attr:`NONE` is CloudWatch's own name for "a number with no unit", and it is what money
+    gets: there is no currency unit, and mislabelling dollars as ``Count`` makes a
+    dashboard read "21.3 milli" at a glance.
+    """
+
+    COUNT = "Count"
+    MILLISECONDS = "Milliseconds"
+    NONE = "None"
+
+
+@dataclass(frozen=True, slots=True)
+class Metric:
+    """One named number to publish."""
+
+    name: str
+    value: int | float | Decimal
+    unit: Unit = Unit.COUNT
+
+
+@dataclass(frozen=True, slots=True)
+class MetricSet:
+    """The metrics published under one dimension set.
+
+    An empty ``dimensions`` tuple is legal EMF and means "publish this against the
+    namespace with no dimensions at all"; nothing here uses it, because a metric with no
+    tenant on it cannot answer the only question anybody asks of it.
+    """
+
+    dimensions: tuple[str, ...]
+    metrics: tuple[Metric, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class MetricPayload:
+    """Everything one log line publishes: the dimension values and the directives.
+
+    There is no separate "properties" bag. The formatter merges this document into the log
+    record it rides on, so the record's own fields — ``trace_id``, ``lead_id``,
+    ``model_id``, ``prompt_version`` — are already at the root of the same object, free to
+    query in Logs Insights and impossible to get out of step with the metrics beside them.
+    """
+
+    dimensions: Mapping[str, str]
+    metric_sets: tuple[MetricSet, ...]
+
+
+def to_emf(
+    payload: MetricPayload, *, timestamp_ms: int, namespace: str = METRIC_NAMESPACE
+) -> dict[str, Any]:
+    """Render ``payload`` as an EMF document.
+
+    Args:
+        payload: the dimension values and directives to publish.
+        timestamp_ms: the event time in epoch milliseconds. Supplied by the formatter from
+            the log record's own creation time, so the metric is stamped when the thing
+            happened rather than when it was serialised.
+        namespace: the CloudWatch namespace. Overridable for tests only.
+
+    Returns:
+        A JSON-safe ``dict`` whose ``_aws`` key CloudWatch Logs recognises, with every
+        dimension value and metric value at the root.
+
+    Raises:
+        ValueError: a directive names a dimension the payload has no value for, or a
+            dimension value is blank, or two directives disagree about a metric's value.
+            All three produce a document CloudWatch silently drops the metrics from, and a
+            metric that silently stops arriving is exactly the failure mode observability
+            exists to prevent — so it fails here, loudly, in a test.
+    """
+    root: dict[str, Any] = {}
+    directives: list[dict[str, Any]] = []
+
+    for metric_set in payload.metric_sets:
+        for name in metric_set.dimensions:
+            value = payload.dimensions.get(name)
+            if value is None or not str(value).strip():
+                raise ValueError(
+                    f"metric dimension {name!r} has no value; CloudWatch would drop "
+                    f"{[metric.name for metric in metric_set.metrics]}"
+                )
+            root[name] = str(value)
+        for metric in metric_set.metrics:
+            number = _as_number(metric.value)
+            existing = root.get(metric.name)
+            if existing is not None and existing != number:
+                raise ValueError(
+                    f"metric {metric.name!r} is published twice on one line with different "
+                    f"values ({existing!r} and {number!r}); EMF reads one root value"
+                )
+            root[metric.name] = number
+        directives.append(
+            {
+                "Namespace": namespace,
+                "Dimensions": [list(metric_set.dimensions)],
+                "Metrics": [
+                    {"Name": metric.name, "Unit": metric.unit.value}
+                    for metric in metric_set.metrics
+                ],
+            }
+        )
+
+    root["_aws"] = {"Timestamp": timestamp_ms, "CloudWatchMetrics": directives}
+    return root
+
+
+def to_text(payload: MetricPayload) -> str:
+    """Render ``payload`` for a human: ``Assessments=1 CostUsd=0.0213``.
+
+    Used by the local formatter. Dimensions are left out — they are already on the line as
+    ``tenant_id`` and ``tier`` — so what is left is the numbers somebody is watching.
+    """
+    seen: dict[str, int | float] = {}
+    for metric_set in payload.metric_sets:
+        for metric in metric_set.metrics:
+            seen.setdefault(metric.name, _as_number(metric.value))
+    return " ".join(f"{name}={_trim(value)}" for name, value in seen.items())
+
+
+def _as_number(value: int | float | Decimal) -> int | float:
+    """A JSON number. ``Decimal`` serialises as a *string* by default, and a metric that
+    arrives as ``"0.0213"`` is not a metric — CloudWatch drops the whole directive."""
+    return float(value) if isinstance(value, Decimal) else value
+
+
+def _trim(value: int | float) -> str:
+    return str(value) if isinstance(value, int) else f"{value:g}"
+
+
+__all__ = [
+    "ASSESSMENTS",
+    "ASSESSMENT_FAILURES",
+    "CACHE_CREATION_TOKENS",
+    "CACHE_READ_TOKENS",
+    "COST_USD",
+    "DIM_DISPOSITION",
+    "DIM_ESCALATION_REASON",
+    "DIM_SPAM_REASON",
+    "DIM_SUPPRESSION_CAUSE",
+    "DIM_TENANT",
+    "DIM_TIER",
+    "DISPATCHES",
+    "DISPATCH_FAILURES",
+    "DUPLICATES",
+    "ENRICHMENT_UNAVAILABLE",
+    "ESCALATIONS",
+    "FALLBACK_DESTINATIONS",
+    "INGESTED_LEADS",
+    "INGEST_SUPPRESSIONS",
+    "INPUT_TOKENS",
+    "METRIC_NAMESPACE",
+    "MODEL_LATENCY_MS",
+    "OUTPUT_TOKENS",
+    "PIPELINE_LATENCY_MS",
+    "SUPPRESSIONS",
+    "Metric",
+    "MetricPayload",
+    "MetricSet",
+    "Unit",
+    "to_emf",
+    "to_text",
+]

--- a/src/leadquali/observability/pii.py
+++ b/src/leadquali/observability/pii.py
@@ -1,0 +1,76 @@
+"""Invariant 5, as code: the hash that may be logged and the net that catches the rest.
+
+``CLAUDE.md``: *no PII in logs — log ``contact_email_hash``, never the address; never raw
+payloads.* That is a rule about every call site in the codebase, present and future, and a
+rule of that shape is kept by two things and not by one:
+
+* :func:`contact_email_hash` — the *positive* half. There is exactly one definition of the
+  hash in the system (``adapters.store_postgres`` re-exports this one) because a log line
+  and a ``leads`` row that hash the same address differently cannot be joined, and a
+  correlation identifier that does not correlate is worse than no identifier at all.
+* :func:`redact_emails` — the *negative* half, applied by both formatters to every rendered
+  message and every traceback on the way out. It is defence in depth, not permission to be
+  careless: it catches the address that arrives inside an exception message from a
+  dependency we do not control, which no amount of discipline at our own call sites can
+  prevent.
+
+The net has a limit worth stating plainly, because it bounds what the tests can promise:
+it recognises a *pattern*, and the lead's free-text message is not a pattern. Nothing here
+can stop ``LOGGER.info(submission.message)``. That is why ``tests/unit/
+test_observability_pipeline.py`` runs a real lead through the real pipeline and asserts the
+message text appears in no record — the only mechanism that actually holds.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import re
+from typing import Final
+
+#: What an address is replaced by. Deliberately visible rather than silent: an operator who
+#: sees this in a log line has learned that a call site tried to log an address, which is a
+#: bug to fix and not a thing to be relieved about.
+EMAIL_REDACTION: Final[str] = "[redacted-email]"
+
+#: Addresses, matched loosely on purpose. Over-matching costs a redacted string in a log
+#: line; under-matching costs a customer's contact in a log aggregator, so every ambiguous
+#: case resolves towards redaction. Bounded quantifiers keep it linear on hostile input.
+_EMAIL_RE: Final[re.Pattern[str]] = re.compile(
+    r"[A-Za-z0-9._%+\-]{1,64}@[A-Za-z0-9.\-]{1,255}\.[A-Za-z]{2,24}"
+)
+
+
+def contact_email_hash(email: str | None) -> str | None:
+    """SHA-256 of the normalised contact address, or ``None`` when there is no address.
+
+    This is the identifier a log line carries in place of the address, and it is the same
+    value stored in ``leads.contact_email_hash`` — the two exist to be joined.
+
+    Normalisation is strip-and-lowercase, so ``Ada@Example.com`` and ``ada@example.com``
+    hash alike, which is the entire point of storing it.
+
+    Not reversible-proof: an address has little entropy and a determined attacker with a
+    wordlist will invert this. It defends against casual disclosure — a support engineer
+    reading logs, a log aggregator with broad access, an exported bundle — which is the
+    threat that actually materialises.
+    """
+    if email is None:
+        return None
+    normalised = email.strip().lower()
+    if not normalised:
+        return None
+    return hashlib.sha256(normalised.encode("utf-8")).hexdigest()
+
+
+def redact_emails(text: str) -> str:
+    """Replace every address-shaped run in ``text`` with :data:`EMAIL_REDACTION`.
+
+    Applied by the formatters to the rendered message and to the exception traceback, which
+    is where an address arrives without anyone having decided to log one: a bounce message
+    quoted by SES, a validation error from a library that echoes its input, a
+    ``ValueError`` that interpolated the value it choked on.
+    """
+    return _EMAIL_RE.sub(EMAIL_REDACTION, text)
+
+
+__all__ = ["EMAIL_REDACTION", "contact_email_hash", "redact_emails"]

--- a/src/leadquali/prompts/lead.py
+++ b/src/leadquali/prompts/lead.py
@@ -118,15 +118,24 @@ class LeadSubmission(BaseModel):
 
     model_config = ConfigDict(frozen=True, extra="forbid")
 
-    full_name: str | None = None
-    email: str | None = None
-    company: str | None = None
-    role: str | None = None
-    phone: str | None = None
-    website: str | None = None
-    message: str | None = None
+    # Every field is ``repr=False``. A submission is personal data, and ``repr`` is the one
+    # place it escapes without anybody deciding to emit it: an exception raised anywhere
+    # below this object — ``ValueError(f"bad lead {submission!r}")``, a ``TypeError`` whose
+    # message pydantic built, an assertion in a library — is formatted into a traceback and
+    # that traceback is logged. #21's formatter redacts addresses on the way out, but it
+    # cannot recognise a lead's free text, so the fix has to be that the text was never in
+    # the string. ``model_dump`` is unaffected, which is what the queue message and the
+    # ``leads`` row use.
+    full_name: str | None = Field(default=None, repr=False)
+    email: str | None = Field(default=None, repr=False)
+    company: str | None = Field(default=None, repr=False)
+    role: str | None = Field(default=None, repr=False)
+    phone: str | None = Field(default=None, repr=False)
+    website: str | None = Field(default=None, repr=False)
+    message: str | None = Field(default=None, repr=False)
     extra: Mapping[str, str | None] = Field(
         default_factory=dict,
+        repr=False,
         description="Form fields beyond the known ones, kept so nothing is lost.",
     )
 

--- a/tests/logcapture.py
+++ b/tests/logcapture.py
@@ -1,0 +1,83 @@
+"""Capture what the process actually writes, and hand it back as parsed JSON.
+
+Shared because #17's endpoint tests, #21's pipeline tests and anything after them all need
+the same thing, and because the way *not* to do it is tempting: ``caplog`` gives you
+``LogRecord`` objects, and asserting on those passes happily on a record the formatter
+would go on to render as unparseable output, or with a field the formatter drops. Every
+assertion in this suite goes through the real handler, the real formatter and
+``json.loads``, so a test proves what a log aggregator would receive.
+
+The root logger is restored on the way out. ``configure_logging`` takes it over by design
+(a Lambda arrives with a handler already installed), and pytest keeps its own capture
+handlers there.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from collections.abc import Iterator
+from contextlib import contextmanager
+from dataclasses import dataclass
+from typing import Any
+
+from leadquali.config import Environment, LogLevel, Settings
+from leadquali.observability import LOG_FORMAT_JSON, configure_logging
+
+
+@dataclass(frozen=True, slots=True)
+class LogCapture:
+    """Everything emitted inside a :func:`capture_json_logs` block."""
+
+    buffer: io.StringIO
+
+    @property
+    def text(self) -> str:
+        """The raw output, for "this string appears nowhere" assertions."""
+        return self.buffer.getvalue()
+
+    def records(self) -> list[dict[str, Any]]:
+        """Every line, parsed. Fails the test if any line is not a JSON object."""
+        return [json.loads(line) for line in self.text.splitlines() if line.strip()]
+
+    def events(self, event: str) -> list[dict[str, Any]]:
+        """Every record for one event name, in order."""
+        return [record for record in self.records() if record.get("event") == event]
+
+    def one(self, event: str) -> dict[str, Any]:
+        """The single record for one event name.
+
+        Raises:
+            AssertionError: the event was emitted no times or more than once. Both are
+                bugs worth failing on — a metric emitted twice is a metric that double
+                counts, which is how a dashboard lies without anybody noticing.
+        """
+        found = self.events(event)
+        assert len(found) == 1, f"expected exactly one {event!r}, got {len(found)}"
+        return found[0]
+
+
+@contextmanager
+def capture_json_logs(level: LogLevel = "DEBUG") -> Iterator[LogCapture]:
+    """Configure real JSON logging into a buffer for the duration of the block."""
+    root = logging.getLogger()
+    handlers = list(root.handlers)
+    previous_level = root.level
+    buffer = io.StringIO()
+    try:
+        configure_logging(
+            Settings(env=Environment.PROD, log_level=level),
+            stream=buffer,
+            log_format=LOG_FORMAT_JSON,
+        )
+        yield LogCapture(buffer=buffer)
+    finally:
+        for installed in list(root.handlers):
+            root.removeHandler(installed)
+        for original in handlers:
+            root.addHandler(original)
+        root.setLevel(previous_level)
+
+
+__all__ = ["LogCapture", "capture_json_logs"]

--- a/tests/unit/test_api_ingest.py
+++ b/tests/unit/test_api_ingest.py
@@ -17,7 +17,6 @@ from __future__ import annotations
 
 import ast
 import json
-import logging
 import threading
 import time
 from collections.abc import Iterator
@@ -58,6 +57,7 @@ from leadquali.config import Settings
 from leadquali.domain.models import Action, EscalationReason
 from leadquali.domain.tenant_config import TenantConfig
 from tests.fakes import FakeClock, InMemoryLeadStore
+from tests.logcapture import capture_json_logs
 
 TENANT = "default"
 API_KEY = "lq_live_5b1f0a7c2e9d4368"
@@ -543,30 +543,35 @@ def test_a_rate_limited_response_says_when_to_come_back() -> None:
     assert int(refused.headers["retry-after"]) >= 1
 
 
-def test_no_contact_address_ever_reaches_the_logs(
-    harness: Harness, caplog: pytest.LogCaptureFixture
-) -> None:
-    """Invariant 5: the hash correlates a person's leads; the address is never written."""
-    with caplog.at_level(logging.DEBUG):
+def test_no_contact_address_ever_reaches_the_logs(harness: Harness) -> None:
+    """Invariant 5: the hash correlates a person's leads; the address is never written.
+
+    Asserted against the emitted JSON rather than ``caplog.text``, because what a log
+    aggregator receives is the formatter's output and that is the only thing invariant 5 is
+    a statement about. #21's ``tests/unit/test_observability_pipeline.py`` makes the same
+    assertion over the worker half of the journey.
+    """
+    with capture_json_logs() as logs:
         harness.post()
 
-    assert "ada@analytical-engines.co.uk" not in caplog.text
-    assert "Ada Lovelace" not in caplog.text
-    assert VALID_FORM["message"] not in caplog.text
+    assert "ada@analytical-engines.co.uk" not in logs.text
+    assert "Ada Lovelace" not in logs.text
+    assert str(VALID_FORM["message"]) not in logs.text
     # 64 hex characters: the contact hash, which is what correlation is done on.
-    assert "contact=" in caplog.text
-    hashed = caplog.text.split("contact=")[1].split()[0]
-    assert len(hashed) == 64
+    accepted = logs.one("lead.accepted")
+    assert len(accepted["contact_email_hash"]) == 64
+    assert accepted["trace_id"] == logs.one("http.ingest")["trace_id"]
 
 
-def test_a_rejected_request_logs_the_reason_but_answers_with_nothing(
-    harness: Harness, caplog: pytest.LogCaptureFixture
-) -> None:
-    with caplog.at_level(logging.WARNING):
+def test_a_rejected_request_logs_the_reason_but_answers_with_nothing(harness: Harness) -> None:
+    with capture_json_logs() as logs:
         response = harness.post(tenant="does-not-exist")
 
     assert response.json() == {"detail": "authentication failed"}
-    assert "unknown_tenant" in caplog.text
+    rejected = logs.one("ingest.rejected")
+    assert rejected["reason"] == "unknown_tenant"
+    assert rejected["claimed_tenant"] == "does-not-exist"
+    assert rejected["level"] == "WARNING"
 
 
 # ------------------------------------------------------------------------- wiring

--- a/tests/unit/test_layering.py
+++ b/tests/unit/test_layering.py
@@ -65,6 +65,45 @@ def test_domain_and_app_import_no_third_party_sdk() -> None:
         assert not leaked, f"{relative} imports {sorted(leaked)}"
 
 
+def test_observability_imports_no_layer_above_it() -> None:
+    """``leadquali.observability`` sits beside the layers, not on top of them.
+
+    It is imported by ``domain``-adjacent value types, by ``app``, by ``adapters`` and by
+    ``api`` alike, which is only safe while it depends on none of them: an
+    ``observability`` that reached into ``adapters`` would put SQLAlchemy in the import
+    graph of every module that wants to write a log line, and would make the import cycle
+    ``app`` → ``observability`` → ``adapters`` → ``app`` a matter of luck about which file
+    was imported first.
+
+    Reading value types (``RoutingDecision``, ``CallMetering``) is allowed and is the point
+    — a metric about a decision has to be able to see one.
+    """
+    permitted = {"leadquali"}
+    for path in python_sources():
+        relative = path.relative_to(SRC).as_posix()
+        if not relative.startswith("observability/"):
+            continue
+        imported = {
+            name
+            for name in _imported_paths(path)
+            if name.startswith("leadquali.") and name.split(".")[1] in {"adapters", "api"}
+        }
+        assert not imported, f"{relative} imports {sorted(imported)}"
+        assert imported_modules(path) & {"anthropic", "boto3", "sqlalchemy", "fastapi"} == set()
+        assert permitted  # the loop ran with a real package root
+
+
+def _imported_paths(path: Path) -> set[str]:
+    """Every dotted module path imported by ``path``, in full."""
+    names: set[str] = set()
+    for node in ast.walk(ast.parse(path.read_text(encoding="utf-8"), filename=str(path))):
+        if isinstance(node, ast.Import):
+            names.update(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom) and node.level == 0 and node.module:
+            names.add(node.module)
+    return names
+
+
 def test_only_the_ses_adapter_imports_boto3() -> None:
     """``CLAUDE.md``: one file per external system, and ``boto3`` belongs to that one.
 

--- a/tests/unit/test_observability.py
+++ b/tests/unit/test_observability.py
@@ -1,0 +1,373 @@
+"""The logging and metrics primitives, asserted on parsed JSON rather than on strings.
+
+Every assertion here goes through ``json.loads`` of a real handler's output. Asserting on
+a formatted string would pass on a line CloudWatch cannot parse, which is the only thing
+that actually matters about this module: an alarm can only fire on a metric that was
+emitted in a shape the platform recognises.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import logging
+from collections.abc import Iterator
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from leadquali.adapters.store_postgres import contact_email_hash as store_hash
+from leadquali.config import Environment, Settings
+from leadquali.observability import (
+    EMAIL_REDACTION,
+    LOG_FORMAT_HUMAN,
+    LOG_FORMAT_JSON,
+    Metric,
+    MetricPayload,
+    MetricSet,
+    Unit,
+    configure_logging,
+    contact_email_hash,
+    current_trace_id,
+    ensure_trace_id,
+    log_context,
+    log_event,
+    new_trace_id,
+    redact_emails,
+)
+from leadquali.observability.metrics import METRIC_NAMESPACE, to_emf
+
+LOGGER = logging.getLogger("leadquali.tests.observability")
+
+
+@pytest.fixture(autouse=True)
+def _restore_root_logging() -> Iterator[None]:
+    """Give every test the root logger back exactly as it found it.
+
+    ``configure_logging`` takes the root logger over on purpose (see its docstring), and
+    pytest's own capture handlers live there. Restoring is what keeps this file from
+    silently switching off logging for the rest of the session.
+    """
+    root = logging.getLogger()
+    handlers = list(root.handlers)
+    level = root.level
+    try:
+        yield
+    finally:
+        root.handlers[:] = handlers
+        root.setLevel(level)
+
+
+def settings_for(env: Environment, level: str = "INFO") -> Settings:
+    return Settings(env=env, log_level=level)  # type: ignore[arg-type]  # narrowed by validator
+
+
+def records(buffer: io.StringIO) -> list[dict[str, Any]]:
+    """Every emitted line, parsed. One JSON object per line is the contract."""
+    return [json.loads(line) for line in buffer.getvalue().splitlines() if line.strip()]
+
+
+def configured(env: Environment = Environment.PROD, level: str = "INFO") -> io.StringIO:
+    buffer = io.StringIO()
+    configure_logging(settings_for(env, level), stream=buffer)
+    return buffer
+
+
+# ------------------------------------------------------------------ configure_logging
+
+
+def test_json_lines_are_one_object_each() -> None:
+    buffer = configured()
+    LOGGER.info("first")
+    LOGGER.info("second")
+
+    assert [record["message"] for record in records(buffer)] == ["first", "second"]
+
+
+def test_configure_logging_twice_does_not_duplicate_records() -> None:
+    first = io.StringIO()
+    second = io.StringIO()
+    configure_logging(settings_for(Environment.PROD), stream=first)
+    configure_logging(settings_for(Environment.PROD), stream=second)
+
+    LOGGER.info("only once")
+
+    assert records(first) == []
+    assert [record["message"] for record in records(second)] == ["only once"]
+    assert len(logging.getLogger().handlers) == 1
+
+
+def test_log_level_comes_from_settings() -> None:
+    buffer = configured(level="WARNING")
+
+    LOGGER.info("dropped")
+    LOGGER.warning("kept")
+
+    assert [record["message"] for record in records(buffer)] == ["kept"]
+
+
+def test_local_environment_gets_human_readable_lines() -> None:
+    buffer = io.StringIO()
+    handler = configure_logging(settings_for(Environment.LOCAL), stream=buffer)
+
+    log_event(LOGGER, "lead.routed", tenant_id="acme", tier="hot")
+
+    line = buffer.getvalue().strip()
+    assert handler.formatter is not None
+    with pytest.raises(json.JSONDecodeError):
+        json.loads(line)
+    assert "lead.routed" in line
+    assert "tenant_id=acme" in line
+    assert "tier=hot" in line
+
+
+def test_format_can_be_forced_independently_of_the_environment() -> None:
+    buffer = io.StringIO()
+    configure_logging(settings_for(Environment.LOCAL), stream=buffer, log_format=LOG_FORMAT_JSON)
+
+    LOGGER.info("json please")
+
+    assert records(buffer)[0]["message"] == "json please"
+
+
+def test_human_format_is_the_local_default_and_json_the_deployed_one() -> None:
+    assert LOG_FORMAT_HUMAN != LOG_FORMAT_JSON
+
+
+# ------------------------------------------------------------------------ field set
+
+
+def test_record_carries_the_standard_field_set() -> None:
+    buffer = configured(env=Environment.STAGING)
+
+    log_event(LOGGER, "lead.routed", tenant_id="acme", lead_id="lead-1", tier="hot")
+
+    record = records(buffer)[0]
+    assert record["event"] == "lead.routed"
+    assert record["level"] == "INFO"
+    assert record["logger"] == LOGGER.name
+    assert record["service"] == "leadquali"
+    assert record["env"] == "staging"
+    assert record["message"] == "lead.routed"
+    assert record["tenant_id"] == "acme"
+    assert record["tier"] == "hot"
+    assert record["timestamp"].endswith("Z")
+
+
+def test_plain_library_records_still_produce_the_core_fields() -> None:
+    """A uvicorn or botocore line has no ``event``; it must still be one JSON object."""
+    buffer = configured()
+
+    logging.getLogger("uvicorn.error").warning("listening on %s", "0.0.0.0:8000")
+
+    record = records(buffer)[0]
+    assert record["message"] == "listening on 0.0.0.0:8000"
+    assert record["logger"] == "uvicorn.error"
+    assert "event" not in record
+
+
+def test_none_valued_fields_are_dropped_rather_than_emitted_as_null() -> None:
+    buffer = configured()
+
+    log_event(LOGGER, "lead.routed", tenant_id="acme", escalation_reason=None)
+
+    record = records(buffer)[0]
+    assert "escalation_reason" not in record
+
+
+# --------------------------------------------------------------------------- context
+
+
+def test_new_trace_id_is_32_lowercase_hex() -> None:
+    trace_id = new_trace_id()
+    assert len(trace_id) == 32
+    assert trace_id == trace_id.lower()
+    assert int(trace_id, 16) >= 0
+    assert new_trace_id() != trace_id
+
+
+def test_bound_context_rides_on_every_record_inside_the_block() -> None:
+    buffer = configured()
+
+    with log_context(trace_id="trace-1", tenant_id="acme"):
+        LOGGER.info("inside")
+    LOGGER.info("outside")
+
+    inside, outside = records(buffer)
+    assert inside["trace_id"] == "trace-1"
+    assert inside["tenant_id"] == "acme"
+    assert "trace_id" not in outside
+
+
+def test_nested_context_extends_and_then_restores() -> None:
+    with log_context(trace_id="trace-1"):
+        with log_context(tenant_id="acme"):
+            assert current_trace_id() == "trace-1"
+        assert current_trace_id() == "trace-1"
+    assert current_trace_id() is None
+
+
+def test_explicit_event_fields_win_over_the_bound_context() -> None:
+    buffer = configured()
+
+    with log_context(trace_id="trace-1", tenant_id="acme"):
+        log_event(LOGGER, "lead.routed", tenant_id="other")
+
+    assert records(buffer)[0]["tenant_id"] == "other"
+
+
+def test_ensure_trace_id_prefers_the_candidate_then_the_context_then_a_new_one() -> None:
+    assert ensure_trace_id("given") == "given"
+    with log_context(trace_id="bound"):
+        assert ensure_trace_id(None) == "bound"
+        assert ensure_trace_id("  ") == "bound"
+    generated = ensure_trace_id(None)
+    assert len(generated) == 32
+
+
+# ------------------------------------------------------------------------------ PII
+
+
+def test_contact_email_hash_is_the_hash_the_store_writes() -> None:
+    """One hash, or a log line cannot be joined to a row (that is the whole point)."""
+    assert contact_email_hash("Ada@Example.com ") == store_hash("ada@example.com")
+    assert contact_email_hash(None) is None
+    assert contact_email_hash("   ") is None
+
+
+def test_redaction_replaces_addresses_and_keeps_the_rest() -> None:
+    assert redact_emails("wrote to ada@example.com twice") == (f"wrote to {EMAIL_REDACTION} twice")
+    assert redact_emails("no address here") == "no address here"
+
+
+def test_an_address_in_a_log_message_never_reaches_the_line() -> None:
+    buffer = configured()
+
+    LOGGER.warning("bounce for ada.lovelace@analytical-engines.test")
+
+    record = records(buffer)[0]
+    assert "ada.lovelace@analytical-engines.test" not in json.dumps(record)
+    assert EMAIL_REDACTION in record["message"]
+
+
+def test_an_address_in_an_event_field_never_reaches_the_line() -> None:
+    buffer = configured()
+
+    log_event(LOGGER, "lead.routed", destination="ada@example.test")
+
+    assert "ada@example.test" not in buffer.getvalue()
+
+
+def test_an_address_in_a_traceback_never_reaches_the_line() -> None:
+    buffer = configured()
+
+    try:
+        raise RuntimeError("SES rejected ada@example.test")
+    except RuntimeError:
+        LOGGER.exception("dispatch failed")
+
+    record = records(buffer)[0]
+    serialised = json.dumps(record)
+    assert "ada@example.test" not in serialised
+    assert record["exception"]["type"] == "RuntimeError"
+    assert EMAIL_REDACTION in record["exception"]["message"]
+    assert "RuntimeError" in record["exception"]["stack"]
+
+
+def test_human_format_redacts_too() -> None:
+    buffer = io.StringIO()
+    configure_logging(settings_for(Environment.LOCAL), stream=buffer)
+
+    LOGGER.warning("bounce for ada@example.test")
+
+    assert "ada@example.test" not in buffer.getvalue()
+
+
+# --------------------------------------------------------------------------- metrics
+
+
+def assessment_payload() -> MetricPayload:
+    return MetricPayload(
+        dimensions={"TenantId": "acme", "Tier": "hot"},
+        metric_sets=(
+            MetricSet(dimensions=("TenantId", "Tier"), metrics=(Metric("Assessments", 1),)),
+            MetricSet(
+                dimensions=("TenantId",),
+                metrics=(
+                    Metric("CostUsd", Decimal("0.0213"), Unit.NONE),
+                    Metric("ModelLatencyMs", 1234, Unit.MILLISECONDS),
+                ),
+            ),
+        ),
+    )
+
+
+def test_emf_document_has_the_shape_cloudwatch_extracts() -> None:
+    document = to_emf(assessment_payload(), timestamp_ms=1_700_000_000_000)
+
+    aws = document["_aws"]
+    assert aws["Timestamp"] == 1_700_000_000_000
+    directives = aws["CloudWatchMetrics"]
+    assert [directive["Namespace"] for directive in directives] == [METRIC_NAMESPACE] * 2
+    assert directives[0]["Dimensions"] == [["TenantId", "Tier"]]
+    assert directives[0]["Metrics"] == [{"Name": "Assessments", "Unit": "Count"}]
+    assert {"Name": "CostUsd", "Unit": "None"} in directives[1]["Metrics"]
+
+    # Dimension values and metric values all sit at the root.
+    assert document["TenantId"] == "acme"
+    assert document["Tier"] == "hot"
+    assert document["Assessments"] == 1
+    assert document["CostUsd"] == pytest.approx(0.0213)
+
+
+def test_emf_refuses_a_dimension_it_has_no_value_for() -> None:
+    payload = MetricPayload(
+        dimensions={"TenantId": "acme"},
+        metric_sets=(MetricSet(dimensions=("TenantId", "Tier"), metrics=(Metric("X", 1),)),),
+    )
+    with pytest.raises(ValueError, match="Tier"):
+        to_emf(payload, timestamp_ms=0)
+
+
+def test_emf_refuses_a_blank_dimension_value() -> None:
+    payload = MetricPayload(
+        dimensions={"TenantId": ""},
+        metric_sets=(MetricSet(dimensions=("TenantId",), metrics=(Metric("X", 1),)),),
+    )
+    with pytest.raises(ValueError, match="TenantId"):
+        to_emf(payload, timestamp_ms=0)
+
+
+def test_metrics_ride_on_the_log_line_itself() -> None:
+    buffer = configured()
+
+    log_event(LOGGER, "assessment.completed", metrics=assessment_payload(), tenant_id="acme")
+
+    record = records(buffer)[0]
+    assert record["event"] == "assessment.completed"
+    assert record["_aws"]["CloudWatchMetrics"][0]["Namespace"] == METRIC_NAMESPACE
+    assert record["Assessments"] == 1
+    assert record["CostUsd"] == pytest.approx(0.0213)
+    assert record["_aws"]["Timestamp"] > 0
+
+
+def test_metric_values_are_json_numbers_not_strings() -> None:
+    buffer = configured()
+
+    log_event(LOGGER, "assessment.completed", metrics=assessment_payload())
+
+    raw = buffer.getvalue()
+    assert '"CostUsd": 0.0213' in raw
+    assert '"CostUsd": "0.0213"' not in raw
+
+
+def test_human_format_renders_metrics_readably_and_emits_no_emf() -> None:
+    buffer = io.StringIO()
+    configure_logging(settings_for(Environment.LOCAL), stream=buffer)
+
+    log_event(LOGGER, "assessment.completed", metrics=assessment_payload())
+
+    line = buffer.getvalue()
+    assert "_aws" not in line
+    assert "Assessments=1" in line

--- a/tests/unit/test_observability_pipeline.py
+++ b/tests/unit/test_observability_pipeline.py
@@ -1,0 +1,781 @@
+"""What one lead's journey actually emits, asserted end to end on parsed JSON.
+
+Two things are being proved here, and only the second one is about metrics.
+
+**Invariant 5 holds through the whole pipeline.** A lead carrying a distinctive address and
+a distinctive free-text message goes through the real ingest service, the real queue
+message, and the real pipeline with real logging captured, and neither string appears in
+any emitted record. Then the same lead goes through the *exception* path, because that is
+where the leak actually happens: a notifier that raises with the submission in its message
+produces a traceback, and a traceback is logged. There is no way to make a rule like
+"never log a lead's message" true by reading the code — the only way it stays true is a
+test that would fail the day somebody makes it false, on both paths.
+
+The message assertion is the load-bearing one. An address is a *pattern* and the formatter
+redacts it as a last resort, so a sloppy call site would still pass that half; the tests
+below therefore also assert that the redaction marker appears nowhere, which says nothing
+even tried. A lead's prose is not a pattern and nothing can save it, which is exactly why
+it is the string this file watches.
+
+**The metrics #29 alarms on are emitted, on every path.** A success, a refusal that was
+still billed, a hard failure with no metering at all, both suppressions, a duplicate and a
+fallback destination — each one asserted on the EMF document that rides on its log line.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import Any
+
+import pytest
+
+from leadquali.adapters.queue_inprocess import InProcessLeadQueue
+from leadquali.app.assessment_result import (
+    AssessmentFailed,
+    AssessmentOutcome,
+    AssessmentSucceeded,
+    CallMetering,
+)
+from leadquali.app.enrichment import Enrichment
+from leadquali.app.ingest import IngestRequest, IngestService, QueuedLead
+from leadquali.app.qualify import (
+    Disposition,
+    QualificationPipeline,
+    QualificationRequest,
+)
+from leadquali.config import Environment, Settings
+from leadquali.domain.models import (
+    DimensionScores,
+    EscalationReason,
+    ExtractedFacts,
+    LeadAssessment,
+    Tier,
+)
+from leadquali.domain.tenant_config import TenantConfig
+from leadquali.observability import (
+    EMAIL_REDACTION,
+    EVENT_ASSESSMENT,
+    EVENT_DISPATCH_FAILED,
+    EVENT_LEAD_ACCEPTED,
+    EVENT_LEAD_DUPLICATE,
+    EVENT_LEAD_ROUTED,
+    EVENT_LEAD_SUPPRESSED,
+    LOG_FORMAT_JSON,
+    METRIC_NAMESPACE,
+    SuppressionCause,
+    configure_logging,
+    contact_email_hash,
+)
+from leadquali.observability.metrics import (
+    ASSESSMENT_FAILURES,
+    ASSESSMENTS,
+    CACHE_READ_TOKENS,
+    COST_USD,
+    DIM_ESCALATION_REASON,
+    DIM_SUPPRESSION_CAUSE,
+    DIM_TENANT,
+    DIM_TIER,
+    DISPATCH_FAILURES,
+    DISPATCHES,
+    DUPLICATES,
+    ENRICHMENT_UNAVAILABLE,
+    ESCALATIONS,
+    FALLBACK_DESTINATIONS,
+    INGESTED_LEADS,
+    INPUT_TOKENS,
+    MODEL_LATENCY_MS,
+    OUTPUT_TOKENS,
+    PIPELINE_LATENCY_MS,
+    SUPPRESSIONS,
+)
+from leadquali.prompts.lead import LeadSubmission
+from tests.fakes import (
+    FakeClock,
+    FakeNotifierError,
+    InMemoryLeadStore,
+    RecordingNotifier,
+    ScriptedAssessor,
+    StaticConfigSource,
+    StaticEnricher,
+)
+from tests.logcapture import LogCapture, capture_json_logs
+
+TENANT = "acme"
+OPERATOR_INBOX = "leadquali-escalations@vendoworks.test"
+
+#: Distinctive enough that a substring search cannot produce a false negative, and shaped
+#: like a real address so the formatter's pattern would match it if it ever got out.
+LEAD_EMAIL = "ada.lovelace+jat21@analytical-engines-quali.co.uk"
+
+#: Not a pattern, on purpose. Nothing in the formatter can recognise this, so the only
+#: reason it stays out of the logs is that no call site ever passes it to one.
+LEAD_MESSAGE = (
+    "We run 40 difference engines in Marylebone and our punch-card vendor just doubled "
+    "their price; I need routing sorted before the Michaelmas board meeting."
+)
+
+LEAD_NAME = "Augusta Ada King-Noel"
+LEAD_PHONE = "+44 20 7946 0958"
+
+SUBMISSION = LeadSubmission(
+    full_name=LEAD_NAME,
+    email=LEAD_EMAIL,
+    company="Analytical Engines Ltd",
+    role="Countess of Lovelace",
+    phone=LEAD_PHONE,
+    website="https://analytical-engines-quali.co.uk",
+    message=LEAD_MESSAGE,
+    extra={"how_did_you_hear": "Charles mentioned you at the Royal Society"},
+)
+
+#: Every string in the submission that must never be logged. The company, the role and the
+#: website are on the list too: a leak is a leak, and the test that only guards the two
+#: obvious fields is the test that misses the third.
+SECRETS: tuple[str, ...] = (
+    LEAD_EMAIL,
+    LEAD_MESSAGE,
+    LEAD_NAME,
+    LEAD_PHONE,
+    "Analytical Engines Ltd",
+    "Countess of Lovelace",
+    "Charles mentioned you at the Royal Society",
+)
+
+EMAIL_EVERYWHERE: dict[str, Any] = {
+    "hot": {"action": "email_sales", "destination": "hot@acme.test"},
+    "warm": {"action": "email_sales", "destination": "sales@acme.test"},
+    "cold": {"action": "email_sales", "destination": "nurture@acme.test"},
+    "disqualified": {"action": "suppress"},
+}
+
+METERING = CallMetering(
+    model_id="claude-opus-5",
+    prompt_version="rubric_v1",
+    effort="medium",
+    input_tokens=512,
+    output_tokens=843,
+    cache_read_tokens=1487,
+    cache_creation_tokens=0,
+    cost_usd=Decimal("0.02347"),
+    latency_ms=4213,
+)
+
+
+def make_config(rules: dict[str, Any] | None = None, **overrides: Any) -> TenantConfig:
+    return TenantConfig.model_validate(
+        {
+            "tenant_id": TENANT,
+            "name": "Acme Corp",
+            "icp_description": "B2B SaaS companies with 50-500 employees in North America.",
+            "routing_rules": rules if rules is not None else EMAIL_EVERYWHERE,
+            **overrides,
+        }
+    )
+
+
+def make_assessment(
+    *, score: int = 25, confidence: float = 0.9, spam: bool = False
+) -> LeadAssessment:
+    return LeadAssessment(
+        dimension_scores=DimensionScores(
+            icp_fit=min(score, 30),
+            intent=min(score, 25),
+            authority=min(score, 15),
+            urgency=min(score, 15),
+            budget_signal=min(score, 15),
+        ),
+        extracted=ExtractedFacts(
+            company_name="Analytical Engines",
+            industry="manufacturing",
+            company_size_estimate="120",
+            role_seniority="owner",
+            stated_use_case="lead routing",
+            stated_timeline="this quarter",
+        ),
+        reasoning="Fits the profile and states a timeline.",
+        confidence=confidence,
+        missing_information=[],
+        suggested_first_question=None,
+        spam_or_test_submission=spam,
+    )
+
+
+def succeeded(**kwargs: Any) -> AssessmentSucceeded:
+    return AssessmentSucceeded(assessment=make_assessment(**kwargs), metering=METERING)
+
+
+def build_pipeline(
+    *,
+    outcome: AssessmentOutcome | None = None,
+    notifier: RecordingNotifier | None = None,
+    store: InMemoryLeadStore | None = None,
+    enricher: StaticEnricher | None = None,
+    rules: dict[str, Any] | None = None,
+) -> tuple[QualificationPipeline, InMemoryLeadStore, RecordingNotifier]:
+    """A pipeline over in-memory ports. No network, no database, no clock."""
+    resolved_store = store if store is not None else InMemoryLeadStore()
+    resolved_notifier = notifier if notifier is not None else RecordingNotifier()
+    pipeline = QualificationPipeline(
+        config_source=StaticConfigSource({TENANT: make_config(rules)}),
+        assessor=ScriptedAssessor(outcome if outcome is not None else succeeded()),
+        store=resolved_store,
+        notifier=resolved_notifier,
+        enricher=enricher if enricher is not None else StaticEnricher(),
+        clock=FakeClock(),
+        escalation_destination=OPERATOR_INBOX,
+    )
+    return pipeline, resolved_store, resolved_notifier
+
+
+def request_for(submission_id: str = "sub-1", trace_id: str | None = None) -> QualificationRequest:
+    return QualificationRequest(
+        tenant_id=TENANT,
+        submission_id=submission_id,
+        submission=SUBMISSION,
+        received_at=datetime(2026, 9, 3, 9, 0, tzinfo=UTC),
+        trace_id=trace_id,
+    )
+
+
+def directives(record: dict[str, Any]) -> list[dict[str, Any]]:
+    """The EMF directives on one record. Fails the test if the line carries no metrics."""
+    aws = record.get("_aws")
+    assert isinstance(aws, dict), f"{record.get('event')!r} carries no EMF document"
+    found = aws["CloudWatchMetrics"]
+    assert all(directive["Namespace"] == METRIC_NAMESPACE for directive in found)
+    return list(found)
+
+
+def dimensioned(record: dict[str, Any], *dimensions: str) -> dict[str, Any]:
+    """The one directive published under exactly ``dimensions``."""
+    wanted = list(dimensions)
+    matches = [directive for directive in directives(record) if directive["Dimensions"] == [wanted]]
+    assert len(matches) == 1, f"expected one directive on {wanted}, got {len(matches)}"
+    return matches[0]
+
+
+def metric_names(directive: dict[str, Any]) -> set[str]:
+    return {metric["Name"] for metric in directive["Metrics"]}
+
+
+def assert_no_pii(logs: LogCapture) -> None:
+    """No field, message, traceback or metric on any record carries the lead's data.
+
+    Checked against the raw output rather than the parsed records, so an address hiding in
+    a key, in a nested object or inside an escaped traceback string is still caught.
+    """
+    blob = logs.text
+    assert blob, "nothing was logged, so this test proves nothing"
+    for secret in SECRETS:
+        assert secret not in blob, f"{secret!r} reached the logs"
+    # Nothing even *tried* to log an address: the formatter's net never had to fire. This is
+    # the assertion that keeps the net from becoming a licence to be careless upstream.
+    assert EMAIL_REDACTION not in blob
+    # And nothing address-shaped survives under any other spelling.
+    for record in logs.records():
+        leaked = re.findall(r"[A-Za-z0-9._%+\-]+@[A-Za-z0-9.\-]+\.[A-Za-z]{2,}", json.dumps(record))
+        assert leaked == [], f"{record.get('event')!r} carries {leaked}"
+
+
+# ------------------------------------------------------------------ trace propagation
+
+
+def ingest_service(store: InMemoryLeadStore, queue: InProcessLeadQueue) -> IngestService:
+    return IngestService(store=store, queue=queue, clock=FakeClock())
+
+
+def test_one_trace_id_spans_ingest_the_queue_and_the_worker() -> None:
+    """The acceptance criterion: one lead's whole journey, by trace id alone."""
+    store = InMemoryLeadStore()
+    queue = InProcessLeadQueue()
+
+    with capture_json_logs() as logs:
+        receipt = ingest_service(store, queue).accept(
+            IngestRequest(tenant_id=TENANT, submission_id="sub-1", submission=SUBMISSION)
+        )
+        # The wire hop, for real: serialise the message and rebuild it the way #26's worker
+        # will, rather than passing the object through and assuming the field survives.
+        rebuilt = QueuedLead.from_message(json.loads(json.dumps(queue.drain()[0].to_message())))
+        pipeline, _, _ = build_pipeline(store=store)
+        result = pipeline.qualify(
+            QualificationRequest(
+                tenant_id=rebuilt.tenant_id,
+                submission_id=rebuilt.submission_id,
+                submission=rebuilt.submission,
+                received_at=rebuilt.received_at,
+                trace_id=rebuilt.trace_id,
+            )
+        )
+
+    assert rebuilt.trace_id == receipt.trace_id
+    assert result.trace_id == receipt.trace_id
+    assert result.disposition is Disposition.DISPATCHED
+
+    emitted = logs.records()
+    # *Every* record, not only the structured ones. The queue's own line is a plain
+    # printf-style ``LOGGER.info`` written by code that was never handed a trace id, and it
+    # carries one anyway — that is the whole reason the id lives on a ContextVar instead of
+    # in six port signatures.
+    assert len(emitted) >= 4
+    assert {record["trace_id"] for record in emitted} == {receipt.trace_id}
+    assert any("event" not in record for record in emitted)
+    # And the structured journey is complete under that one id: edge, assessment, dispatch.
+    assert [record["event"] for record in emitted if "event" in record] == [
+        EVENT_LEAD_ACCEPTED,
+        EVENT_ASSESSMENT,
+        EVENT_LEAD_ROUTED,
+    ]
+
+
+def test_the_lead_id_appears_from_the_edge_onwards() -> None:
+    store = InMemoryLeadStore()
+    queue = InProcessLeadQueue()
+    with capture_json_logs() as logs:
+        receipt = ingest_service(store, queue).accept(
+            IngestRequest(tenant_id=TENANT, submission_id="sub-1", submission=SUBMISSION)
+        )
+    assert logs.one(EVENT_LEAD_ACCEPTED)["lead_id"] == receipt.lead_id
+    assert logs.one(EVENT_LEAD_ACCEPTED)["submission_id"] == "sub-1"
+
+
+def test_a_queue_message_round_trips_its_trace_id() -> None:
+    lead = QueuedLead(
+        tenant_id=TENANT,
+        lead_id="lead-0001",
+        submission_id="sub-1",
+        submission=SUBMISSION,
+        source="web_form",
+        received_at=datetime(2026, 9, 3, 9, 0, tzinfo=UTC),
+        trace_id="0123456789abcdef0123456789abcdef",
+    )
+    assert lead.to_message()["trace_id"] == lead.trace_id
+    assert QueuedLead.from_message(lead.to_message()).trace_id == lead.trace_id
+
+
+def test_a_message_written_before_trace_ids_existed_still_loads() -> None:
+    """The in-flight case. A version bump would have DLQ'd these; an optional field does not.
+
+    The message keeps ``version: 1`` because the field is additive both ways — an old
+    worker ignores a key it does not know, and a new worker mints one for a message that
+    has none. What must never happen is a real lead refused to protect a log field.
+    """
+    message = QueuedLead(
+        tenant_id=TENANT,
+        lead_id="lead-0001",
+        submission_id="sub-1",
+        submission=SUBMISSION,
+        source="web_form",
+        received_at=datetime(2026, 9, 3, 9, 0, tzinfo=UTC),
+    ).to_message()
+    del message["trace_id"]
+
+    rebuilt = QueuedLead.from_message(message)
+
+    assert len(rebuilt.trace_id) == 32
+    assert rebuilt.submission == SUBMISSION
+
+
+def test_a_lead_with_no_trace_id_at_all_still_gets_one() -> None:
+    """A CLI replay or a direct call. Untraced is the one outcome that helps nobody."""
+    pipeline, _, _ = build_pipeline()
+    with capture_json_logs() as logs:
+        result = pipeline.qualify(request_for(trace_id=None))
+    assert len(result.trace_id) == 32
+    assert logs.one(EVENT_ASSESSMENT)["trace_id"] == result.trace_id
+
+
+# -------------------------------------------------------------------------- invariant 5
+
+
+def test_no_record_carries_the_address_or_the_lead_s_own_words() -> None:
+    store = InMemoryLeadStore()
+    queue = InProcessLeadQueue()
+
+    with capture_json_logs() as logs:
+        ingest_service(store, queue).accept(
+            IngestRequest(tenant_id=TENANT, submission_id="sub-1", submission=SUBMISSION)
+        )
+        pipeline, _, _ = build_pipeline(store=store)
+        pipeline.qualify(request_for())
+
+    assert_no_pii(logs)
+    # The hash is there instead, and it is the one the store writes.
+    assert logs.one(EVENT_LEAD_ACCEPTED)["contact_email_hash"] == contact_email_hash(LEAD_EMAIL)
+
+
+def test_the_exception_path_carries_no_more_than_the_happy_one() -> None:
+    """A traceback that formats a ``LeadSubmission`` would leak the entire lead.
+
+    The notifier raises with the submission interpolated into its message — the realistic
+    shape of the bug, since a provider error is normally reported with the thing that was
+    being sent. The pipeline logs that at ``ERROR`` with the traceback attached and then
+    re-raises, so this is the one path where the whole payload is one ``repr`` away from
+    CloudWatch.
+    """
+    notifier = RecordingNotifier()
+
+    def explode(**kwargs: Any) -> str | None:
+        raise FakeNotifierError(f"SES rejected this message: {kwargs['submission']!r}")
+
+    notifier.dispatch = explode  # type: ignore[method-assign]  # a deliberately leaky double
+    pipeline, _, _ = build_pipeline(notifier=notifier)
+
+    with capture_json_logs() as logs, pytest.raises(FakeNotifierError):
+        pipeline.qualify(request_for())
+
+    assert_no_pii(logs)
+    failed = logs.one(EVENT_DISPATCH_FAILED)
+    assert failed["level"] == "ERROR"
+    assert failed["error_type"] == "FakeNotifierError"
+    assert failed["exception"]["type"] == "FakeNotifierError"
+    # The traceback is genuinely there — the assertion above is not passing because the
+    # exception was swallowed.
+    assert "FakeNotifierError" in failed["exception"]["stack"]
+    assert "raise FakeNotifierError" in failed["exception"]["stack"]
+
+
+def test_a_submission_repr_carries_no_field_values() -> None:
+    """The mechanism behind the test above, asserted on its own.
+
+    ``repr`` is where a submission escapes without anybody deciding to emit it. Redaction
+    cannot help — the message is prose, not a pattern — so the payload has to be absent
+    from the string in the first place.
+    """
+    rendered = repr(SUBMISSION)
+    for secret in SECRETS:
+        assert secret not in rendered
+    assert "LeadSubmission" in rendered
+
+
+def test_an_unassessable_lead_leaks_nothing_either() -> None:
+    """The system-failure path: a detail string, a banner, and no submission."""
+    pipeline, _, _ = build_pipeline(
+        outcome=AssessmentFailed(
+            reason=EscalationReason.API_ERROR,
+            detail="APIStatusError 503",
+            latency_ms=900,
+        )
+    )
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+    assert_no_pii(logs)
+
+
+def test_a_broken_enricher_leaks_nothing() -> None:
+    """The enricher sees the submission, so its exception is another leak candidate."""
+    pipeline, _, _ = build_pipeline(
+        enricher=StaticEnricher(raises=RuntimeError(f"DNS lookup failed for {LEAD_EMAIL}"))
+    )
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+    assert_no_pii(logs)
+
+
+# ------------------------------------------------------------- per-assessment metrics
+
+
+def test_a_successful_assessment_emits_the_metering_it_was_given() -> None:
+    pipeline, _, _ = build_pipeline(outcome=succeeded(score=28))
+
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+
+    record = logs.one(EVENT_ASSESSMENT)
+    # Fields: the provenance and the numbers, exactly as the adapter computed them.
+    assert record["model_id"] == METERING.model_id
+    assert record["prompt_version"] == METERING.prompt_version
+    assert record["effort"] == METERING.effort
+    assert record["input_tokens"] == METERING.input_tokens
+    assert record["output_tokens"] == METERING.output_tokens
+    assert record["cache_read_tokens"] == METERING.cache_read_tokens
+    assert record["cache_creation_tokens"] == METERING.cache_creation_tokens
+    assert record["model_latency_ms"] == METERING.latency_ms
+    assert record["cost_usd"] == pytest.approx(float(METERING.cost_usd))
+    assert record["assessed"] is True
+    assert record["tier"] == Tier.HOT.value
+    assert record["confidence"] == pytest.approx(0.9)
+    assert record["enrichment_available"] is True
+
+    # Metrics: the same numbers, as EMF, under the dimensions #29 alarms on.
+    per_tenant = dimensioned(record, DIM_TENANT)
+    assert metric_names(per_tenant) >= {
+        ASSESSMENTS,
+        ASSESSMENT_FAILURES,
+        ENRICHMENT_UNAVAILABLE,
+        INPUT_TOKENS,
+        OUTPUT_TOKENS,
+        CACHE_READ_TOKENS,
+        COST_USD,
+        MODEL_LATENCY_MS,
+    }
+    assert record[DIM_TENANT] == TENANT
+    assert record[ASSESSMENTS] == 1
+    assert record[ASSESSMENT_FAILURES] == 0
+    assert record[COST_USD] == pytest.approx(float(METERING.cost_usd))
+    assert record[MODEL_LATENCY_MS] == METERING.latency_ms
+    assert {"Name": COST_USD, "Unit": "None"} in per_tenant["Metrics"]
+
+
+def test_cost_is_a_json_number_so_it_can_be_summed() -> None:
+    """A ``Decimal`` serialises as a string, and CloudWatch drops a directive that has one."""
+    pipeline, _, _ = build_pipeline()
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+    assert f'"{COST_USD}": {float(METERING.cost_usd)}' in logs.text
+
+
+def test_the_tier_of_every_decision_is_emitted() -> None:
+    """Plan section 8's drift signal is ``Assessments`` by ``Tier`` — so every decision counts.
+
+    Including the ones nobody was emailed about. A tier distribution computed only over
+    dispatched leads would move whenever a tenant changed its routing table, which is
+    exactly the false positive that gets a drift alarm switched off.
+    """
+    cases: dict[Tier, AssessmentOutcome] = {
+        Tier.HOT: succeeded(score=28),
+        Tier.COLD: succeeded(score=8),
+        Tier.WARM: AssessmentFailed(
+            reason=EscalationReason.TIMEOUT, detail="read timeout", latency_ms=30_000
+        ),
+        Tier.DISQUALIFIED: succeeded(spam=True),
+    }
+    for tier, outcome in cases.items():
+        pipeline, _, _ = build_pipeline(outcome=outcome)
+        with capture_json_logs() as logs:
+            pipeline.qualify(request_for())
+        record = logs.one(EVENT_ASSESSMENT)
+        assert record["tier"] == tier.value, tier
+        assert record[DIM_TIER] == tier.value
+        assert dimensioned(record, DIM_TENANT, DIM_TIER)["Metrics"] == [
+            {"Name": ASSESSMENTS, "Unit": "Count"}
+        ]
+        assert record[ASSESSMENTS] == 1
+
+
+def test_a_failed_assessment_is_counted_and_attributed() -> None:
+    pipeline, _, _ = build_pipeline(
+        outcome=AssessmentFailed(
+            reason=EscalationReason.PARSE_ERROR, detail="schema violation", latency_ms=1500
+        )
+    )
+
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+
+    record = logs.one(EVENT_ASSESSMENT)
+    assert record["assessed"] is False
+    assert record["escalation_reason"] == EscalationReason.PARSE_ERROR.value
+    assert "confidence" not in record  # there is no assessment to be confident about
+    assert "cost_usd" not in record  # the call never completed, so nothing was billed
+    assert record[ASSESSMENT_FAILURES] == 1
+    assert record[DIM_ESCALATION_REASON] == EscalationReason.PARSE_ERROR.value
+    assert metric_names(dimensioned(record, DIM_TENANT, DIM_ESCALATION_REASON)) == {ESCALATIONS}
+    assert record[ESCALATIONS] == 1
+
+
+def test_a_refusal_is_a_failure_that_still_cost_money() -> None:
+    """A refusal is an HTTP 200 and Anthropic bills for it. An unmetered refusal is a hole
+    in the cost figure, so the metering rides on the failure and is emitted from it."""
+    pipeline, _, _ = build_pipeline(
+        outcome=AssessmentFailed(
+            reason=EscalationReason.MODEL_REFUSAL,
+            detail="refusal stop reason",
+            latency_ms=2100,
+            metering=METERING,
+        )
+    )
+
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+
+    record = logs.one(EVENT_ASSESSMENT)
+    assert record[ASSESSMENT_FAILURES] == 1
+    assert record[COST_USD] == pytest.approx(float(METERING.cost_usd))
+    assert record["model_id"] == METERING.model_id
+
+
+def test_a_low_confidence_escalation_is_attributed_to_the_gate() -> None:
+    pipeline, _, _ = build_pipeline(outcome=succeeded(score=28, confidence=0.2))
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+    record = logs.one(EVENT_ASSESSMENT)
+    assert record["assessed"] is True
+    assert record["escalation_reason"] == EscalationReason.LOW_CONFIDENCE.value
+    assert record["tier"] == Tier.WARM.value
+    assert record[ASSESSMENT_FAILURES] == 0  # our systems worked; the model was unsure
+
+
+def test_enrichment_being_unavailable_is_counted() -> None:
+    """#58's failure mode: an enricher that quietly stops working degrades every assessment
+    and nothing in the product looks different. The counter is the only symptom."""
+    pipeline, _, _ = build_pipeline(
+        enricher=StaticEnricher(Enrichment.unavailable("mx lookup timed out"))
+    )
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+    record = logs.one(EVENT_ASSESSMENT)
+    assert record["enrichment_available"] is False
+    assert record[ENRICHMENT_UNAVAILABLE] == 1
+
+
+def test_enrichment_being_available_is_counted_as_zero_not_omitted() -> None:
+    """A metric that is absent on the happy path cannot be averaged or alarmed on."""
+    pipeline, _, _ = build_pipeline()
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+    assert logs.one(EVENT_ASSESSMENT)[ENRICHMENT_UNAVAILABLE] == 0
+
+
+# --------------------------------------------------------------------- outcome metrics
+
+
+def test_a_dispatch_emits_its_tier_destination_hash_and_latency() -> None:
+    pipeline, _, notifier = build_pipeline(outcome=succeeded(score=28))
+
+    with capture_json_logs() as logs:
+        result = pipeline.qualify(request_for())
+
+    record = logs.one(EVENT_LEAD_ROUTED)
+    assert record["tier"] == Tier.HOT.value
+    assert record["action"] == "email_sales"
+    assert record["provider_message_id"] == notifier.message_id
+    assert record["destination_hash"] == contact_email_hash("hot@acme.test")
+    assert "hot@acme.test" not in logs.text
+    assert record["latency_ms"] == result.latency_ms
+    assert record[DISPATCHES] == 1
+    assert record[FALLBACK_DESTINATIONS] == 0
+    assert record[PIPELINE_LATENCY_MS] == result.latency_ms
+    assert metric_names(dimensioned(record, DIM_TENANT, DIM_TIER)) == {DISPATCHES}
+
+
+def test_a_fallback_destination_is_counted() -> None:
+    """A tenant whose routing table has nowhere to put an escalation. The lead still lands;
+    the counter is how anyone finds out the configuration disagrees with reality."""
+    pipeline, _, _ = build_pipeline(
+        outcome=AssessmentFailed(reason=EscalationReason.API_ERROR, detail="503", latency_ms=800),
+        rules={tier: {"action": "suppress"} for tier in EMAIL_EVERYWHERE},
+    )
+
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+
+    record = logs.one(EVENT_LEAD_ROUTED)
+    assert record["used_fallback_destination"] is True
+    assert record[FALLBACK_DESTINATIONS] == 1
+    assert record["destination_hash"] == contact_email_hash(OPERATOR_INBOX)
+
+
+def test_the_two_suppressions_are_told_apart() -> None:
+    """#52 gave them distinguishable notes for exactly this. "A bot found our form" and
+    "our rubric is rejecting everybody" need different people to look."""
+    spam_pipeline, _, _ = build_pipeline(outcome=succeeded(spam=True))
+    with capture_json_logs() as logs:
+        spam_pipeline.qualify(request_for())
+    spam = logs.one(EVENT_LEAD_SUPPRESSED)
+    assert spam["suppression_cause"] == SuppressionCause.SPAM.value
+    assert spam[DIM_SUPPRESSION_CAUSE] == SuppressionCause.SPAM.value
+    assert spam[SUPPRESSIONS] == 1
+    assert metric_names(dimensioned(spam, DIM_TENANT, DIM_SUPPRESSION_CAUSE)) == {SUPPRESSIONS}
+
+    low_pipeline, _, _ = build_pipeline(outcome=succeeded(score=1))
+    with capture_json_logs() as logs:
+        low_pipeline.qualify(request_for())
+    low = logs.one(EVENT_LEAD_SUPPRESSED)
+    assert low["suppression_cause"] == SuppressionCause.BELOW_THRESHOLD.value
+    assert low["tier"] == Tier.DISQUALIFIED.value
+
+
+def test_a_suppressed_lead_emits_no_dispatch() -> None:
+    pipeline, _, _ = build_pipeline(outcome=succeeded(spam=True))
+    with capture_json_logs() as logs:
+        pipeline.qualify(request_for())
+    assert logs.events(EVENT_LEAD_ROUTED) == []
+
+
+def test_a_redelivery_emits_the_duplicate_metric_and_nothing_else() -> None:
+    store = InMemoryLeadStore()
+    pipeline, _, _ = build_pipeline(store=store)
+    pipeline.qualify(request_for())
+
+    with capture_json_logs() as logs:
+        result = pipeline.qualify(request_for())
+
+    assert result.disposition is Disposition.DUPLICATE
+    record = logs.one(EVENT_LEAD_DUPLICATE)
+    assert record[DUPLICATES] == 1
+    assert record[PIPELINE_LATENCY_MS] == result.latency_ms
+    # No second model call, so no second assessment metric to double count the spend with.
+    assert logs.events(EVENT_ASSESSMENT) == []
+    assert logs.events(EVENT_LEAD_ROUTED) == []
+
+
+def test_a_dispatch_failure_is_counted_for_the_worker_error_rate() -> None:
+    pipeline, _, _ = build_pipeline(notifier=RecordingNotifier(fail_times=1))
+
+    with capture_json_logs() as logs, pytest.raises(FakeNotifierError):
+        pipeline.qualify(request_for())
+
+    record = logs.one(EVENT_DISPATCH_FAILED)
+    assert record[DISPATCH_FAILURES] == 1
+    assert metric_names(dimensioned(record, DIM_TENANT)) == {DISPATCH_FAILURES}
+    assert logs.events(EVENT_LEAD_ROUTED) == []
+
+
+def test_the_edge_counts_what_it_did_with_each_submission() -> None:
+    store = InMemoryLeadStore()
+    queue = InProcessLeadQueue()
+    with capture_json_logs() as logs:
+        ingest_service(store, queue).accept(
+            IngestRequest(tenant_id=TENANT, submission_id="sub-1", submission=SUBMISSION)
+        )
+    record = logs.one(EVENT_LEAD_ACCEPTED)
+    assert record["disposition"] == "queued"
+    assert record[INGESTED_LEADS] == 1
+    assert record["Disposition"] == "queued"
+
+
+def test_the_edge_counts_a_pre_filtered_submission_by_filter() -> None:
+    store = InMemoryLeadStore()
+    queue = InProcessLeadQueue()
+    with capture_json_logs() as logs:
+        ingest_service(store, queue).accept(
+            IngestRequest(
+                tenant_id=TENANT,
+                submission_id="sub-1",
+                submission=SUBMISSION,
+                honeypot="filled-by-a-bot",
+            )
+        )
+    record = logs.one(EVENT_LEAD_ACCEPTED)
+    assert record["disposition"] == "suppressed"
+    assert record["spam_reason"] == "honeypot"
+    assert record["SpamReason"] == "honeypot"
+    assert record["IngestSuppressions"] == 1
+    assert queue.pending() == ()
+
+
+# ------------------------------------------------------------------------ idempotency
+
+
+def test_configuring_logging_twice_does_not_double_a_lead_s_journey() -> None:
+    """A Lambda container is reused; a handler added per invocation doubles every metric.
+
+    Asserted on the journey rather than on handler bookkeeping: two ``lead.routed`` lines
+    for one lead is two dispatches as far as CloudWatch is concerned, and that is what the
+    duplication actually costs.
+    """
+    pipeline, _, _ = build_pipeline()
+    with capture_json_logs() as logs:
+        configure_logging(
+            Settings(env=Environment.PROD, log_level="INFO"),
+            stream=logs.buffer,
+            log_format=LOG_FORMAT_JSON,
+        )
+        pipeline.qualify(request_for())
+
+    assert len(logs.events(EVENT_LEAD_ROUTED)) == 1
+    assert len(logs.events(EVENT_ASSESSMENT)) == 1
+    assert len(logs.events(EVENT_LEAD_ACCEPTED)) == 0  # nothing stray got in either


### PR DESCRIPTION
Closes #21. **This completes Phase 2.** On top of #60 (SES) → #59 → #57 → #50 → #56.

An alarm can only fire on something that is emitted, so this is what makes #29 possible. `docs/observability.md` is the contract #29 and #33 build on.

## Metrics: EMF, not `PutMetricData`

The reasoning matters more than the choice. `PutMetricData` adds 20–80 ms to a lead a customer is waiting on, needs IAM the worker otherwise lacks, costs per call, and **can fail** — which forces a choice between a silently unfed alarm and failing a lead over telemetry. EMF writes to the log line the worker is already writing.

Namespace `LeadQuali`, dimensions `TenantId` / `Tier` / `EscalationReason` / `SuppressionCause` / `SpamReason` / `Disposition` — all bounded, ~20 metrics per tenant. `lead_id` and `trace_id` are **fields, not dimensions**; making them dimensions would mint a new metric per lead and produce a bill worth more than the leads.

## What #29 should alarm on

1. DLQ depth > 0 (backstop).
2. `DispatchFailures` > 0 / 5 min.
3. `AssessmentFailures` ÷ `Assessments` > 5% / 15 min, routed by `EscalationReason`.
4. p99 `PipelineLatencyMs` beside p99 `ModelLatencyMs` — **the gap tells you whether it's Anthropic or you.**
5. Daily `CostUsd` > ~2× baseline, and daily `CacheReadTokens` → 0 (the prefix moved; the cost model no longer holds).
6. **Tier drift** — plan §8's leading indicator that a prompt or the upstream form changed: metric math `Assessments[Tier=hot] ÷ Assessments[all]`, hourly per tenant, against a 7-day band. Valid because `Assessments` is emitted **before** the suppress/dispatch branch, so it counts decisions rather than dispatches.
7. `EnrichmentUnavailable` > ~10% / hour — #58's invisible failure mode.
8. `Suppressions` by `SuppressionCause` daily; `spam` and `below_threshold` have different owners, which is why #52 gave them distinguishable notes.

## Trace-id propagation, and why the message version stayed at 1

`api.main` mints the id (so 401/413/422 also log under one) → `IngestRequest` → `IngestService` binds context → `IngestReceipt` → `QueuedLead.to_message()` → queue → `from_message()` → pipeline → every record, including SQLAlchemy's and botocore's.

**The queue message version deliberately stays `1`.** The field is additive and optional in both directions: an old worker ignores the key, a new worker mints one for a message that lacks it. Bumping the version would have DLQ'd every message the new ingest wrote during a rolling deploy — **refusing real leads to protect a log field.**

## PII discipline

The test is the deliverable: a lead with a distinctive address *and* message goes through the pipeline with logging captured, asserting neither string appears in any record — on the happy path **and the exception path**.

That second one required reaching into #54's file: `LeadSubmission`'s fields are now `repr=False`, because a traceback formatting a submission leaks everything and no redaction pass can recognise arbitrary prose. **Rendering to the model is untouched** — #54's containment tests still pass. Only `repr` changed.

## Two other judgement calls

- **`contact_email_hash` moved to `observability/pii.py`** and is re-exported by `store_postgres`. One definition, or a log line cannot be joined to a `leads` row — which is the entire point of logging a hash.
- **`app` now imports `observability`**, a documented exception to CLAUDE.md's layering rule, with a new layering test that fails if `observability` ever imports `adapters` or `api`. The alternative — threading a logger through every call signature — is worse.

## Verification

53 new tests (1039 passing). Two of #59's log tests were rewritten to assert on parsed JSON rather than formatted strings. Includes a test that `configure_logging()` twice does not duplicate records — Lambda reuses containers, and a doubled handler doubles every log line *and* every metric derived from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_