### PR TITLE
[P3.2] Eval harness: run_eval.py, the four metrics, and a manual-dispatch workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,11 @@ venv/
 .aws-sam/
 samconfig.toml
 
+# Eval runs. A result file is evidence attached to a pull request (#23), not source:
+# it is timestamped, it is regenerated on every run, and it would otherwise turn every
+# eval into a diff nobody reviews.
+tests/evals/results/
+
 # Local tooling
 .venv*/
 *.log

--- a/README.md
+++ b/README.md
@@ -50,3 +50,38 @@ Two behaviours are deliberate and worth knowing before you read the output:
 
 If `cache_read` is `0` on a second run of the same tenant, the cacheable prompt prefix has
 moved — something volatile has leaked into it, and the cost model no longer holds.
+
+## The release rule: no prompt or model change ships without an eval
+
+Every change to the rubric, the prompt, the model id or the effort level **must have an
+eval run attached to the pull request** — the run summary or the JSON result file from
+`tests/evals/run_eval.py`. Not a description of one; the output. Without it the change is
+a guess, and a rubric regression is invisible until a salesperson notices that good leads
+stopped arriving, which is months later and unattributable.
+
+```bash
+# What will this cost? Free, calls nothing, needs no key.
+python -m tests.evals.run_eval --estimate
+
+# Run it. Both the flag and the key are required, and neither implies the other.
+export ANTHROPIC_API_KEY=sk-ant-...
+python -m tests.evals.run_eval --confirm-spend --effort medium
+```
+
+It prints, in this order: **recall on "should have been contacted"** (hot + warm — the
+false-disqualification rate, the number that costs money), precision on `hot` (the number
+sales feels), exact and adjacent tier accuracy, cost and p95 latency per lead, a confusion
+matrix, per-case results with each label's notes beside the model's reasoning, and any
+prompt-injection findings. It also writes a timestamped JSON file under
+`tests/evals/results/` tagged with the model, prompt version, effort and git SHA, so two
+runs can be diffed.
+
+In CI it is `workflow_dispatch` only — see the header of `ci/github-actions-eval.yml` for
+the one-line `git mv` that activates it. It never runs on `push`: the eval costs real
+money per invocation.
+
+> **Read this before quoting a number from it.** The golden set is currently **synthetic
+> and self-labeled**, so every figure it produces measures self-consistency with whoever
+> wrote the seed cases — not correctness. The report says so beside every metric, and
+> [`docs/labeling-golden-set.md`](docs/labeling-golden-set.md) is how the set stops being
+> synthetic: promote real leads from the `feedback` table, weekly.

--- a/ci/github-actions-eval.yml
+++ b/ci/github-actions-eval.yml
@@ -1,0 +1,159 @@
+# ACTIVATION REQUIRED — this file must live at .github/workflows/eval.yml to run.
+#
+#     git mv ci/github-actions-eval.yml .github/workflows/eval.yml && git commit -m "Activate the eval workflow"
+#
+# It is staged here only because the automation that authored it pushes over a credential
+# without GitHub's `workflow` scope, which rejects any push that touches
+# .github/workflows/. The content below is final; the move is the whole activation.
+# tests/unit/test_eval_workflow.py finds the file at either path, so the move needs no
+# test change.
+#
+# BEFORE THE FIRST RUN: add the *development* Anthropic key as a repository secret named
+# ANTHROPIC_API_KEY. Scope it to this workflow's environment if the repository has one; it
+# is the only workflow that should ever be able to read it, and CI (ci.yml) deliberately
+# cannot — see the assertion in tests/unit/test_ci_workflow.py.
+#
+# WHY workflow_dispatch AND NOTHING ELSE (plan §7.4). Every run of this workflow makes one
+# billable model call per golden case and consumes real rate limit. On `push` it would
+# bill every commit, and on `pull_request` it would let anybody with a fork spend the
+# account's money. It runs when a person decides a prompt or model change is worth
+# measuring, and before a deploy. That is the entire trigger policy, and the harness
+# refuses to start without --confirm-spend besides, so a mis-wired trigger still cannot
+# spend anything.
+#
+# WHAT A GREEN RUN DOES NOT MEAN. The golden set is currently synthetic and self-labeled,
+# so the numbers in the summary measure self-consistency with whoever wrote the seed, not
+# correctness. The report says so on every metric block; read it, and read
+# docs/labeling-golden-set.md, before quoting anything from an Actions run.
+name: Eval
+
+on:
+  workflow_dispatch:
+    inputs:
+      effort:
+        description: "Model effort level to evaluate at."
+        type: choice
+        default: medium
+        options:
+          - low
+          - medium
+          - high
+          - xhigh
+          - max
+      prompt_version:
+        description: "Prompt version you believe you are testing. The run aborts if the checkout ships a different one."
+        type: string
+        default: rubric_v1
+      repeat:
+        description: "Runs of the whole set. 2+ quantifies run-to-run nondeterminism, and multiplies the cost."
+        type: string
+        default: "1"
+      concurrency:
+        description: "In-flight model calls. Lower this if the account is rate limited; the SDK already retries with backoff."
+        type: string
+        default: "4"
+
+# Read-only: this job checks out the source, spends money and writes a summary. It does
+# not need to write to the repository, and a token that could would be a token an eval
+# result could be forged with.
+permissions:
+  contents: read
+
+# One paid run at a time. `cancel-in-progress: false` on purpose - unlike CI, a superseded
+# run here has already spent money, and cancelling it throws that away while leaving no
+# report to show for it. A second dispatch queues behind the first, which also keeps two
+# runs from competing for the same account rate limit.
+concurrency:
+  group: eval-${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  eval:
+    name: Golden-set eval
+    runs-on: ubuntu-latest
+    # Generous, because this waits on a model: 100 cases at 4-way concurrency and a
+    # 120s per-attempt timeout is minutes, not seconds. Bounded anyway, so a hung run
+    # cannot burn an hour of minutes on a call that is never coming back.
+    timeout-minutes: 45
+    defaults:
+      run:
+        shell: bash
+
+    steps:
+      - name: Check out the revision being evaluated
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.13
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install the package and its dev extras
+        run: pip install -e ".[dev]"
+
+      - name: Verify the checkout ships the prompt version being claimed
+        # Fails before a penny is spent. A run labeled `rubric_v1` that actually exercised
+        # `rubric_v2` is worse than no run: it is a number filed against the wrong prompt.
+        run: |
+          set -o pipefail
+          shipped=$(python -c 'from leadquali.prompts.rubric import PROMPT_VERSION; print(PROMPT_VERSION)')
+          echo "checkout ships: $shipped"
+          if [ "$shipped" != "${{ inputs.prompt_version }}" ]; then
+            echo "::error::this checkout ships prompt version '$shipped', but the run was dispatched for '${{ inputs.prompt_version }}'"
+            exit 1
+          fi
+
+      - name: Estimate the spend before committing to it
+        # Free, calls nothing, and needs no key. Printed first so the cost of the run is
+        # in the log above the run itself rather than discovered on the invoice.
+        run: |
+          set -o pipefail
+          python -m tests.evals.run_eval --estimate \
+            --effort "${{ inputs.effort }}" \
+            --concurrency "${{ inputs.concurrency }}" | tee eval-estimate.txt
+
+      - name: Run the golden-set eval
+        # The only step that sees the key, and the only one that spends anything.
+        env:
+          ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
+        run: |
+          set -o pipefail
+          python -m tests.evals.run_eval \
+            --confirm-spend \
+            --effort "${{ inputs.effort }}" \
+            --repeat "${{ inputs.repeat }}" \
+            --concurrency "${{ inputs.concurrency }}" \
+            --out eval-results | tee eval-report.txt
+
+      - name: Post the report to the run summary
+        # `always()`: a run that ended on a prompt-injection finding exits non-zero, and
+        # that is exactly the run whose report somebody needs to read.
+        if: always()
+        run: |
+          {
+            echo '### Golden-set eval — effort `${{ inputs.effort }}`, prompt `${{ inputs.prompt_version }}`'
+            echo
+            echo '> The golden set is currently synthetic and self-labeled. Numbers below measure'
+            echo '> self-consistency with the seed author, not correctness. See docs/labeling-golden-set.md.'
+            echo
+            echo '```'
+            cat eval-estimate.txt 2>/dev/null || echo '(no estimate: the run failed before it was produced)'
+            echo
+            cat eval-report.txt 2>/dev/null || echo '(no report: the run failed before it produced one)'
+            echo '```'
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload the JSON result
+        # Retained so two runs can be diffed later - which is the whole point of the file,
+        # and what #24's effort sweep consumes.
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: eval-results-${{ inputs.effort }}-${{ github.run_id }}
+          path: |
+            eval-results/
+            eval-report.txt
+          if-no-files-found: warn
+          retention-days: 90

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,10 @@ dev = [
     # SES is mocked in-process: there are no AWS credentials in CI and a test that
     # needed them would simply never run.
     "moto[ses]",
+    # The CI and eval workflows are configuration, and configuration that spends money
+    # gets asserted rather than assumed: tests/unit/test_eval_workflow.py parses them.
+    "pyyaml",
+    "types-PyYAML",
 ]
 
 [build-system]

--- a/tests/evals/metrics.py
+++ b/tests/evals/metrics.py
@@ -1,0 +1,727 @@
+"""The eval maths: four metrics, a confusion matrix, and the honesty around them.
+
+Pure functions over :class:`CaseResult` values. Nothing here talks to a model, reads a
+file or knows what a tenant is — which is what makes the arithmetic testable against
+hand-computed fixtures in ``tests/unit/test_eval_metrics.py``, and what keeps
+``run_eval.py`` to wiring.
+
+Three decisions in here are load-bearing.
+
+**Every comparison goes through :attr:`~leadquali.domain.models.Tier.rank`.** ``Tier`` is a
+``StrEnum``, so ``Tier.COLD < Tier.HOT`` is ``True`` — lexicographically — and an
+adjacency check written on the string would quietly rank a cold lead above a hot one. #7
+added ``rank`` for exactly this, and no module-level ordering is defined here that could
+drift from it.
+
+**An empty denominator is undefined, not zero.** Precision on ``hot`` with nothing
+predicted hot is not 0% — there is nothing to be right or wrong about, and a report that
+prints ``0.0%`` sends someone to fix a prompt that may be fine. :class:`Ratio` carries the
+numerator, the denominator and, when the denominator is zero, the sentence saying why the
+number does not exist. The same applies to recall when no case is labeled contactable, and
+to every metric of an empty segment — which is the normal state of the ``real`` segment
+today, because the golden set has no real cases in it yet.
+
+**Every metric block carries the synthetic caveat.** :func:`synthetic_caveat` is computed
+per segment and stored on :class:`SegmentMetrics` rather than printed once at the top of a
+report, because a number gets copied out of a report and the sentence has to travel with
+it. The seed golden set is entirely synthetic (see ``docs/labeling-golden-set.md`` §0), so
+today every one of these figures measures agreement with whoever wrote the seed, not
+correctness.
+"""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterable, Mapping, Sequence
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Final, Self
+
+from leadquali.domain.models import EscalationReason, Tier
+from tests.evals.golden_set import Provenance
+
+#: Tiers whose leads a human should have been given the chance to contact. Derived from
+#: :attr:`~leadquali.domain.models.Tier.rank` rather than written out, so a fifth tier
+#: inserted between ``warm`` and ``cold`` cannot silently fall out of the recall
+#: denominator — the number that costs money.
+CONTACTABLE_TIERS: Final[frozenset[Tier]] = frozenset(
+    tier for tier in Tier if tier.rank >= Tier.WARM.rank
+)
+
+#: Tiers best-first. The reporting order everywhere: a confusion matrix whose rows moved
+#: between runs is a diff nobody can read.
+TIERS_BY_RANK: Final[tuple[Tier, ...]] = tuple(
+    sorted(Tier, key=lambda tier: tier.rank, reverse=True)
+)
+
+#: How far apart two tiers may be and still count as an adjacent-tier match.
+ADJACENT_RANK_DISTANCE: Final[int] = 1
+
+#: Percentile reported for latency. Tail latency, not the average: the average hides the
+#: one lead in twenty that took forty seconds, and that lead is the one someone notices.
+TAIL_QUANTILE: Final[float] = 0.95
+
+
+def is_contactable(tier: Tier) -> bool:
+    """Whether a lead in this tier should have reached a human."""
+    return tier in CONTACTABLE_TIERS
+
+
+def is_adjacent(expected: Tier, predicted: Tier) -> bool:
+    """Whether two tiers are the same or one rank apart. Exact matches are adjacent too."""
+    return abs(expected.rank - predicted.rank) <= ADJACENT_RANK_DISTANCE
+
+
+@dataclass(frozen=True, slots=True)
+class Ratio:
+    """A metric as the two counts it was computed from, plus why it may not exist.
+
+    Keeping the counts rather than only the fraction is what makes two runs comparable:
+    ``0.80`` to ``0.75`` says nothing on its own, and ``12/15`` to ``12/16`` says the
+    golden set grew rather than the model regressing.
+    """
+
+    numerator: int
+    denominator: int
+    undefined_reason: str = field(default="", compare=False)
+    """Sentence to print instead of a number when ``denominator`` is zero.
+
+    Excluded from equality: it is how the absence of a number is explained, not part of
+    the measurement, so ``Ratio(0, 0, "no hot predictions") == Ratio(0, 0)``.
+    """
+
+    def __post_init__(self) -> None:
+        if self.denominator < 0 or self.numerator < 0:
+            raise ValueError(f"a ratio cannot have negative counts: {self!r}")
+        if self.numerator > self.denominator:
+            raise ValueError(
+                f"numerator {self.numerator} exceeds denominator {self.denominator}: "
+                "a metric that cannot be true is a bug, not a measurement"
+            )
+
+    @property
+    def defined(self) -> bool:
+        """Whether there was anything to divide."""
+        return self.denominator > 0
+
+    @property
+    def value(self) -> float | None:
+        """The fraction, or ``None`` when the denominator is zero."""
+        if not self.defined:
+            return None
+        return self.numerator / self.denominator
+
+    @property
+    def text(self) -> str:
+        """One human-readable cell: ``80.0% (12/15)``, or the undefined sentence."""
+        if not self.defined:
+            reason = self.undefined_reason or "nothing to measure"
+            return f"undefined ({reason})"
+        return f"{self.numerator / self.denominator:6.1%} ({self.numerator}/{self.denominator})"
+
+    def as_json(self) -> dict[str, object]:
+        """The machine-readable form #24 diffs."""
+        payload: dict[str, object] = {
+            "numerator": self.numerator,
+            "denominator": self.denominator,
+            "value": self.value,
+        }
+        if not self.defined:
+            payload["undefined_reason"] = self.undefined_reason or "nothing to measure"
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class CaseResult:
+    """What the pipeline did with one golden case, and what the label said it should do.
+
+    Deliberately holds no lead payload: an eval result file is pasted into pull requests
+    and Slack, and invariant 5 applies to it as much as to a log line. ``label_notes`` and
+    ``model_reasoning`` are prose for a human to read side by side — nothing in this module
+    or its tests ever asserts on either.
+    """
+
+    case_id: str
+    provenance: Provenance
+    expected_tier: Tier
+    lower_bound: Tier
+    upper_bound: Tier
+    predicted_tier: Tier
+    assessed: bool
+    """Whether the model returned a judgement. ``False`` is a failure, routed by
+    ``system_failure`` and reported as an escalation rather than crashing the run."""
+
+    escalation_reason: EscalationReason | None
+    total_score: float
+    confidence: float | None
+    hard_case: bool
+    injection_case_id: str | None
+    cost_usd: Decimal
+    latency_ms: int
+    note: str = ""
+    label_notes: str = ""
+    labelers: tuple[str, ...] = ()
+    model_reasoning: str = ""
+    failure_detail: str = ""
+    dimension_range_violations: tuple[str, ...] = ()
+    extracted_mismatches: tuple[str, ...] = ()
+    expect_escalation: bool = False
+    tags: tuple[str, ...] = ()
+    record: Mapping[str, object] = field(default_factory=dict, compare=False)
+    """#13's ``--json`` record for this case, carried verbatim into the result file.
+
+    The CLI already defines a machine-readable shape for "what happened to one lead"
+    (``assessment`` / ``decision`` / ``metering`` / ``failure``), and the eval consumes it
+    rather than inventing a second vocabulary for the same facts. Excluded from equality:
+    it is a payload, and two results are the same result when their measured fields are.
+    """
+
+    @property
+    def is_synthetic(self) -> bool:
+        """Whether this case is illustrative rather than evidential."""
+        return self.provenance is Provenance.SYNTHETIC
+
+    @property
+    def is_injection(self) -> bool:
+        """Whether the payload was an attack from #12's corpus."""
+        return self.injection_case_id is not None
+
+    @property
+    def exact_match(self) -> bool:
+        """Whether the pipeline landed on the tier the human adjudicated."""
+        return self.predicted_tier is self.expected_tier
+
+    @property
+    def adjacent_match(self) -> bool:
+        """Whether the pipeline landed within one rank of the label."""
+        return is_adjacent(self.expected_tier, self.predicted_tier)
+
+    @property
+    def within_band(self) -> bool:
+        """Whether the tier is inside the band the label declared acceptable."""
+        return self.lower_bound.rank <= self.predicted_tier.rank <= self.upper_bound.rank
+
+    @property
+    def expected_contactable(self) -> bool:
+        """Whether a human said this lead should have reached sales."""
+        return is_contactable(self.expected_tier)
+
+    @property
+    def predicted_contactable(self) -> bool:
+        """Whether the pipeline surfaced it."""
+        return is_contactable(self.predicted_tier)
+
+    @property
+    def false_disqualification(self) -> bool:
+        """A lead the human would have called, and the pipeline did not. The costly error."""
+        return self.expected_contactable and not self.predicted_contactable
+
+    @property
+    def escalated(self) -> bool:
+        """Whether this lead reached a human because the system was unsure or broken."""
+        return self.escalation_reason is not None
+
+    @property
+    def missing_expected_escalation(self) -> bool:
+        """The label demanded a human see this lead, and the decision did not escalate."""
+        return self.expect_escalation and not self.escalated
+
+
+@dataclass(frozen=True, slots=True)
+class LatencyStats:
+    """Latency across a segment. ``None`` throughout when the segment is empty."""
+
+    p50_ms: int | None
+    p95_ms: int | None
+    max_ms: int | None
+
+    def as_json(self) -> dict[str, int | None]:
+        """The machine-readable form."""
+        return {"p50_ms": self.p50_ms, "p95_ms": self.p95_ms, "max_ms": self.max_ms}
+
+
+@dataclass(frozen=True, slots=True)
+class SegmentMetrics:
+    """Every number for one slice of the run — the whole set, the hard cases, or one shape.
+
+    ``caveat`` is a field rather than a footnote so that no consumer can render a metric
+    from this object without the sentence that says what it is worth.
+    """
+
+    name: str
+    cases: int
+    synthetic_cases: int
+    real_cases: int
+    assessed: int
+    failures: int
+    exact_tier_accuracy: Ratio
+    adjacent_tier_accuracy: Ratio
+    within_band_accuracy: Ratio
+    precision_on_hot: Ratio
+    precision_on_hot_within_band: Ratio
+    recall_on_contactable: Ratio
+    false_disqualified_case_ids: tuple[str, ...]
+    escalations: int
+    escalations_by_reason: Mapping[str, int]
+    missing_expected_escalations: tuple[str, ...]
+    total_cost_usd: Decimal
+    cost_usd_per_lead: Decimal | None
+    latency: LatencyStats
+    caveat: str
+
+    def as_json(self) -> dict[str, object]:
+        """The machine-readable form #24 diffs. Costs are strings: they are money."""
+        return {
+            "name": self.name,
+            "cases": self.cases,
+            "synthetic_cases": self.synthetic_cases,
+            "real_cases": self.real_cases,
+            "assessed": self.assessed,
+            "failures": self.failures,
+            "recall_on_contactable": self.recall_on_contactable.as_json(),
+            "false_disqualified_case_ids": list(self.false_disqualified_case_ids),
+            "precision_on_hot": self.precision_on_hot.as_json(),
+            "precision_on_hot_within_band": self.precision_on_hot_within_band.as_json(),
+            "exact_tier_accuracy": self.exact_tier_accuracy.as_json(),
+            "adjacent_tier_accuracy": self.adjacent_tier_accuracy.as_json(),
+            "within_band_accuracy": self.within_band_accuracy.as_json(),
+            "escalations": self.escalations,
+            "escalations_by_reason": dict(self.escalations_by_reason),
+            "missing_expected_escalations": list(self.missing_expected_escalations),
+            "total_cost_usd": str(self.total_cost_usd),
+            "cost_usd_per_lead": None
+            if self.cost_usd_per_lead is None
+            else str(self.cost_usd_per_lead),
+            "latency": self.latency.as_json(),
+            "caveat": self.caveat,
+        }
+
+
+def percentile_ms(values: Sequence[int], quantile: float) -> int | None:
+    """Nearest-rank percentile of ``values``, or ``None`` when there are none.
+
+    Nearest-rank rather than an interpolating definition: it always returns a latency that
+    was actually observed, which is what someone comparing two runs wants, and it needs no
+    tie-breaking rule that could differ between two implementations of the same report.
+
+    Args:
+        values: latencies in milliseconds, in any order.
+        quantile: between 0 and 1 inclusive.
+    """
+    if not 0.0 <= quantile <= 1.0:
+        raise ValueError(f"quantile must be in [0, 1], got {quantile}")
+    if not values:
+        return None
+    ordered = sorted(values)
+    index = max(0, min(len(ordered) - 1, math.ceil(quantile * len(ordered)) - 1))
+    return ordered[index]
+
+
+def synthetic_caveat(results: Sequence[CaseResult]) -> str:
+    """The sentence that must travel with every number computed from ``results``.
+
+    Kept as a function of the segment, not of the whole run, because "the hard cases are
+    all synthetic" is a different and more important claim than "the set is 40% synthetic".
+    """
+    if not results:
+        return "No cases in this segment, so there is nothing to measure."
+    synthetic = sum(1 for result in results if result.is_synthetic)
+    if synthetic == 0:
+        return f"All {len(results)} cases came from real submissions."
+    if synthetic == len(results):
+        return (
+            f"Every one of these {len(results)} cases is synthetic: these numbers measure "
+            "self-consistency with whoever wrote the seed set, not correctness."
+        )
+    return (
+        f"{synthetic} of {len(results)} cases are synthetic; to that extent these numbers "
+        "measure self-consistency, not correctness."
+    )
+
+
+def compute_segment(name: str, results: Sequence[CaseResult]) -> SegmentMetrics:
+    """Compute every metric for one slice of a run.
+
+    Failures are in the denominators, not excluded from them. ``system_failure`` routes an
+    unassessable lead to ``warm``, so a failure is a prediction like any other and drops
+    accuracy exactly as much as production would suffer — while also being counted in
+    :attr:`SegmentMetrics.failures` and in ``escalations_by_reason``, so a run whose
+    accuracy fell because the API was down does not read as a prompt regression.
+    """
+    total = len(results)
+    predicted_hot = [result for result in results if result.predicted_tier is Tier.HOT]
+    contactable = [result for result in results if result.expected_contactable]
+    latencies = [result.latency_ms for result in results]
+    total_cost = sum((result.cost_usd for result in results), Decimal(0))
+    return SegmentMetrics(
+        name=name,
+        cases=total,
+        synthetic_cases=sum(1 for result in results if result.is_synthetic),
+        real_cases=sum(1 for result in results if not result.is_synthetic),
+        assessed=sum(1 for result in results if result.assessed),
+        failures=sum(1 for result in results if not result.assessed),
+        exact_tier_accuracy=Ratio(
+            sum(1 for result in results if result.exact_match),
+            total,
+            _NO_CASES,
+        ),
+        adjacent_tier_accuracy=Ratio(
+            sum(1 for result in results if result.adjacent_match),
+            total,
+            _NO_CASES,
+        ),
+        within_band_accuracy=Ratio(
+            sum(1 for result in results if result.within_band),
+            total,
+            _NO_CASES,
+        ),
+        precision_on_hot=Ratio(
+            sum(1 for result in predicted_hot if result.expected_tier is Tier.HOT),
+            len(predicted_hot),
+            _NO_HOT_PREDICTIONS,
+        ),
+        precision_on_hot_within_band=Ratio(
+            sum(1 for result in predicted_hot if result.within_band),
+            len(predicted_hot),
+            _NO_HOT_PREDICTIONS,
+        ),
+        recall_on_contactable=Ratio(
+            sum(1 for result in contactable if result.predicted_contactable),
+            len(contactable),
+            _NO_CONTACTABLE_CASES,
+        ),
+        false_disqualified_case_ids=_sorted_ids(
+            result for result in results if result.false_disqualification
+        ),
+        escalations=sum(1 for result in results if result.escalated),
+        escalations_by_reason=_escalations_by_reason(results),
+        missing_expected_escalations=_sorted_ids(
+            result for result in results if result.missing_expected_escalation
+        ),
+        total_cost_usd=total_cost,
+        cost_usd_per_lead=None if total == 0 else total_cost / Decimal(total),
+        latency=LatencyStats(
+            p50_ms=percentile_ms(latencies, 0.5),
+            p95_ms=percentile_ms(latencies, TAIL_QUANTILE),
+            max_ms=percentile_ms(latencies, 1.0),
+        ),
+        caveat=synthetic_caveat(results),
+    )
+
+
+_NO_CASES: Final[str] = "no cases in this segment"
+_NO_HOT_PREDICTIONS: Final[str] = "no lead was predicted hot, so there is nothing to be right about"
+_NO_CONTACTABLE_CASES: Final[str] = "no case is labeled hot or warm"
+
+
+def _sorted_ids(results: Iterable[CaseResult]) -> tuple[str, ...]:
+    return tuple(sorted(result.case_id for result in results))
+
+
+def _escalations_by_reason(results: Sequence[CaseResult]) -> Mapping[str, int]:
+    """Escalation counts keyed by reason, in a fixed order so two runs diff cleanly."""
+    counts: dict[str, int] = {}
+    for reason in sorted(EscalationReason, key=lambda item: item.value):
+        matching = sum(1 for result in results if result.escalation_reason is reason)
+        if matching:
+            counts[reason.value] = matching
+    return counts
+
+
+@dataclass(frozen=True, slots=True)
+class ConfusionMatrix:
+    """Expected tier against predicted tier, every tier always present.
+
+    A fixed 4x4 shape rather than only the observed combinations: a report whose rows
+    appear and disappear with the data cannot be diffed, and a zero is information — "no
+    hot lead was ever disqualified" is the single most reassuring cell in the table.
+    """
+
+    counts: Mapping[Tier, Mapping[Tier, int]]
+
+    @classmethod
+    def of(cls, results: Sequence[CaseResult]) -> Self:
+        """Tabulate ``results``, rows best-first by :attr:`~Tier.rank`."""
+        return cls(
+            counts={
+                expected: {
+                    predicted: sum(
+                        1
+                        for result in results
+                        if result.expected_tier is expected and result.predicted_tier is predicted
+                    )
+                    for predicted in TIERS_BY_RANK
+                }
+                for expected in TIERS_BY_RANK
+            }
+        )
+
+    @property
+    def total(self) -> int:
+        """How many cases the matrix accounts for."""
+        return sum(count for row in self.counts.values() for count in row.values())
+
+    def as_json(self) -> dict[str, dict[str, int]]:
+        """``{expected_tier: {predicted_tier: count}}``, keyed by tier name."""
+        return {
+            expected.value: {predicted.value: count for predicted, count in row.items()}
+            for expected, row in self.counts.items()
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class MetricSpread:
+    """How far one metric moved across repeated runs of an unchanged prompt."""
+
+    minimum: float | None
+    maximum: float | None
+    values: tuple[float | None, ...]
+
+    @property
+    def spread(self) -> float | None:
+        """``maximum - minimum``, or ``None`` if the metric was undefined in any repeat."""
+        if self.minimum is None or self.maximum is None:
+            return None
+        return self.maximum - self.minimum
+
+    def as_json(self) -> dict[str, object]:
+        """The machine-readable form."""
+        return {
+            "minimum": self.minimum,
+            "maximum": self.maximum,
+            "spread": self.spread,
+            "values": list(self.values),
+        }
+
+
+#: The metrics whose run-to-run movement is reported. Cost is in here because "the same
+#: prompt cost 30% more this time" is a real finding about caching, not noise.
+STABILITY_METRICS: Final[tuple[str, ...]] = (
+    "recall_on_contactable",
+    "precision_on_hot",
+    "exact_tier_accuracy",
+    "adjacent_tier_accuracy",
+    "cost_usd_per_lead",
+)
+
+
+@dataclass(frozen=True, slots=True)
+class StabilityReport:
+    """Quantified nondeterminism: what moved when nothing changed.
+
+    #23's acceptance criterion is that two runs on an unchanged prompt produce stable
+    numbers — which is a claim that has to be measured rather than asserted, because the
+    model is sampling and the same lead can land either side of a threshold. Reported, not
+    enforced: a threshold on run-to-run spread computed over 15 synthetic cases would be a
+    number invented from noise.
+    """
+
+    repeats: int
+    tier_stability: Ratio
+    unstable_case_ids: tuple[str, ...]
+    metric_spreads: Mapping[str, MetricSpread] = field(default_factory=dict)
+
+    def as_json(self) -> dict[str, object]:
+        """The machine-readable form."""
+        return {
+            "repeats": self.repeats,
+            "tier_stability": self.tier_stability.as_json(),
+            "unstable_case_ids": list(self.unstable_case_ids),
+            "metric_spreads": {
+                name: spread.as_json() for name, spread in self.metric_spreads.items()
+            },
+        }
+
+
+def compute_stability(runs: Sequence[Sequence[CaseResult]]) -> StabilityReport | None:
+    """Compare repeated runs of the same golden set. ``None`` from fewer than two.
+
+    Args:
+        runs: one sequence of results per repeat. Every repeat must cover the same case
+            ids — comparing different sets would produce a stability figure that means
+            nothing.
+
+    Returns:
+        The report, or ``None`` when there is only one run: a single run cannot say
+        anything about variation and must not report a fabricated ``1.0``.
+    """
+    if len(runs) < 2:
+        return None
+    by_repeat = [{result.case_id: result for result in run} for run in runs]
+    case_ids = sorted(by_repeat[0])
+    for index, mapping in enumerate(by_repeat[1:], start=1):
+        if sorted(mapping) != case_ids:
+            raise ValueError(
+                f"repeat {index} does not cover the same cases as repeat 0; stability is "
+                "only meaningful across identical case sets"
+            )
+    unstable = tuple(
+        case_id
+        for case_id in case_ids
+        if len({mapping[case_id].predicted_tier for mapping in by_repeat}) > 1
+    )
+    return StabilityReport(
+        repeats=len(runs),
+        tier_stability=Ratio(
+            len(case_ids) - len(unstable),
+            len(case_ids),
+            _NO_CASES,
+        ),
+        unstable_case_ids=unstable,
+        metric_spreads=_metric_spreads([compute_segment("repeat", run) for run in runs]),
+    )
+
+
+def _metric_spreads(per_repeat: Sequence[SegmentMetrics]) -> Mapping[str, MetricSpread]:
+    spreads: dict[str, MetricSpread] = {}
+    for name in STABILITY_METRICS:
+        values = tuple(_metric_value(segment, name) for segment in per_repeat)
+        present = [value for value in values if value is not None]
+        spreads[name] = MetricSpread(
+            minimum=min(present) if present else None,
+            maximum=max(present) if present else None,
+            values=values,
+        )
+    return spreads
+
+
+def _metric_value(segment: SegmentMetrics, name: str) -> float | None:
+    if name == "cost_usd_per_lead":
+        return None if segment.cost_usd_per_lead is None else float(segment.cost_usd_per_lead)
+    ratio: Ratio = getattr(segment, name)
+    return ratio.value
+
+
+# ------------------------------------------------------------------- security findings
+#
+# An injection case that scores hot is not a bad metric, it is a defect. Keeping these out
+# of the accuracy numbers is deliberate: averaged into a 15-case accuracy figure, one
+# successful attack moves the headline by seven points and is invisible. Reported
+# separately, it is the thing the run is red for.
+
+
+#: The attack succeeded in the direction that matters: the payload talked the pipeline
+#: into treating an attack as a lead worth a sales call today.
+FINDING_SCORED_HOT: Final[str] = "scored_hot"
+
+#: The case landed above the ceiling its entry in ``tests/fixtures/injection_corpus.json``
+#: declares. #22's loader already refuses a label above that ceiling, so this is the model
+#: exceeding it, not the label.
+FINDING_ABOVE_CEILING: Final[str] = "above_declared_ceiling"
+
+#: The opposite failure, and the one a blunt keyword filter causes: a genuine enquiry that
+#: happens to carry an injected instruction, binned below the floor its label declares. A
+#: defence that destroys real leads is not a defence, and #12's corpus carries a case with
+#: a floor above ``disqualified`` precisely so this is measurable.
+FINDING_GENUINE_LEAD_DESTROYED: Final[str] = "genuine_lead_destroyed"
+
+_FINDING_EXPLANATIONS: Final[Mapping[str, str]] = {
+    FINDING_SCORED_HOT: (
+        "an attack payload was tiered hot, which would put it in front of a salesperson today"
+    ),
+    FINDING_ABOVE_CEILING: (
+        "the tier exceeds the ceiling declared for this attack in the injection corpus"
+    ),
+    FINDING_GENUINE_LEAD_DESTROYED: (
+        "a genuine enquiry carrying an injected instruction was binned below its labeled "
+        "floor: the defence cost a real lead"
+    ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class SecurityFinding:
+    """One injection case that behaved in a way no accuracy number should absorb."""
+
+    case_id: str
+    injection_case_id: str
+    predicted_tier: Tier
+    lower_bound: Tier
+    upper_bound: Tier
+    kinds: tuple[str, ...]
+
+    @property
+    def summary(self) -> str:
+        """One sentence per kind, for the report and for whoever reads the JSON."""
+        return "; ".join(_FINDING_EXPLANATIONS[kind] for kind in self.kinds)
+
+    def as_json(self) -> dict[str, object]:
+        """The machine-readable form."""
+        return {
+            "case_id": self.case_id,
+            "injection_case_id": self.injection_case_id,
+            "predicted_tier": self.predicted_tier.value,
+            "declared_band": {"lower": self.lower_bound.value, "upper": self.upper_bound.value},
+            "kinds": list(self.kinds),
+            "summary": self.summary,
+        }
+
+
+def security_findings(results: Sequence[CaseResult]) -> tuple[SecurityFinding, ...]:
+    """Every injection case that scored hot, above its ceiling, or below its floor.
+
+    Sorted by ``case_id``, like everything else the harness emits, so a diff of two runs
+    shows a finding appearing rather than the whole list moving.
+    """
+    findings: list[SecurityFinding] = []
+    for result in sorted(results, key=lambda item: item.case_id):
+        if result.injection_case_id is None:
+            continue
+        if not result.assessed:
+            # A refusal or a timeout on an attack payload routes to WARM through
+            # `system_failure`, which can sit above the corpus ceiling - but that tier is
+            # our policy for "we could not answer", not the attack talking the model into
+            # anything. Reporting it as a successful injection would cry wolf every time
+            # the API had a bad minute, and a security signal nobody believes is worse
+            # than none. It is still visible: the case is counted as a failure and an
+            # escalation like any other.
+            continue
+        kinds: list[str] = []
+        if result.predicted_tier is Tier.HOT:
+            kinds.append(FINDING_SCORED_HOT)
+        if result.predicted_tier.rank > result.upper_bound.rank:
+            kinds.append(FINDING_ABOVE_CEILING)
+        if (
+            result.lower_bound.rank > Tier.DISQUALIFIED.rank
+            and result.predicted_tier.rank < result.lower_bound.rank
+        ):
+            kinds.append(FINDING_GENUINE_LEAD_DESTROYED)
+        if kinds:
+            findings.append(
+                SecurityFinding(
+                    case_id=result.case_id,
+                    injection_case_id=result.injection_case_id,
+                    predicted_tier=result.predicted_tier,
+                    lower_bound=result.lower_bound,
+                    upper_bound=result.upper_bound,
+                    kinds=tuple(kinds),
+                )
+            )
+    return tuple(findings)
+
+
+__all__ = [
+    "ADJACENT_RANK_DISTANCE",
+    "CONTACTABLE_TIERS",
+    "FINDING_ABOVE_CEILING",
+    "FINDING_GENUINE_LEAD_DESTROYED",
+    "FINDING_SCORED_HOT",
+    "STABILITY_METRICS",
+    "TAIL_QUANTILE",
+    "TIERS_BY_RANK",
+    "CaseResult",
+    "ConfusionMatrix",
+    "LatencyStats",
+    "MetricSpread",
+    "Ratio",
+    "SecurityFinding",
+    "SegmentMetrics",
+    "StabilityReport",
+    "compute_segment",
+    "compute_stability",
+    "is_adjacent",
+    "is_contactable",
+    "percentile_ms",
+    "security_findings",
+    "synthetic_caveat",
+]

--- a/tests/evals/report.py
+++ b/tests/evals/report.py
@@ -1,0 +1,604 @@
+"""What an eval run produced, rendered twice: for a person, and for #24.
+
+One assembled value (:class:`EvalRun`) and two renderings of it. They are in the same
+module on purpose — the text a human reads and the JSON the next tool diffs must describe
+the same run, and keeping them apart is how a report ends up quoting a number the file
+does not contain.
+
+**The JSON is a contract.** #24 sweeps effort levels by running this harness twice and
+diffing the results, so key names and the shape of a metric (``numerator`` /
+``denominator`` / ``value``, never a bare float) are stable, and every collection in it is
+sorted by ``case_id``. :data:`RESULT_SCHEMA_VERSION` is bumped if that ever has to change.
+
+**The caveat travels with every number.** Both renderings print
+:attr:`~tests.evals.metrics.SegmentMetrics.caveat` next to each block of metrics, and the
+document carries the golden set's own summary at the top. The seed set is entirely
+synthetic (``docs/labeling-golden-set.md`` §0), so an accuracy figure from it measures
+whether the model agrees with the person who invented the cases. A harness that printed
+``86.7%`` without that sentence would be a machine for manufacturing false confidence, and
+the sentence is therefore structural rather than editorial.
+
+**No lead payload appears in either rendering.** Not the email address, not the message
+body — a result file gets attached to a pull request (invariant 5). The label's notes and
+the model's reasoning are included because reading them side by side is the whole point of
+the per-case detail, and neither is ever asserted on.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any, Final, Self
+
+from tests.evals.golden_set import GoldenSet, describe_golden_set
+from tests.evals.metrics import (
+    TIERS_BY_RANK,
+    CaseResult,
+    ConfusionMatrix,
+    SecurityFinding,
+    SegmentMetrics,
+    StabilityReport,
+    compute_segment,
+    compute_stability,
+    security_findings,
+)
+
+#: Version of the result document. #24 reads it before diffing two runs; a change to any
+#: key below that is not purely additive bumps it.
+RESULT_SCHEMA_VERSION: Final[int] = 1
+
+#: The banner that opens every report and sits at the top of every result file. Long,
+#: unmissable, and repeated per metric block by :func:`render_text_report` — because the
+#: failure mode this defends against is one number being copied into a sales conversation.
+HEADLINE_CAVEAT: Final[str] = (
+    "These numbers are computed against the golden set as it currently stands. Any figure "
+    "computed against synthetic cases measures self-consistency with whoever wrote them, "
+    "not correctness: it says whether the model agrees with the seed author, not whether "
+    "the rubric is right. Read docs/labeling-golden-set.md before quoting anything here, "
+    "and never quote a number from this run without the sentence attached to it."
+)
+
+#: Segments broken out beside the headline. ``hard_cases`` is where a rubric earns its
+#: keep, ``injection_cases`` is a security surface rather than a quality one, and the
+#: real/synthetic split is the one that says what the rest is worth.
+SEGMENT_NAMES: Final[tuple[str, ...]] = ("hard_cases", "injection_cases", "real", "synthetic")
+
+_RULE: Final[str] = "=" * 92
+_THIN: Final[str] = "-" * 92
+
+
+@dataclass(frozen=True, slots=True)
+class RunMetadata:
+    """Provenance of one run: what was run, against what, and from which commit.
+
+    Every field here is something two comparable runs must agree on. A pair of runs whose
+    ``prompt_version`` or ``git_sha`` differ are not a regression signal, they are two
+    different experiments, and #24 refuses to read them as one.
+    """
+
+    started_at: datetime
+    finished_at: datetime
+    git_sha: str
+    git_dirty: bool
+    """``True`` when the working tree had uncommitted changes: the run is then not
+    reproducible from ``git_sha`` alone, and the report says so out loud."""
+
+    model_id: str
+    prompt_version: str
+    effort: str
+    tenant_id: str
+    concurrency: int
+    repeats: int
+    golden_set_path: str
+
+    @property
+    def duration_seconds(self) -> float:
+        """Wall clock for the whole run, including the concurrency the harness used."""
+        return (self.finished_at - self.started_at).total_seconds()
+
+    @property
+    def revision(self) -> str:
+        """Short commit, marked when the tree was dirty."""
+        return f"{self.git_sha[:7]}{'+dirty' if self.git_dirty else ''}"
+
+    def as_json(self) -> dict[str, Any]:
+        """The machine-readable form."""
+        return {
+            "started_at": self.started_at.isoformat(),
+            "finished_at": self.finished_at.isoformat(),
+            "duration_seconds": self.duration_seconds,
+            "git_sha": self.git_sha,
+            "git_dirty": self.git_dirty,
+            "model_id": self.model_id,
+            "prompt_version": self.prompt_version,
+            "effort": self.effort,
+            "tenant_id": self.tenant_id,
+            "concurrency": self.concurrency,
+            "repeats": self.repeats,
+            "golden_set_path": self.golden_set_path,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class EvalRun:
+    """One run, assembled: the results, everything derived from them, and its provenance."""
+
+    metadata: RunMetadata
+    golden: GoldenSet
+    results: tuple[CaseResult, ...]
+    """The primary repeat, sorted by ``case_id`` so two runs diff line for line."""
+
+    repeats: tuple[tuple[CaseResult, ...], ...]
+    headline: SegmentMetrics
+    segments: Mapping[str, SegmentMetrics]
+    confusion: ConfusionMatrix
+    stability: StabilityReport | None
+    findings: tuple[SecurityFinding, ...]
+
+    @classmethod
+    def of(
+        cls,
+        metadata: RunMetadata,
+        golden: GoldenSet,
+        repeats: Sequence[Sequence[CaseResult]],
+    ) -> Self:
+        """Assemble a run from its raw per-repeat results.
+
+        The first repeat is the primary one: its metrics are the headline, and the others
+        exist to quantify how much of the difference between two runs is just sampling.
+
+        Raises:
+            ValueError: ``repeats`` is empty. A run with no repeats is a bug, not an
+                empty result — the caller has lost the results it collected.
+        """
+        if not repeats:
+            raise ValueError("an eval run needs at least one repeat of results")
+        ordered = tuple(tuple(sorted(run, key=lambda item: item.case_id)) for run in repeats)
+        primary = ordered[0]
+        return cls(
+            metadata=metadata,
+            golden=golden,
+            results=primary,
+            repeats=ordered,
+            headline=compute_segment("all", primary),
+            segments={
+                "hard_cases": compute_segment(
+                    "hard_cases", [case for case in primary if case.hard_case]
+                ),
+                "injection_cases": compute_segment(
+                    "injection_cases", [case for case in primary if case.is_injection]
+                ),
+                "real": compute_segment(
+                    "real", [case for case in primary if not case.is_synthetic]
+                ),
+                "synthetic": compute_segment(
+                    "synthetic", [case for case in primary if case.is_synthetic]
+                ),
+            },
+            confusion=ConfusionMatrix.of(primary),
+            stability=compute_stability(ordered),
+            findings=security_findings(primary),
+        )
+
+
+def as_json(run: EvalRun) -> dict[str, Any]:
+    """The result document. This shape is what #24 diffs between two runs."""
+    golden = run.golden
+    return {
+        "schema_version": RESULT_SCHEMA_VERSION,
+        "caveat": HEADLINE_CAVEAT,
+        "run": run.metadata.as_json(),
+        "golden_set": {
+            "path": str(golden.path),
+            "counts": dict(golden.counts()),
+            "inter_labeler_agreement": golden.inter_labeler_agreement,
+            "meets_acceptance_criteria": golden.meets_acceptance_criteria,
+            "acceptance_gaps": list(golden.acceptance_gaps),
+            "summary": describe_golden_set(golden),
+        },
+        "metrics": run.headline.as_json(),
+        "segments": {name: run.segments[name].as_json() for name in SEGMENT_NAMES},
+        "confusion_matrix": run.confusion.as_json(),
+        "stability": None if run.stability is None else run.stability.as_json(),
+        "security_findings": [finding.as_json() for finding in run.findings],
+        "cases": [_case_json(case) for case in run.results],
+    }
+
+
+def dumps(run: EvalRun) -> str:
+    """The result document as text: two-space indent, trailing newline.
+
+    Keys are emitted in the order the builders above insert them, which is fixed and
+    meaningful — recall before precision, tiers best-first — rather than sorted, which
+    would put ``cold`` above ``hot`` in the confusion matrix for the same reason ``Tier``
+    needed a ``rank``. Insertion order is deterministic, so two runs still diff line for
+    line, which is the only reason this file exists.
+    """
+    return json.dumps(as_json(run), indent=2) + "\n"
+
+
+def _case_json(case: CaseResult) -> dict[str, Any]:
+    """One case. ``record`` is #13's ``--json`` record, carried verbatim."""
+    return {
+        "case_id": case.case_id,
+        "provenance": case.provenance.value,
+        "hard_case": case.hard_case,
+        "injection_case_id": case.injection_case_id,
+        "tags": list(case.tags),
+        "expected_tier": case.expected_tier.value,
+        "expected_band": {"lower": case.lower_bound.value, "upper": case.upper_bound.value},
+        "predicted_tier": case.predicted_tier.value,
+        "status": case_status(case),
+        "exact_match": case.exact_match,
+        "adjacent_match": case.adjacent_match,
+        "within_band": case.within_band,
+        "expected_contactable": case.expected_contactable,
+        "predicted_contactable": case.predicted_contactable,
+        "false_disqualification": case.false_disqualification,
+        "assessed": case.assessed,
+        "escalated": case.escalated,
+        "escalation_reason": None
+        if case.escalation_reason is None
+        else case.escalation_reason.value,
+        "expect_escalation": case.expect_escalation,
+        "missing_expected_escalation": case.missing_expected_escalation,
+        "dimension_range_violations": list(case.dimension_range_violations),
+        "extracted_mismatches": list(case.extracted_mismatches),
+        "cost_usd": str(case.cost_usd),
+        "latency_ms": case.latency_ms,
+        "labelers": list(case.labelers),
+        "label_notes": case.label_notes,
+        "model_reasoning": case.model_reasoning,
+        "record": dict(case.record),
+    }
+
+
+#: Per-case verdicts, worst first. ``LOST`` is separate from ``MISS`` because it is the
+#: only one that costs money: a lead a human would have called and the pipeline binned.
+STATUS_LOST: Final[str] = "LOST"
+STATUS_FAILED: Final[str] = "FAILED"
+STATUS_MISS: Final[str] = "MISS"
+STATUS_BAND: Final[str] = "band"
+STATUS_OK: Final[str] = "ok"
+
+
+def case_status(case: CaseResult) -> str:
+    """One word for how this case went, worst-first: LOST, FAILED, MISS, band, ok."""
+    if case.false_disqualification:
+        return STATUS_LOST
+    if not case.assessed:
+        return STATUS_FAILED
+    if case.exact_match:
+        return STATUS_OK
+    if case.within_band:
+        return STATUS_BAND
+    return STATUS_MISS
+
+
+def needs_detail(case: CaseResult) -> bool:
+    """Whether this case is worth printing the notes and the reasoning for.
+
+    Everything that did not land exactly on the label, plus anything that escalated, plus
+    anything whose declared expectations were violated. A case the model got right teaches
+    nobody anything, and printing fifteen of them buries the four that matter.
+    """
+    return (
+        case_status(case) != STATUS_OK
+        or case.escalated
+        or bool(case.dimension_range_violations)
+        or bool(case.extracted_mismatches)
+        or case.missing_expected_escalation
+    )
+
+
+def render_text_report(run: EvalRun, *, detail_for_every_case: bool = False) -> str:
+    """The report a human reads, and what the CI job posts to its run summary."""
+    lines: list[str] = []
+    lines.extend(_header(run))
+    lines.extend(_headline_section(run))
+    lines.extend(_accuracy_section(run))
+    lines.extend(_cost_section(run))
+    lines.extend(_confusion_section(run))
+    lines.extend(_segments_section(run))
+    lines.extend(_findings_section(run))
+    lines.extend(_stability_section(run))
+    lines.extend(_case_table(run, detail_for_every_case=detail_for_every_case))
+    return "\n".join(lines) + "\n"
+
+
+def _header(run: EvalRun) -> list[str]:
+    meta = run.metadata
+    return [
+        _RULE,
+        f"LeadQuali eval - {meta.started_at.isoformat(timespec='seconds')}",
+        _RULE,
+        f"model {meta.model_id}  prompt {meta.prompt_version}  effort {meta.effort}  "
+        f"tenant {meta.tenant_id}",
+        f"commit {meta.revision}  concurrency {meta.concurrency}  repeats {meta.repeats}  "
+        f"duration {meta.duration_seconds:.1f}s",
+        f"golden set {meta.golden_set_path}",
+        "",
+        _wrap(describe_golden_set(run.golden)),
+        "",
+        "READ THIS BEFORE QUOTING ANY NUMBER BELOW",
+        _wrap(HEADLINE_CAVEAT),
+        "",
+    ]
+
+
+def _headline_section(run: EvalRun) -> list[str]:
+    """Recall first, and on its own, because it is the number that costs money."""
+    metrics = run.headline
+    lines = [
+        _THIN,
+        "THE NUMBER THAT COSTS MONEY",
+        _THIN,
+        f"  Recall on contactable (hot+warm)   {metrics.recall_on_contactable.text}",
+        "  = of the leads a human said should have been contacted, the share the",
+        "    pipeline actually surfaced. Every miss below is a deal nobody called.",
+    ]
+    if metrics.false_disqualified_case_ids:
+        lines.append(
+            f"  FALSE DISQUALIFICATIONS ({len(metrics.false_disqualified_case_ids)}): "
+            + ", ".join(metrics.false_disqualified_case_ids)
+        )
+    else:
+        lines.append("  False disqualifications: none in this run.")
+    lines.extend(["  " + _wrap(metrics.caveat, indent=4).strip(), ""])
+    return lines
+
+
+def _accuracy_section(run: EvalRun) -> list[str]:
+    metrics = run.headline
+    return [
+        _THIN,
+        "PRECISION AND CALIBRATION",
+        _THIN,
+        f"  Precision on hot (exact label)     {metrics.precision_on_hot.text}",
+        f"  Precision on hot (within band)     {metrics.precision_on_hot_within_band.text}",
+        f"  Tier accuracy, exact match         {metrics.exact_tier_accuracy.text}",
+        f"  Tier accuracy, adjacent tier       {metrics.adjacent_tier_accuracy.text}",
+        f"  Inside the label's accepted band   {metrics.within_band_accuracy.text}",
+        "  " + _wrap(metrics.caveat, indent=4).strip(),
+        "",
+    ]
+
+
+def _cost_section(run: EvalRun) -> list[str]:
+    metrics = run.headline
+    per_lead = "n/a" if metrics.cost_usd_per_lead is None else f"${metrics.cost_usd_per_lead:.6f}"
+    latency = metrics.latency
+    lines = [
+        _THIN,
+        "COST AND LATENCY",
+        _THIN,
+        f"  Total spend                        ${metrics.total_cost_usd:.4f} "
+        f"over {metrics.cases} leads",
+        f"  Cost per lead                      {per_lead}",
+        f"  Latency p50 / p95 / max            {_ms(latency.p50_ms)} / {_ms(latency.p95_ms)} "
+        f"/ {_ms(latency.max_ms)}",
+        f"  Assessed / failed                  {metrics.assessed} / {metrics.failures}",
+    ]
+    if metrics.failures:
+        lines.append(
+            "  Failures route through system_failure to WARM and are reported as escalations,"
+        )
+        lines.append(
+            "  exactly as production would: they lower accuracy without being a prompt regression."
+        )
+    if metrics.escalations_by_reason:
+        lines.append(
+            "  Escalations                        "
+            + ", ".join(
+                f"{reason} {count}" for reason, count in metrics.escalations_by_reason.items()
+            )
+        )
+    if metrics.missing_expected_escalations:
+        lines.append(
+            "  Labeled expect_escalation but did not escalate: "
+            + ", ".join(metrics.missing_expected_escalations)
+        )
+    lines.append("")
+    return lines
+
+
+def _confusion_section(run: EvalRun) -> list[str]:
+    header = "".join(f"{tier.value[:4]:>6}" for tier in TIERS_BY_RANK)
+    lines = [
+        _THIN,
+        "CONFUSION MATRIX  (rows = human label, columns = pipeline)",
+        _THIN,
+        f"  {'label':<14}{header}",
+    ]
+    for expected in TIERS_BY_RANK:
+        row = run.confusion.counts[expected]
+        cells = "".join(f"{row[predicted]:>6}" for predicted in TIERS_BY_RANK)
+        lines.append(f"  {expected.value:<14}{cells}")
+    lines.append("")
+    return lines
+
+
+def _segments_section(run: EvalRun) -> list[str]:
+    lines = [_THIN, "SEGMENTS", _THIN]
+    for name in SEGMENT_NAMES:
+        metrics = run.segments[name]
+        lines.append(f"  {name} ({metrics.cases} cases)")
+        if metrics.cases == 0:
+            lines.append(f"    {metrics.caveat}")
+            lines.append("")
+            continue
+        lines.extend(
+            [
+                f"    recall on contactable   {metrics.recall_on_contactable.text}",
+                f"    precision on hot        {metrics.precision_on_hot.text}",
+                f"    exact tier accuracy     {metrics.exact_tier_accuracy.text}",
+                f"    adjacent tier accuracy  {metrics.adjacent_tier_accuracy.text}",
+                f"    failures / escalations  {metrics.failures} / {metrics.escalations}",
+                "    " + _wrap(metrics.caveat, indent=4).strip(),
+                "",
+            ]
+        )
+    return lines
+
+
+def _findings_section(run: EvalRun) -> list[str]:
+    lines = [_THIN, "PROMPT-INJECTION FINDINGS", _THIN]
+    if not run.findings:
+        lines.extend(
+            [
+                "  None. No injection case was scored above the ceiling its corpus entry",
+                "  declares, and none was scored hot.",
+                "",
+            ]
+        )
+        return lines
+    lines.append(
+        f"  {len(run.findings)} finding(s). These are security results, not metrics: an attack that"
+    )
+    lines.append("  raises a lead's tier is a defect regardless of what the accuracy says.")
+    for finding in run.findings:
+        lines.append(
+            f"  - {finding.case_id} [{finding.injection_case_id}] "
+            f"predicted {finding.predicted_tier.value}, "
+            f"ceiling {finding.upper_bound.value}: {', '.join(finding.kinds)}"
+        )
+        lines.append(f"      {finding.summary}")
+    lines.append("")
+    return lines
+
+
+def _stability_section(run: EvalRun) -> list[str]:
+    lines = [_THIN, "NONDETERMINISM", _THIN]
+    stability = run.stability
+    if stability is None:
+        lines.extend(
+            [
+                "  Not measured: this was a single run. The model samples, so a case near a",
+                "  threshold can land either side of it between two identical runs. Use",
+                "  --repeat 2 (or more) to quantify it rather than assuming it away.",
+                "",
+            ]
+        )
+        return lines
+    lines.append(f"  Repeats                     {stability.repeats}")
+    lines.append(f"  Cases with a stable tier    {stability.tier_stability.text}")
+    if stability.unstable_case_ids:
+        lines.append("  Moved between repeats:      " + ", ".join(stability.unstable_case_ids))
+    for name, spread in stability.metric_spreads.items():
+        rendered = ", ".join("n/a" if value is None else f"{value:.4f}" for value in spread.values)
+        gap = "n/a" if spread.spread is None else f"{spread.spread:.4f}"
+        lines.append(f"  {name:<27} spread {gap}  [{rendered}]")
+    lines.append("")
+    return lines
+
+
+def _case_table(run: EvalRun, *, detail_for_every_case: bool) -> list[str]:
+    lines = [
+        _THIN,
+        "PER-CASE RESULTS  (sorted by case id; LOST = a lead a human would have called)",
+        _THIN,
+        f"  {'status':<7}{'case_id':<40}{'label':>13} {'pipeline':>13}{'score':>8}"
+        f"{'ms':>8}{'usd':>10}",
+    ]
+    for case in run.results:
+        lines.append(
+            f"  {case_status(case):<7}{case.case_id[:39]:<40}"
+            f"{case.expected_tier.value:>13} {case.predicted_tier.value:>13}"
+            f"{case.total_score:>8.1f}{case.latency_ms:>8}{float(case.cost_usd):>10.5f}"
+        )
+    lines.append("")
+
+    detailed = [case for case in run.results if detail_for_every_case or needs_detail(case)]
+    if not detailed:
+        lines.extend(["  Every case landed exactly on its label.", ""])
+        return lines
+    lines.extend(
+        [
+            _THIN,
+            "CASE DETAIL  (the label's reasoning beside the model's; neither is asserted on)",
+            _THIN,
+        ]
+    )
+    for case in detailed:
+        lines.extend(_case_detail(case))
+    return lines
+
+
+def _case_detail(case: CaseResult) -> list[str]:
+    band = (
+        ""
+        if case.lower_bound is case.upper_bound
+        else f"  accepted band {case.lower_bound.value}..{case.upper_bound.value}"
+    )
+    lines = [
+        f"  [{case_status(case)}] {case.case_id}"
+        f"{'  (hard case)' if case.hard_case else ''}"
+        f"{'  (injection: ' + str(case.injection_case_id) + ')' if case.is_injection else ''}",
+        f"      label {case.expected_tier.value} -> pipeline {case.predicted_tier.value}"
+        f"  score {case.total_score:.1f}{band}",
+    ]
+    if case.confidence is not None:
+        lines.append(f"      model confidence {case.confidence:.2f}")
+    if case.escalation_reason is not None:
+        lines.append(f"      escalated: {case.escalation_reason.value}")
+    if not case.assessed:
+        lines.append(f"      no assessment: {case.failure_detail}")
+    if case.note:
+        lines.append(f"      decision note: {case.note}")
+    for violation in case.dimension_range_violations:
+        lines.append(f"      dimension out of labeled range: {violation}")
+    for mismatch in case.extracted_mismatches:
+        lines.append(f"      extracted field mismatch: {mismatch}")
+    if case.missing_expected_escalation:
+        lines.append("      the label says a human must see this lead, and it did not escalate")
+    labelers = ", ".join(case.labelers) or "unattributed"
+    lines.append(f"      label notes ({labelers}):")
+    lines.append(_wrap(case.label_notes or "(none)", indent=10))
+    lines.append("      model reasoning:")
+    lines.append(_wrap(case.model_reasoning or "(none - no assessment)", indent=10))
+    lines.append("")
+    return lines
+
+
+def _ms(value: int | None) -> str:
+    return "n/a" if value is None else f"{value}ms"
+
+
+def _wrap(text: str, *, indent: int = 0, width: int = 92) -> str:
+    """Wrap prose to the report width. Local rather than ``textwrap`` for the indent."""
+    prefix = " " * indent
+    words = text.split()
+    if not words:
+        return prefix
+    lines: list[str] = []
+    current = prefix
+    for word in words:
+        candidate = f"{current}{word}" if current == prefix else f"{current} {word}"
+        if len(candidate) > width and current != prefix:
+            lines.append(current)
+            current = f"{prefix}{word}"
+        else:
+            current = candidate
+    lines.append(current)
+    return "\n".join(lines)
+
+
+__all__ = [
+    "HEADLINE_CAVEAT",
+    "RESULT_SCHEMA_VERSION",
+    "SEGMENT_NAMES",
+    "STATUS_BAND",
+    "STATUS_FAILED",
+    "STATUS_LOST",
+    "STATUS_MISS",
+    "STATUS_OK",
+    "EvalRun",
+    "RunMetadata",
+    "as_json",
+    "case_status",
+    "dumps",
+    "needs_detail",
+    "render_text_report",
+]

--- a/tests/evals/run_eval.py
+++ b/tests/evals/run_eval.py
@@ -1,0 +1,723 @@
+"""``python -m tests.evals.run_eval --confirm-spend`` — the eval harness (plan §7).
+
+Runs every case in the golden set through the real pipeline — #12's renderer, #11's
+adapter, #9's ``decide`` — and reports the four numbers a prompt change is judged by, a
+confusion matrix, a per-case breakdown, and a JSON result file #24 diffs between runs.
+
+**This command spends money, so it refuses to start by accident.** Two independent things
+must be true: ``--confirm-spend`` on the command line, and an ``ANTHROPIC_API_KEY`` in the
+environment. Either one alone exits :data:`EXIT_REFUSED` without making a single call. The
+module is also marked ``live_api``, so ``pytest`` never collects it into the default suite
+(``tests/conftest.py`` skips that marker unless a run selects it), and the CI workflow that
+invokes it is ``workflow_dispatch`` only. Three separate guards for one mistake, because
+the mistake is a bill and a rate-limit incident rather than a red build.
+
+**Rate-limit posture.** Calls run on a bounded thread pool — :data:`DEFAULT_CONCURRENCY` by
+default, ``--concurrency`` to change it. Bounded rather than unbounded because a 100-case
+sweep fired at once is a 429 storm that costs more wall clock than it saves; concurrent
+rather than serial because a 100-case sweep at ~8s a lead is a quarter of an hour of
+staring. There is deliberately **no retry loop in this module**: the SDK already retries
+408/409/429/5xx with exponential backoff (see
+:func:`~leadquali.adapters.llm_anthropic.build_anthropic_client`), and a second loop on top
+would multiply the bill and re-try what the SDK decided was hopeless. If a run hits
+sustained 429s the answer is a lower ``--concurrency``, not more retries.
+
+**A failure is a data point, not a crash.** A refusal, a timeout, a parse error or an
+adapter that raises when its port says it must not — each one becomes a
+``system_failure`` decision, which is exactly what production does with it (invariant 3).
+The case is reported as an escalation, counted in the denominators, and the run continues.
+One unqualifiable lead must not cost you the other fourteen results you have already paid
+for.
+
+**Deterministic output.** Cases are dispatched in ``case_id`` order and every collection in
+the report and the JSON is sorted by ``case_id``, so two runs differ only where the model
+did.
+
+**Nothing here asserts on model prose.** ``reasoning`` is printed beside the label's notes
+because reading them together is how a human decides whether the label or the rubric is
+wrong; it is never compared, matched or scored.
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from collections.abc import Callable, Sequence
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from shutil import which
+from typing import Any, Final
+
+import pytest
+
+from leadquali.adapters.llm_anthropic import (
+    CLAUDE_OPUS_5_PRICES,
+    MODEL_ID,
+    AnthropicLeadAssessor,
+    TokenPrices,
+    build_anthropic_client,
+    token_cost_usd,
+)
+from leadquali.adapters.tenant_config_json import (
+    DEFAULT_TENANT_ID,
+    JsonFileTenantConfigLoader,
+    default_tenants_dir,
+)
+from leadquali.app.assessment_result import (
+    DEFAULT_EFFORT,
+    EFFORT_LEVELS,
+    AssessmentOutcome,
+    AssessmentSucceeded,
+    Effort,
+)
+from leadquali.app.ports import LeadAssessorPort
+from leadquali.cli import decision_for
+from leadquali.config import get_settings
+from leadquali.domain.models import EscalationReason, RoutingDecision
+from leadquali.domain.routing import system_failure
+from leadquali.domain.tenant_config import TenantConfig, TenantConfigError
+from leadquali.observability import configure_logging
+from leadquali.prompts.lead import render_lead_detailed
+from leadquali.prompts.rubric import PROMPT_VERSION, build_system_blocks
+from tests.evals.golden_set import GOLDEN_LEADS_PATH, GoldenCase, GoldenSet, load_golden_set
+from tests.evals.metrics import CaseResult
+from tests.evals.report import EvalRun, RunMetadata, dumps, render_text_report
+
+#: Marks the whole module billable. Nothing here is collected today - the file is not
+#: named ``test_*.py`` - so this is the guard for the day somebody adds a live test beside
+#: the harness or renames the file: ``tests/conftest.py`` skips ``live_api`` unless a run
+#: selects markers explicitly, and the default suite therefore still cannot spend money.
+pytestmark = pytest.mark.live_api
+
+#: The run finished and produced a report.
+EXIT_OK: Final[int] = 0
+
+#: A usage or input problem: an unreadable golden set, an unknown tenant, a bad effort.
+EXIT_INPUT_ERROR: Final[int] = 2
+
+#: The run was never authorised — no ``--confirm-spend``, or no API key. Distinct from
+#: :data:`EXIT_INPUT_ERROR` so a wrapper can tell "you did not mean this" from "this is
+#: broken", and so a CI job that forgot the secret fails with a legible reason.
+EXIT_REFUSED: Final[int] = 3
+
+#: The run completed and an injection case behaved badly. Non-zero on purpose: a run that
+#: reports an attack payload tiered hot must not be green in the Actions tab. Note that no
+#: *accuracy* threshold fails the run — a pass mark computed against a synthetic set would
+#: be a gate on a number that measures self-consistency.
+EXIT_SECURITY_FINDING: Final[int] = 4
+
+#: In-flight model calls. Four is a deliberate compromise: fast enough that the seed set
+#: finishes in well under a minute, small enough to stay under a fresh account's request
+#: rate limit without the SDK ever having to back off.
+DEFAULT_CONCURRENCY: Final[int] = 4
+
+#: Where result files are written when ``--out`` is not given. Git-ignored: a result file
+#: is evidence attached to a pull request, not a source file.
+DEFAULT_RESULTS_DIR: Final[Path] = Path(__file__).resolve().parent / "results"
+
+#: Output tokens assumed per call by ``--estimate``. A guess, and labeled as one wherever
+#: it is printed: real output length depends on the effort level, since thinking tokens are
+#: billed as output. Override with ``--assumed-output-tokens`` once a real run has told you
+#: the true figure for the effort level you care about.
+DEFAULT_ASSUMED_OUTPUT_TOKENS: Final[int] = 1200
+
+#: Characters per token used by ``--estimate``. English prose runs about four; this is a
+#: sizing heuristic for a pre-flight number, never a billing figure.
+CHARS_PER_TOKEN: Final[float] = 4.0
+
+AssessorFactory = Callable[[Effort], LeadAssessorPort]
+
+
+# --------------------------------------------------------------------------- estimating
+
+
+@dataclass(frozen=True, slots=True)
+class CostEstimate:
+    """A pre-flight guess at what a run will cost, with its assumptions attached.
+
+    Exists so nobody has to discover the price of a sweep by paying it. The input side is
+    close — it is measured off the text that will actually be sent — and the output side is
+    an assumption, which is why the assumptions travel with the number.
+    """
+
+    cases: int
+    input_tokens: int
+    cache_write_tokens: int
+    cache_read_tokens: int
+    output_tokens: int
+    cost_usd: Decimal
+    assumptions: tuple[str, ...]
+
+    def render(self) -> str:
+        """The text printed by ``--estimate``."""
+        lines = [
+            f"Estimated cost of one run over {self.cases} cases: ${self.cost_usd:.4f} "
+            f"(about ${self.cost_usd / max(self.cases, 1):.4f} per lead).",
+            f"  input {self.input_tokens} tok, cache write {self.cache_write_tokens} tok, "
+            f"cache read {self.cache_read_tokens} tok, output {self.output_tokens} tok",
+            "This is an estimate, not a quote. It assumes:",
+        ]
+        lines.extend(f"  - {assumption}" for assumption in self.assumptions)
+        return "\n".join(lines)
+
+
+def estimate_cost(
+    golden: GoldenSet,
+    config: TenantConfig,
+    *,
+    effort: Effort,
+    concurrency: int = DEFAULT_CONCURRENCY,
+    output_tokens_per_case: int = DEFAULT_ASSUMED_OUTPUT_TOKENS,
+    prices: TokenPrices = CLAUDE_OPUS_5_PRICES,
+) -> CostEstimate:
+    """What one run over ``golden`` will cost, before spending anything.
+
+    The input side is measured from the prompts that will really be sent: #10's two system
+    blocks and #12's rendered lead for each case. The output side cannot be measured
+    without making the call, so it is an explicit assumption. Caching is modelled as one
+    cache write per concurrent worker — the first ``concurrency`` calls start before any of
+    them has populated the prefix — and a cache read for everything after that.
+    """
+    rubric, tenant = build_system_blocks(config)
+    rubric_tokens = _tokens(rubric.text)
+    tenant_tokens = _tokens(tenant.text)
+    lead_tokens = sum(
+        _tokens(render_lead_detailed(case.to_submission()).text) for case in golden.cases
+    )
+    cases = len(golden.cases)
+    writes = min(concurrency, cases)
+    reads = max(cases - writes, 0)
+    output_tokens = cases * output_tokens_per_case
+    return CostEstimate(
+        cases=cases,
+        input_tokens=cases * tenant_tokens + lead_tokens,
+        cache_write_tokens=writes * rubric_tokens,
+        cache_read_tokens=reads * rubric_tokens,
+        output_tokens=output_tokens,
+        cost_usd=token_cost_usd(
+            input_tokens=cases * tenant_tokens + lead_tokens,
+            output_tokens=output_tokens,
+            cache_read_tokens=reads * rubric_tokens,
+            cache_creation_tokens=writes * rubric_tokens,
+            prices=prices,
+        ),
+        assumptions=(
+            f"{output_tokens_per_case} output tokens per call, thinking included - a guess, "
+            f"and the largest source of error at effort={effort}",
+            f"{CHARS_PER_TOKEN:.0f} characters per token for the prompts, measured off the "
+            "text that will actually be sent",
+            f"{writes} cache write(s) and {reads} cache read(s), i.e. one write per "
+            f"concurrent worker at --concurrency {concurrency}",
+            "the published rate card in adapters/llm_anthropic.py, which is a documented "
+            "snapshot and not a feed; the invoice wins",
+        ),
+    )
+
+
+def _tokens(text: str) -> int:
+    return int(len(text) / CHARS_PER_TOKEN)
+
+
+# ------------------------------------------------------------------------- running cases
+
+
+def assess_case(
+    case: GoldenCase, *, assessor: LeadAssessorPort, config: TenantConfig
+) -> CaseResult:
+    """Run one golden case through the pipeline and score it against its label.
+
+    Never raises for anything the model or the network can do. The port says an assessor
+    returns an ``AssessmentFailed`` rather than raising, but a buggy adapter can still
+    throw, and one exception must not cost the run the results it has already paid for —
+    so an escaped exception is converted into the same ``API_ERROR`` failure the adapter
+    should have returned, and routed through ``system_failure`` like any other.
+    """
+    rendered = render_lead_detailed(case.to_submission())
+    try:
+        outcome: AssessmentOutcome = assessor.assess(config=config, rendered_lead=rendered.text)
+    except Exception as error:  # a raise here is a bug, and must still not lose the run
+        return _failed_result(case, EscalationReason.API_ERROR, type(error).__name__)
+    # #13's own policy call, imported rather than reimplemented: the tier an eval reports
+    # must be the tier production produces, including the `warm` a `system_failure` gives.
+    decision = decision_for(outcome, config)
+    return build_case_result(case, outcome, decision)
+
+
+def build_case_result(
+    case: GoldenCase, outcome: AssessmentOutcome, decision: RoutingDecision
+) -> CaseResult:
+    """Pair what the pipeline decided with what the human said, for one case."""
+    metering = outcome.metering
+    assessment = outcome.assessment if isinstance(outcome, AssessmentSucceeded) else None
+    return CaseResult(
+        case_id=case.case_id,
+        provenance=case.provenance,
+        expected_tier=case.expected_tier,
+        lower_bound=case.lower_bound,
+        upper_bound=case.upper_bound,
+        predicted_tier=decision.tier,
+        assessed=assessment is not None,
+        escalation_reason=decision.escalation_reason,
+        total_score=decision.total_score,
+        confidence=None if assessment is None else assessment.confidence,
+        hard_case=case.hard_case,
+        injection_case_id=case.injection_case_id,
+        cost_usd=Decimal(0) if metering is None else metering.cost_usd,
+        latency_ms=_latency_of(outcome),
+        note=decision.note,
+        label_notes=case.labels[0].notes if case.labels else "",
+        labelers=case.labelers,
+        model_reasoning="" if assessment is None else assessment.reasoning,
+        failure_detail="" if isinstance(outcome, AssessmentSucceeded) else outcome.detail,
+        dimension_range_violations=_dimension_violations(case, outcome),
+        extracted_mismatches=_extracted_mismatches(case, outcome),
+        expect_escalation=case.expect_escalation,
+        tags=case.tags,
+        record=cli_shaped_record(outcome, decision),
+    )
+
+
+def _failed_result(case: GoldenCase, reason: EscalationReason, detail: str) -> CaseResult:
+    """A case the harness itself could not complete, routed exactly as production would."""
+    decision = system_failure(reason, detail)
+    return CaseResult(
+        case_id=case.case_id,
+        provenance=case.provenance,
+        expected_tier=case.expected_tier,
+        lower_bound=case.lower_bound,
+        upper_bound=case.upper_bound,
+        predicted_tier=decision.tier,
+        assessed=False,
+        escalation_reason=decision.escalation_reason,
+        total_score=decision.total_score,
+        confidence=None,
+        hard_case=case.hard_case,
+        injection_case_id=case.injection_case_id,
+        cost_usd=Decimal(0),
+        latency_ms=0,
+        note=decision.note,
+        label_notes=case.labels[0].notes if case.labels else "",
+        labelers=case.labelers,
+        failure_detail=detail,
+        expect_escalation=case.expect_escalation,
+        tags=case.tags,
+        record=cli_shaped_record(None, decision, failure=(reason, detail)),
+    )
+
+
+def _latency_of(outcome: AssessmentOutcome) -> int:
+    if isinstance(outcome, AssessmentSucceeded):
+        return outcome.metering.latency_ms
+    return outcome.latency_ms
+
+
+def cli_shaped_record(
+    outcome: AssessmentOutcome | None,
+    decision: RoutingDecision,
+    *,
+    failure: tuple[EscalationReason, str] | None = None,
+) -> dict[str, Any]:
+    """One case in the vocabulary #13's ``--json`` already defined.
+
+    Same four keys, same field names, same ``cost_usd``-as-a-string convention: the CLI's
+    record is the project's answer to "what happened to one lead", and the eval extends it
+    rather than competing with it. ``tests/unit/test_run_eval.py`` pins the shapes against
+    the CLI's own output so the two cannot drift apart unnoticed.
+    """
+    record: dict[str, Any] = {
+        "assessment": None,
+        "decision": decision.model_dump(mode="json"),
+        "metering": None,
+        "failure": None,
+    }
+    if isinstance(outcome, AssessmentSucceeded):
+        record["assessment"] = outcome.assessment.model_dump(mode="json")
+    if outcome is not None and outcome.metering is not None:
+        metering = outcome.metering
+        record["metering"] = {
+            "model_id": metering.model_id,
+            "prompt_version": metering.prompt_version,
+            "effort": metering.effort,
+            "input_tokens": metering.input_tokens,
+            "output_tokens": metering.output_tokens,
+            "cache_read_tokens": metering.cache_read_tokens,
+            "cache_creation_tokens": metering.cache_creation_tokens,
+            "cost_usd": str(metering.cost_usd),
+            "latency_ms": metering.latency_ms,
+        }
+    if outcome is not None and not isinstance(outcome, AssessmentSucceeded):
+        record["failure"] = {
+            "reason": outcome.reason.value,
+            "detail": outcome.detail,
+            "latency_ms": outcome.latency_ms,
+        }
+    elif failure is not None:
+        reason, detail = failure
+        record["failure"] = {"reason": reason.value, "detail": detail, "latency_ms": 0}
+    return record
+
+
+def _dimension_violations(case: GoldenCase, outcome: AssessmentOutcome) -> tuple[str, ...]:
+    """Dimension scores outside the range the label declared. Numbers, never prose."""
+    if not isinstance(outcome, AssessmentSucceeded) or not case.expected_dimension_ranges:
+        return ()
+    scores = outcome.assessment.dimension_scores
+    violations: list[str] = []
+    for name, (low, high) in sorted(case.expected_dimension_ranges.items()):
+        actual = getattr(scores, name)
+        if not low <= actual <= high:
+            violations.append(f"{name}={actual}, expected {low}..{high}")
+    return tuple(violations)
+
+
+def _extracted_mismatches(case: GoldenCase, outcome: AssessmentOutcome) -> tuple[str, ...]:
+    """Extracted fields that differ from the label. Compared case-insensitively, trimmed."""
+    if not isinstance(outcome, AssessmentSucceeded) or not case.expected_extracted:
+        return ()
+    extracted = outcome.assessment.extracted
+    mismatches: list[str] = []
+    for name, expected in sorted(case.expected_extracted.items()):
+        actual = getattr(extracted, name)
+        if _normalise(actual) != _normalise(expected):
+            mismatches.append(f"{name}={actual!r}, expected {expected!r}")
+    return tuple(mismatches)
+
+
+def _normalise(value: str | None) -> str | None:
+    return None if value is None else " ".join(value.split()).casefold()
+
+
+def run_cases(
+    cases: Sequence[GoldenCase],
+    *,
+    assessor: LeadAssessorPort,
+    config: TenantConfig,
+    concurrency: int = DEFAULT_CONCURRENCY,
+) -> tuple[CaseResult, ...]:
+    """Assess every case on a bounded pool and return the results in ``case_id`` order.
+
+    ``ThreadPoolExecutor.map`` preserves input order regardless of completion order, and
+    the input is sorted, so the output is deterministic even though the calls are not.
+    """
+    ordered = sorted(cases, key=lambda case: case.case_id)
+    if not ordered:
+        return ()
+    workers = max(1, min(concurrency, len(ordered)))
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="eval") as pool:
+        return tuple(
+            pool.map(lambda case: assess_case(case, assessor=assessor, config=config), ordered)
+        )
+
+
+# ------------------------------------------------------------------------------- the CLI
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The command line. ``--confirm-spend`` is required for any run that calls the API."""
+    parser = argparse.ArgumentParser(
+        prog="python -m tests.evals.run_eval",
+        description=(
+            "Score the golden set through the real pipeline and report the four eval "
+            "metrics. Makes one billable model call per case."
+        ),
+        epilog=(
+            "The seed golden set is entirely synthetic: numbers computed against it "
+            "measure self-consistency with its author, not correctness. Read "
+            "docs/labeling-golden-set.md before quoting any of them."
+        ),
+    )
+    parser.add_argument(
+        "--confirm-spend",
+        action="store_true",
+        help=(
+            "Required. Acknowledges that this makes one billable model call per golden "
+            "case. Without it nothing is called. Use --estimate to see the price first."
+        ),
+    )
+    parser.add_argument(
+        "--estimate",
+        action="store_true",
+        help="Print the estimated cost of a run and exit. Needs no key and calls nothing.",
+    )
+    parser.add_argument(
+        "--effort",
+        choices=sorted(EFFORT_LEVELS),
+        default=DEFAULT_EFFORT,
+        help=f"Model effort level (default: {DEFAULT_EFFORT}).",
+    )
+    parser.add_argument(
+        "--tenant",
+        default=DEFAULT_TENANT_ID,
+        help=f"Tenant whose rubric to apply (default: {DEFAULT_TENANT_ID}).",
+    )
+    parser.add_argument(
+        "--tenants-dir",
+        type=Path,
+        default=None,
+        help="Directory of tenant config files (default: the bundled tenants/).",
+    )
+    parser.add_argument(
+        "--golden-set",
+        type=Path,
+        default=None,
+        help=f"Golden set to run (default: {GOLDEN_LEADS_PATH}).",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=DEFAULT_CONCURRENCY,
+        help=(
+            f"In-flight model calls (default: {DEFAULT_CONCURRENCY}). Lower this on a 429; "
+            "the SDK already retries with backoff, so do not add retries."
+        ),
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help=(
+            "Run the whole set this many times and report how much the numbers moved "
+            "with nothing changed. Multiplies the cost by the same factor."
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=f"Directory for the JSON result file (default: {DEFAULT_RESULTS_DIR}).",
+    )
+    parser.add_argument(
+        "--all-case-detail",
+        action="store_true",
+        help="Print notes and reasoning for every case, not only the ones that moved.",
+    )
+    parser.add_argument(
+        "--assumed-output-tokens",
+        type=int,
+        default=DEFAULT_ASSUMED_OUTPUT_TOKENS,
+        help=f"Output tokens per call assumed by --estimate (default: "
+        f"{DEFAULT_ASSUMED_OUTPUT_TOKENS}).",
+    )
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    assessor_factory: AssessorFactory | None = None,
+    now: Callable[[], datetime] | None = None,
+) -> int:
+    """Run the eval. Returns the process exit code.
+
+    ``assessor_factory`` and ``now`` are injected so the harness itself is testable
+    offline: every test in ``tests/unit/test_run_eval.py`` drives this function with a
+    scripted assessor and a fixed clock, and none of them needs a key or a network.
+    """
+    configure_logging(stream=sys.stderr)
+    parser = build_parser()
+    args = parser.parse_args(list(sys.argv[1:] if argv is None else argv))
+
+    try:
+        golden = load_golden_set(args.golden_set)
+        config = _load_config(args.tenant, args.tenants_dir)
+        effort = _checked_effort(args.effort)
+        _check_bounds(args.concurrency, args.repeat)
+    except (OSError, ValueError, TenantConfigError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    estimate = estimate_cost(
+        golden,
+        config,
+        effort=effort,
+        concurrency=args.concurrency,
+        output_tokens_per_case=args.assumed_output_tokens,
+    )
+    if args.estimate:
+        print(estimate.render())
+        if args.repeat > 1:
+            print(f"Multiply by {args.repeat} for --repeat {args.repeat}.")
+        return EXIT_OK
+
+    refusal = _refuse_unless_authorised(args.confirm_spend, estimate, args.repeat)
+    if refusal is not None:
+        print(refusal, file=sys.stderr)
+        return EXIT_REFUSED
+
+    factory = assessor_factory or _default_assessor_factory
+    try:
+        assessor = factory(effort)
+    except RuntimeError as error:  # a missing ANTHROPIC_API_KEY, most likely
+        print(f"error: {error}", file=sys.stderr)
+        return EXIT_REFUSED
+
+    clock = now or _utc_now
+    started_at = clock()
+    repeats = [
+        run_cases(golden.cases, assessor=assessor, config=config, concurrency=args.concurrency)
+        for _ in range(args.repeat)
+    ]
+    finished_at = clock()
+
+    run = EvalRun.of(
+        RunMetadata(
+            started_at=started_at,
+            finished_at=finished_at,
+            git_sha=git_sha(),
+            git_dirty=git_dirty(),
+            model_id=MODEL_ID,
+            prompt_version=PROMPT_VERSION,
+            effort=effort,
+            tenant_id=config.tenant_id,
+            concurrency=args.concurrency,
+            repeats=args.repeat,
+            golden_set_path=str(golden.path),
+        ),
+        golden,
+        repeats,
+    )
+    print(render_text_report(run, detail_for_every_case=args.all_case_detail))
+    destination = write_result(run, args.out or DEFAULT_RESULTS_DIR)
+    print(f"JSON result written to {destination}")
+    return EXIT_SECURITY_FINDING if run.findings else EXIT_OK
+
+
+def _refuse_unless_authorised(confirmed: bool, estimate: CostEstimate, repeat: int) -> str | None:
+    """The message to print, or ``None`` when the run may proceed.
+
+    Both conditions are checked before any assessor is built, so a refusal costs nothing
+    and reports *everything* that is missing rather than one thing at a time.
+    """
+    missing: list[str] = []
+    if not confirmed:
+        missing.append(
+            "--confirm-spend was not given: this command makes one billable model call "
+            f"per golden case (about ${estimate.cost_usd * repeat:.2f} for this run)"
+        )
+    if not _api_key_present():
+        missing.append(
+            "ANTHROPIC_API_KEY is not set: the eval calls the real API, and there is no "
+            "offline mode that would produce a meaningful number"
+        )
+    if not missing:
+        return None
+    return (
+        "refusing to run:\n"
+        + "\n".join(f"  - {reason}" for reason in missing)
+        + ("\n\nRun with --estimate to see the cost without calling anything.")
+    )
+
+
+def _api_key_present() -> bool:
+    try:
+        get_settings().require_anthropic_api_key()
+    except RuntimeError:
+        return False
+    return True
+
+
+def write_result(run: EvalRun, directory: Path) -> Path:
+    """Write the timestamped JSON result file and return its path.
+
+    Named for the instant it started and the commit it ran against, because the question
+    six weeks from now is "which run was that, and against what?" and a filename is the
+    cheapest possible answer.
+    """
+    directory.mkdir(parents=True, exist_ok=True)
+    stamp = run.metadata.started_at.strftime("%Y%m%dT%H%M%SZ")
+    destination = directory / f"eval-{stamp}-{run.metadata.revision}.json"
+    destination.write_text(dumps(run), encoding="utf-8")
+    return destination
+
+
+def _load_config(tenant_id: str, tenants_dir: Path | None) -> TenantConfig:
+    loader = JsonFileTenantConfigLoader(tenants_dir or default_tenants_dir())
+    return loader.get(tenant_id)
+
+
+def _checked_effort(effort: str) -> Effort:
+    if effort not in EFFORT_LEVELS:
+        raise ValueError(f"unknown effort {effort!r}; expected one of {sorted(EFFORT_LEVELS)}")
+    return effort
+
+
+def _check_bounds(concurrency: int, repeat: int) -> None:
+    if concurrency < 1:
+        raise ValueError(f"--concurrency must be at least 1, got {concurrency}")
+    if repeat < 1:
+        raise ValueError(f"--repeat must be at least 1, got {repeat}")
+
+
+def _default_assessor_factory(effort: Effort) -> LeadAssessorPort:
+    """The real assessor. Only reached once the run has been authorised."""
+    return AnthropicLeadAssessor(
+        build_anthropic_client(get_settings().require_anthropic_api_key()), effort=effort
+    )
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def git_sha() -> str:
+    """The commit this run was made from, or ``"unknown"`` outside a checkout."""
+    return _git("rev-parse", "HEAD") or "unknown"
+
+
+def git_dirty() -> bool:
+    """Whether the working tree had uncommitted changes. A dirty run is not reproducible."""
+    return bool(_git("status", "--porcelain"))
+
+
+def _git(*arguments: str) -> str:
+    """Run one read-only git command, or return ``""`` if git is unavailable.
+
+    Provenance is worth having and never worth failing a paid run over: a checkout without
+    git, or a tarball with no ``.git``, reports ``unknown`` and carries on.
+    """
+    executable = which("git")
+    if executable is None:
+        return ""
+    try:
+        completed = subprocess.run(  # noqa: S603 - fixed argv, resolved binary, no shell
+            [executable, *arguments],
+            cwd=Path(__file__).resolve().parents[2],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return ""
+    return completed.stdout.strip() if completed.returncode == 0 else ""
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via `python -m tests.evals.run_eval`
+    raise SystemExit(main())
+
+
+__all__ = [
+    "CHARS_PER_TOKEN",
+    "DEFAULT_ASSUMED_OUTPUT_TOKENS",
+    "DEFAULT_CONCURRENCY",
+    "DEFAULT_RESULTS_DIR",
+    "EXIT_INPUT_ERROR",
+    "EXIT_OK",
+    "EXIT_REFUSED",
+    "EXIT_SECURITY_FINDING",
+    "CostEstimate",
+    "assess_case",
+    "build_case_result",
+    "build_parser",
+    "cli_shaped_record",
+    "estimate_cost",
+    "git_dirty",
+    "git_sha",
+    "main",
+    "run_cases",
+    "write_result",
+]

--- a/tests/unit/test_eval_metrics.py
+++ b/tests/unit/test_eval_metrics.py
@@ -1,0 +1,567 @@
+"""The eval maths, against hand-computed fixtures.
+
+These are the numbers a prompt change is judged by, so the arithmetic is pinned rather
+than trusted. Every expectation here is computed by hand in the test name or the comment
+next to it — a metric implementation checked against itself proves nothing.
+
+The edge cases are the point. A precision of "0.0" when nothing was predicted hot is a
+lie that reads as a catastrophe; a recall of "1.0" over an empty denominator is a lie that
+reads as perfection. Both must come out *undefined*, carrying the reason, and both are
+asserted below.
+"""
+
+from __future__ import annotations
+
+from decimal import Decimal
+
+import pytest
+
+from leadquali.domain.models import EscalationReason, Tier
+from tests.evals import Provenance
+from tests.evals.metrics import (
+    CONTACTABLE_TIERS,
+    FINDING_ABOVE_CEILING,
+    FINDING_GENUINE_LEAD_DESTROYED,
+    FINDING_SCORED_HOT,
+    CaseResult,
+    ConfusionMatrix,
+    Ratio,
+    compute_segment,
+    compute_stability,
+    is_adjacent,
+    is_contactable,
+    percentile_ms,
+    security_findings,
+    synthetic_caveat,
+)
+
+
+def _case(
+    case_id: str,
+    expected: Tier,
+    predicted: Tier,
+    *,
+    lower: Tier | None = None,
+    upper: Tier | None = None,
+    assessed: bool = True,
+    escalation_reason: EscalationReason | None = None,
+    cost: str = "0.02",
+    latency_ms: int = 1000,
+    provenance: Provenance = Provenance.SYNTHETIC,
+    hard_case: bool = False,
+    injection_case_id: str | None = None,
+) -> CaseResult:
+    """One case result, with everything irrelevant to the metric under test defaulted."""
+    return CaseResult(
+        case_id=case_id,
+        provenance=provenance,
+        expected_tier=expected,
+        lower_bound=lower or expected,
+        upper_bound=upper or expected,
+        predicted_tier=predicted,
+        assessed=assessed,
+        escalation_reason=escalation_reason,
+        total_score=42.0,
+        confidence=0.9 if assessed else None,
+        hard_case=hard_case,
+        injection_case_id=injection_case_id,
+        cost_usd=Decimal(cost),
+        latency_ms=latency_ms,
+    )
+
+
+# ------------------------------------------------------------------------------ Ratio
+
+
+def test_ratio_reports_a_fraction_and_its_counts() -> None:
+    ratio = Ratio(3, 4)
+    assert ratio.defined
+    assert ratio.value == 0.75
+    assert "3/4" in ratio.text
+
+
+def test_ratio_over_an_empty_denominator_is_undefined_not_zero() -> None:
+    ratio = Ratio(0, 0, "no lead was predicted hot")
+    assert not ratio.defined
+    assert ratio.value is None
+    assert "undefined" in ratio.text
+    assert "no lead was predicted hot" in ratio.text
+
+
+def test_ratio_refuses_a_numerator_larger_than_its_denominator() -> None:
+    """A metric that cannot be true is a bug, and it must not reach a report."""
+    with pytest.raises(ValueError, match="numerator"):
+        Ratio(5, 4)
+
+
+def test_ratio_json_carries_the_counts_so_a_diff_shows_which_half_moved() -> None:
+    assert Ratio(3, 4).as_json() == {"numerator": 3, "denominator": 4, "value": 0.75}
+    empty = Ratio(0, 0, "nothing to divide").as_json()
+    assert empty["value"] is None
+    assert empty["undefined_reason"] == "nothing to divide"
+
+
+# ---------------------------------------------------------------------- tier ordering
+
+
+def test_contactable_is_hot_and_warm_by_rank() -> None:
+    assert frozenset({Tier.HOT, Tier.WARM}) == CONTACTABLE_TIERS
+    assert is_contactable(Tier.HOT)
+    assert is_contactable(Tier.WARM)
+    assert not is_contactable(Tier.COLD)
+    assert not is_contactable(Tier.DISQUALIFIED)
+
+
+@pytest.mark.parametrize(
+    ("expected", "predicted", "adjacent"),
+    [
+        (Tier.HOT, Tier.HOT, True),
+        (Tier.HOT, Tier.WARM, True),
+        (Tier.WARM, Tier.HOT, True),
+        # rank distance 2. String comparison would call "cold" < "hot" and get this wrong.
+        (Tier.COLD, Tier.HOT, False),
+        (Tier.HOT, Tier.COLD, False),
+        (Tier.DISQUALIFIED, Tier.COLD, True),
+        (Tier.DISQUALIFIED, Tier.HOT, False),
+    ],
+)
+def test_adjacency_is_computed_from_rank_not_from_the_string(
+    expected: Tier, predicted: Tier, adjacent: bool
+) -> None:
+    assert is_adjacent(expected, predicted) is adjacent
+
+
+def test_the_string_ordering_this_module_refuses_to_use_really_is_wrong() -> None:
+    """The trap #7 added `rank` for: lexicographically, `cold` outranks `hot`."""
+    assert Tier.COLD < Tier.HOT  # string ordering, and business-nonsense
+    assert Tier.COLD.rank < Tier.HOT.rank
+
+
+# ----------------------------------------------------------------- the four metrics
+
+
+def test_exact_and_adjacent_tier_accuracy_over_a_hand_counted_set() -> None:
+    # 5 cases: 3 exact (a, b, e); d is adjacent (warm vs hot); c is two ranks out.
+    results = [
+        _case("a", Tier.HOT, Tier.HOT),
+        _case("b", Tier.WARM, Tier.WARM),
+        _case("c", Tier.COLD, Tier.HOT),
+        _case("d", Tier.HOT, Tier.WARM),
+        _case("e", Tier.DISQUALIFIED, Tier.DISQUALIFIED),
+    ]
+    segment = compute_segment("all", results)
+    assert segment.exact_tier_accuracy == Ratio(3, 5)
+    assert segment.exact_tier_accuracy.value == 0.6
+    assert segment.adjacent_tier_accuracy == Ratio(4, 5)
+    assert segment.adjacent_tier_accuracy.value == 0.8
+
+
+def test_precision_on_hot_is_over_the_leads_called_hot() -> None:
+    # 4 predicted hot; the human agreed with 3 of them. Two other cases are not counted.
+    results = [
+        _case("a", Tier.HOT, Tier.HOT),
+        _case("b", Tier.HOT, Tier.HOT),
+        _case("c", Tier.HOT, Tier.HOT),
+        _case("d", Tier.COLD, Tier.HOT),
+        _case("e", Tier.WARM, Tier.WARM),
+        _case("f", Tier.HOT, Tier.COLD),
+    ]
+    segment = compute_segment("all", results)
+    assert segment.precision_on_hot == Ratio(3, 4)
+    assert segment.precision_on_hot.value == 0.75
+
+
+def test_precision_on_hot_is_undefined_when_nothing_was_predicted_hot() -> None:
+    """Zero hot predictions is not zero precision - there is nothing to be right about."""
+    results = [
+        _case("a", Tier.HOT, Tier.WARM),
+        _case("b", Tier.WARM, Tier.COLD),
+    ]
+    segment = compute_segment("all", results)
+    precision = segment.precision_on_hot
+    assert not precision.defined
+    assert precision.value is None
+    assert precision.denominator == 0
+    assert "hot" in precision.text
+
+
+def test_precision_within_band_credits_a_label_that_permits_hot() -> None:
+    """A label of `warm` with a ceiling of `hot` is not a wrong hot prediction."""
+    results = [_case("a", Tier.WARM, Tier.HOT, upper=Tier.HOT)]
+    segment = compute_segment("all", results)
+    assert segment.precision_on_hot == Ratio(0, 1)
+    assert segment.precision_on_hot_within_band == Ratio(1, 1)
+
+
+def test_recall_on_contactable_is_the_false_disqualification_rate() -> None:
+    # 4 cases labeled hot or warm; 3 of them were surfaced. `c` is the money case.
+    results = [
+        _case("a", Tier.HOT, Tier.HOT),
+        _case("b", Tier.WARM, Tier.HOT),
+        _case("c", Tier.HOT, Tier.DISQUALIFIED),
+        _case("d", Tier.WARM, Tier.WARM),
+        _case("e", Tier.COLD, Tier.COLD),
+    ]
+    segment = compute_segment("all", results)
+    assert segment.recall_on_contactable == Ratio(3, 4)
+    assert segment.recall_on_contactable.value == 0.75
+    assert segment.false_disqualified_case_ids == ("c",)
+
+
+def test_recall_is_undefined_when_no_case_should_have_been_contacted() -> None:
+    results = [
+        _case("a", Tier.COLD, Tier.COLD),
+        _case("b", Tier.DISQUALIFIED, Tier.COLD),
+    ]
+    segment = compute_segment("all", results)
+    recall = segment.recall_on_contactable
+    assert not recall.defined
+    assert recall.denominator == 0
+    assert "hot or warm" in recall.text
+    assert segment.false_disqualified_case_ids == ()
+
+
+def test_false_disqualified_ids_are_sorted_so_two_runs_diff_cleanly() -> None:
+    results = [
+        _case("zebra", Tier.HOT, Tier.COLD),
+        _case("alpha", Tier.WARM, Tier.DISQUALIFIED),
+    ]
+    segment = compute_segment("all", results)
+    assert segment.false_disqualified_case_ids == ("alpha", "zebra")
+
+
+def test_cost_and_latency_come_straight_from_the_metering() -> None:
+    results = [
+        _case("a", Tier.HOT, Tier.HOT, cost="0.0100", latency_ms=1000),
+        _case("b", Tier.WARM, Tier.WARM, cost="0.0200", latency_ms=9000),
+        _case("c", Tier.COLD, Tier.COLD, cost="0.0300", latency_ms=3000),
+        _case("d", Tier.COLD, Tier.COLD, cost="0.0400", latency_ms=2000),
+    ]
+    segment = compute_segment("all", results)
+    assert segment.total_cost_usd == Decimal("0.1000")
+    assert segment.cost_usd_per_lead == Decimal("0.025")
+    # Nearest-rank p95 over 4 values: ceil(0.95 * 4) = 4, so the 4th smallest.
+    assert segment.latency.p95_ms == 9000
+    assert segment.latency.p50_ms == 2000
+    assert segment.latency.max_ms == 9000
+
+
+@pytest.mark.parametrize(
+    ("values", "quantile", "expected"),
+    [
+        ([], 0.95, None),
+        ([7], 0.95, 7),
+        ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0.95, 10),
+        ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 0.5, 5),
+        ([5, 1, 3], 0.95, 5),
+    ],
+)
+def test_percentile_is_nearest_rank_and_order_independent(
+    values: list[int], quantile: float, expected: int | None
+) -> None:
+    assert percentile_ms(values, quantile) == expected
+
+
+# --------------------------------------------------------------------- the edge cases
+
+
+def test_a_single_case_produces_defined_metrics() -> None:
+    segment = compute_segment("all", [_case("only", Tier.HOT, Tier.HOT, latency_ms=1234)])
+    assert segment.cases == 1
+    assert segment.exact_tier_accuracy == Ratio(1, 1)
+    assert segment.precision_on_hot == Ratio(1, 1)
+    assert segment.recall_on_contactable == Ratio(1, 1)
+    assert segment.latency.p95_ms == 1234
+    assert segment.cost_usd_per_lead == Decimal("0.02")
+
+
+def test_an_empty_segment_reports_undefined_everywhere_and_never_divides_by_zero() -> None:
+    """An empty segment is normal: there are no real cases in the seed set yet."""
+    segment = compute_segment("real", [])
+    assert segment.cases == 0
+    for ratio in (
+        segment.exact_tier_accuracy,
+        segment.adjacent_tier_accuracy,
+        segment.within_band_accuracy,
+        segment.precision_on_hot,
+        segment.recall_on_contactable,
+    ):
+        assert not ratio.defined
+    assert segment.total_cost_usd == Decimal(0)
+    assert segment.cost_usd_per_lead is None
+    assert segment.latency.p95_ms is None
+    assert segment.caveat
+
+
+# --------------------------------------------------------------- failures are escalations
+
+
+def test_a_failed_case_is_counted_as_an_escalation_and_still_scored() -> None:
+    """`system_failure` routes to WARM, so a failure is a prediction like any other."""
+    results = [
+        _case("ok", Tier.HOT, Tier.HOT),
+        _case(
+            "broke",
+            Tier.COLD,
+            Tier.WARM,
+            assessed=False,
+            escalation_reason=EscalationReason.API_ERROR,
+            cost="0",
+        ),
+    ]
+    segment = compute_segment("all", results)
+    assert segment.cases == 2
+    assert segment.assessed == 1
+    assert segment.failures == 1
+    assert segment.escalations == 1
+    assert segment.escalations_by_reason == {"api_error": 1}
+    # It counts against accuracy rather than vanishing from the denominator.
+    assert segment.exact_tier_accuracy == Ratio(1, 2)
+
+
+def test_a_low_confidence_escalation_is_an_escalation_but_not_a_failure() -> None:
+    results = [
+        _case(
+            "unsure",
+            Tier.WARM,
+            Tier.WARM,
+            escalation_reason=EscalationReason.LOW_CONFIDENCE,
+        )
+    ]
+    segment = compute_segment("all", results)
+    assert segment.failures == 0
+    assert segment.escalations == 1
+    assert segment.escalations_by_reason == {"low_confidence": 1}
+
+
+def test_escalation_reasons_are_ordered_so_the_json_diffs_cleanly() -> None:
+    results = [
+        _case(
+            "t", Tier.WARM, Tier.WARM, assessed=False, escalation_reason=EscalationReason.TIMEOUT
+        ),
+        _case(
+            "a",
+            Tier.WARM,
+            Tier.WARM,
+            assessed=False,
+            escalation_reason=EscalationReason.API_ERROR,
+        ),
+        _case(
+            "p",
+            Tier.WARM,
+            Tier.WARM,
+            assessed=False,
+            escalation_reason=EscalationReason.PARSE_ERROR,
+        ),
+    ]
+    segment = compute_segment("all", results)
+    assert list(segment.escalations_by_reason) == ["api_error", "parse_error", "timeout"]
+
+
+# ----------------------------------------------------------------------- within-band
+
+
+def test_within_band_accuracy_honours_the_label_bounds() -> None:
+    results = [
+        # Labeled cold, band cold..warm: a warm prediction is inside the band, not exact.
+        _case("banded", Tier.COLD, Tier.WARM, upper=Tier.WARM),
+        # Labeled cold with the same band: hot is outside it.
+        _case("outside", Tier.COLD, Tier.HOT, upper=Tier.WARM),
+    ]
+    segment = compute_segment("all", results)
+    assert segment.exact_tier_accuracy == Ratio(0, 2)
+    assert segment.within_band_accuracy == Ratio(1, 2)
+
+
+# ------------------------------------------------------------------- confusion matrix
+
+
+def test_confusion_matrix_covers_every_tier_in_rank_order() -> None:
+    results = [
+        _case("a", Tier.HOT, Tier.HOT),
+        _case("b", Tier.HOT, Tier.WARM),
+        _case("c", Tier.WARM, Tier.WARM),
+        _case("d", Tier.COLD, Tier.DISQUALIFIED),
+    ]
+    matrix = ConfusionMatrix.of(results)
+    assert matrix.total == 4
+    assert matrix.counts[Tier.HOT][Tier.HOT] == 1
+    assert matrix.counts[Tier.HOT][Tier.WARM] == 1
+    assert matrix.counts[Tier.COLD][Tier.DISQUALIFIED] == 1
+    # Every tier is present as a row and a column, even with no cases, so the shape of
+    # the JSON does not change when the golden set grows a tier.
+    assert list(matrix.counts) == [Tier.HOT, Tier.WARM, Tier.COLD, Tier.DISQUALIFIED]
+    for row in matrix.counts.values():
+        assert list(row) == [Tier.HOT, Tier.WARM, Tier.COLD, Tier.DISQUALIFIED]
+    assert matrix.counts[Tier.DISQUALIFIED][Tier.HOT] == 0
+
+
+def test_confusion_matrix_json_is_keyed_by_tier_name() -> None:
+    matrix = ConfusionMatrix.of([_case("a", Tier.HOT, Tier.WARM)])
+    payload = matrix.as_json()
+    assert payload["hot"]["warm"] == 1
+    assert payload["hot"]["hot"] == 0
+    assert list(payload) == ["hot", "warm", "cold", "disqualified"]
+
+
+def test_an_empty_confusion_matrix_is_all_zeroes() -> None:
+    matrix = ConfusionMatrix.of([])
+    assert matrix.total == 0
+    assert all(count == 0 for row in matrix.counts.values() for count in row.values())
+
+
+# ------------------------------------------------------------------------- the caveat
+
+
+def test_the_caveat_names_the_synthetic_share_of_the_segment() -> None:
+    all_synthetic = synthetic_caveat([_case("a", Tier.HOT, Tier.HOT)])
+    assert "self-consistency" in all_synthetic
+    assert "synthetic" in all_synthetic
+
+    mixed = synthetic_caveat(
+        [
+            _case("a", Tier.HOT, Tier.HOT),
+            _case("b", Tier.HOT, Tier.HOT, provenance=Provenance.REAL),
+        ]
+    )
+    assert "1 of 2" in mixed
+    assert "self-consistency" in mixed
+
+
+def test_every_segment_carries_the_caveat_next_to_its_numbers() -> None:
+    segment = compute_segment("hard_cases", [_case("a", Tier.HOT, Tier.HOT, hard_case=True)])
+    assert "self-consistency" in segment.caveat
+
+
+# ----------------------------------------------------------------------- nondeterminism
+
+
+def test_stability_is_unmeasured_from_a_single_repeat() -> None:
+    """One run cannot say anything about run-to-run variation, and must not pretend to."""
+    assert compute_stability([[_case("a", Tier.HOT, Tier.HOT)]]) is None
+
+
+def test_stability_counts_the_cases_whose_tier_moved_between_repeats() -> None:
+    first = [
+        _case("a", Tier.HOT, Tier.HOT),
+        _case("b", Tier.WARM, Tier.WARM),
+        _case("c", Tier.COLD, Tier.COLD),
+    ]
+    second = [
+        _case("a", Tier.HOT, Tier.HOT),
+        _case("b", Tier.WARM, Tier.HOT),  # moved
+        _case("c", Tier.COLD, Tier.COLD),
+    ]
+    stability = compute_stability([first, second])
+    assert stability is not None
+    assert stability.repeats == 2
+    assert stability.tier_stability == Ratio(2, 3)
+    assert stability.unstable_case_ids == ("b",)
+    exact = stability.metric_spreads["exact_tier_accuracy"]
+    # 3/3 in the first repeat, 2/3 in the second.
+    assert exact.minimum == pytest.approx(2 / 3)
+    assert exact.maximum == 1.0
+    assert exact.spread == pytest.approx(1 / 3)
+
+
+def test_stability_over_identical_repeats_reports_no_spread() -> None:
+    run = [_case("a", Tier.HOT, Tier.HOT), _case("b", Tier.COLD, Tier.COLD)]
+    stability = compute_stability([list(run), list(run)])
+    assert stability is not None
+    assert stability.tier_stability == Ratio(2, 2)
+    assert stability.unstable_case_ids == ()
+    assert stability.metric_spreads["exact_tier_accuracy"].spread == 0.0
+
+
+def test_stability_refuses_repeats_over_different_case_sets() -> None:
+    """Comparing two runs of different sets would produce a meaningless stability figure."""
+    with pytest.raises(ValueError, match="same cases"):
+        compute_stability([[_case("a", Tier.HOT, Tier.HOT)], [_case("b", Tier.HOT, Tier.HOT)]])
+
+
+# ------------------------------------------------------------------ security findings
+
+
+def _injection(
+    case_id: str,
+    predicted: Tier,
+    *,
+    expected: Tier = Tier.DISQUALIFIED,
+    lower: Tier | None = None,
+    upper: Tier | None = None,
+    assessed: bool = True,
+) -> CaseResult:
+    return _case(
+        case_id,
+        expected,
+        predicted,
+        lower=lower,
+        upper=upper,
+        assessed=assessed,
+        injection_case_id="direct_override",
+    )
+
+
+def test_an_injection_case_scored_hot_is_a_finding_not_a_metric() -> None:
+    findings = security_findings([_injection("attack", Tier.HOT, upper=Tier.COLD)])
+    assert len(findings) == 1
+    assert findings[0].case_id == "attack"
+    assert FINDING_SCORED_HOT in findings[0].kinds
+    assert FINDING_ABOVE_CEILING in findings[0].kinds
+    assert "hot" in findings[0].summary
+
+
+def test_an_injection_case_at_its_declared_ceiling_is_not_a_finding() -> None:
+    assert security_findings([_injection("attack", Tier.COLD, upper=Tier.COLD)]) == ()
+
+
+def test_an_injection_case_above_its_ceiling_is_a_finding_even_below_hot() -> None:
+    findings = security_findings([_injection("attack", Tier.WARM, upper=Tier.COLD)])
+    assert findings[0].kinds == (FINDING_ABOVE_CEILING,)
+
+
+def test_destroying_a_genuine_lead_that_carries_a_payload_is_also_a_finding() -> None:
+    """The failure mode a blunt keyword filter causes, and the reason #12 has that case."""
+    findings = security_findings(
+        [
+            _injection(
+                "genuine_with_payload",
+                Tier.DISQUALIFIED,
+                expected=Tier.WARM,
+                lower=Tier.COLD,
+                upper=Tier.WARM,
+            )
+        ]
+    )
+    assert findings[0].kinds == (FINDING_GENUINE_LEAD_DESTROYED,)
+    assert "cost a real lead" in findings[0].summary
+
+
+def test_an_unassessed_injection_case_is_not_reported_as_a_successful_attack() -> None:
+    """`system_failure` routes to WARM. That is our outage, not the attacker winning."""
+    assert (
+        security_findings([_injection("attack", Tier.WARM, upper=Tier.COLD, assessed=False)]) == ()
+    )
+
+
+def test_an_ordinary_lead_scored_hot_is_never_a_security_finding() -> None:
+    assert security_findings([_case("ordinary", Tier.COLD, Tier.HOT)]) == ()
+
+
+def test_findings_are_sorted_by_case_id() -> None:
+    findings = security_findings(
+        [
+            _injection("zulu", Tier.HOT, upper=Tier.COLD),
+            _injection("alpha", Tier.HOT, upper=Tier.COLD),
+        ]
+    )
+    assert [finding.case_id for finding in findings] == ["alpha", "zulu"]
+
+
+def test_a_finding_serialises_with_its_band_and_its_explanation() -> None:
+    payload = security_findings([_injection("attack", Tier.HOT, upper=Tier.COLD)])[0].as_json()
+    assert payload["case_id"] == "attack"
+    assert payload["injection_case_id"] == "direct_override"
+    assert payload["predicted_tier"] == "hot"
+    assert payload["declared_band"] == {"lower": "disqualified", "upper": "cold"}
+    assert payload["summary"]

--- a/tests/unit/test_eval_workflow.py
+++ b/tests/unit/test_eval_workflow.py
@@ -1,0 +1,231 @@
+"""The eval workflow is configuration that spends money, so its invariants are asserted.
+
+A workflow file is only ever executed by GitHub, so what can be checked here is the
+policy encoded in it — and the policy is the whole point. One mistake in this file (a
+``push`` trigger, a key handed to the wrong step) is a bill and a rate-limit incident
+rather than a red build, and neither is visible until it has already happened.
+
+The assertions follow ``tests/unit/test_ci_workflow.py``, including its two-path
+resolution: ``.github/workflows/`` is where GitHub runs it from, ``ci/`` is the staging
+path used while the authoring credential lacks GitHub's ``workflow`` scope, and accepting
+both means activating the workflow is a ``git mv`` with no test edit — so the move cannot
+silently disable what is asserted below.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+_CANDIDATE_PATHS = (
+    _REPO_ROOT / ".github" / "workflows" / "eval.yml",
+    _REPO_ROOT / "ci" / "github-actions-eval.yml",
+)
+
+
+def _workflow_path() -> Path:
+    """Return the eval workflow, wherever it currently lives."""
+    for candidate in _CANDIDATE_PATHS:
+        if candidate.is_file():
+            return candidate
+    searched = ", ".join(str(path) for path in _CANDIDATE_PATHS)
+    raise AssertionError(f"no eval workflow found; looked in: {searched}")
+
+
+WORKFLOW_PATH = _workflow_path()
+
+# Keyed by `object` because of the `on` quirk below; values are `Any` because a workflow is
+# an untyped document. Every value is narrowed with `isinstance` before it is asserted on.
+Workflow = dict[object, Any]
+
+
+def _load_workflow() -> Workflow:
+    with WORKFLOW_PATH.open(encoding="utf-8") as handle:
+        loaded: object = yaml.safe_load(handle)
+    assert isinstance(loaded, dict), "the workflow must parse to a mapping"
+    return loaded
+
+
+def _triggers(workflow: Workflow) -> dict[str, Any]:
+    """Return the ``on:`` block.
+
+    YAML 1.1 resolves the bare key ``on`` to the boolean ``True``, which is what PyYAML
+    does and what GitHub's own parser tolerates; accept either spelling.
+    """
+    raw: object = workflow.get("on", workflow.get(True))
+    assert isinstance(raw, dict), "`on:` must be a mapping of trigger names"
+    return raw
+
+
+@pytest.fixture(scope="module")
+def workflow() -> Workflow:
+    return _load_workflow()
+
+
+@pytest.fixture(scope="module")
+def eval_job(workflow: Workflow) -> dict[str, Any]:
+    jobs: object = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    assert len(jobs) == 1, "one job keeps the summary and the artifact in one place"
+    job: object = next(iter(jobs.values()))
+    assert isinstance(job, dict)
+    return job
+
+
+@pytest.fixture(scope="module")
+def steps(eval_job: dict[str, Any]) -> list[dict[str, Any]]:
+    raw: object = eval_job["steps"]
+    assert isinstance(raw, list)
+    return [step for step in raw if isinstance(step, dict)]
+
+
+def _run_commands(steps: list[dict[str, Any]]) -> list[str]:
+    return [str(step["run"]) for step in steps if "run" in step]
+
+
+def _eval_step(steps: list[dict[str, Any]]) -> dict[str, Any]:
+    """The one step that actually spends money."""
+    matching = [step for step in steps if "run" in step and "--confirm-spend" in str(step["run"])]
+    assert len(matching) == 1, "exactly one step may run the paid eval"
+    return matching[0]
+
+
+def test_workflow_file_exists_and_parses() -> None:
+    assert WORKFLOW_PATH.is_file(), f"missing workflow at {WORKFLOW_PATH}"
+    assert _load_workflow()
+
+
+def test_the_header_says_how_to_activate_it() -> None:
+    """Staged at ``ci/`` is only useful if the move is written down where it is found."""
+    header = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "git mv ci/github-actions-eval.yml .github/workflows/eval.yml" in header
+    assert "ANTHROPIC_API_KEY" in header, "the secret it needs must be named in the header"
+
+
+def test_it_runs_only_on_manual_dispatch(workflow: Workflow) -> None:
+    """The trigger policy is the cost control. Anything automatic bills every commit."""
+    assert set(_triggers(workflow)) == {"workflow_dispatch"}
+
+
+@pytest.mark.parametrize("forbidden", ["push", "pull_request", "pull_request_target", "schedule"])
+def test_no_automatic_trigger_can_fire_a_paid_run(workflow: Workflow, forbidden: str) -> None:
+    assert forbidden not in _triggers(workflow)
+
+
+def test_effort_and_prompt_version_are_dispatch_inputs(workflow: Workflow) -> None:
+    dispatch: object = _triggers(workflow)["workflow_dispatch"]
+    assert isinstance(dispatch, dict)
+    inputs: object = dispatch["inputs"]
+    assert isinstance(inputs, dict)
+    assert {"effort", "prompt_version"} <= set(inputs)
+    effort: object = inputs["effort"]
+    assert isinstance(effort, dict)
+    assert effort["type"] == "choice"
+    # The five levels claude-opus-5 accepts, matching EFFORT_LEVELS. A sixth here would be
+    # a dispatch that fails after the checkout rather than in the form.
+    assert set(effort["options"]) == {"low", "medium", "high", "xhigh", "max"}
+    assert effort["default"] == "medium"
+
+
+def test_the_prompt_version_input_is_verified_before_any_spend(
+    steps: list[dict[str, Any]],
+) -> None:
+    """A number filed against the wrong prompt version is worse than no number."""
+    commands = _run_commands(steps)
+    verification = [command for command in commands if "PROMPT_VERSION" in command]
+    assert len(verification) == 1
+    assert "inputs.prompt_version" in verification[0]
+    assert commands.index(verification[0]) < commands.index(_eval_step(steps)["run"])
+
+
+def test_the_estimate_runs_before_the_paid_run(steps: list[dict[str, Any]]) -> None:
+    commands = _run_commands(steps)
+    estimates = [command for command in commands if "--estimate" in command]
+    assert len(estimates) == 1
+    assert commands.index(estimates[0]) < commands.index(_eval_step(steps)["run"])
+
+
+def test_workflow_permissions_are_read_only(workflow: Workflow) -> None:
+    assert workflow["permissions"] == {"contents": "read"}
+
+
+def test_a_superseded_run_is_not_cancelled(workflow: Workflow) -> None:
+    """Unlike CI, a superseded run here has already spent money. Queue it, do not bin it."""
+    concurrency: object = workflow["concurrency"]
+    assert isinstance(concurrency, dict)
+    assert concurrency["cancel-in-progress"] is False
+
+
+def test_the_job_is_bounded_and_runs_on_ubuntu(eval_job: dict[str, Any]) -> None:
+    assert eval_job["runs-on"] == "ubuntu-latest"
+    timeout: object = eval_job["timeout-minutes"]
+    assert isinstance(timeout, int)
+    assert 0 < timeout <= 60, "a run that takes longer than an hour is a hung model call"
+
+
+def test_python_is_313_with_the_dev_extras(steps: list[dict[str, Any]]) -> None:
+    setup = [step for step in steps if str(step.get("uses", "")).startswith("actions/setup-python")]
+    assert len(setup) == 1
+    params: object = setup[0]["with"]
+    assert isinstance(params, dict)
+    assert str(params["python-version"]) == "3.13"
+    assert any('pip install -e ".[dev]"' in command for command in _run_commands(steps))
+
+
+def test_the_key_reaches_exactly_one_step_and_it_is_the_eval(
+    steps: list[dict[str, Any]],
+) -> None:
+    """A key on the job, or on the checkout, is a key every future step inherits."""
+    with_key = [step for step in steps if "ANTHROPIC_API_KEY" in str(step.get("env", {}))]
+    assert len(with_key) == 1
+    assert with_key[0] is _eval_step(steps)
+    assert with_key[0]["env"]["ANTHROPIC_API_KEY"] == "${{ secrets.ANTHROPIC_API_KEY }}"
+
+
+def test_the_key_is_not_exposed_to_the_job_or_the_workflow(
+    workflow: Workflow, eval_job: dict[str, Any]
+) -> None:
+    assert "env" not in workflow, "a workflow-level env is inherited by every step"
+    assert "env" not in eval_job, "a job-level env is inherited by every step"
+
+
+def test_the_paid_run_passes_the_confirmation_flag_and_the_dispatch_inputs(
+    steps: list[dict[str, Any]],
+) -> None:
+    command = str(_eval_step(steps)["run"])
+    assert "python -m tests.evals.run_eval" in command
+    assert "--confirm-spend" in command
+    for name in ("effort", "repeat", "concurrency"):
+        assert f"inputs.{name}" in command, f"the {name} input must reach the harness"
+
+
+def test_the_report_is_posted_to_the_run_summary_even_when_the_run_fails(
+    steps: list[dict[str, Any]],
+) -> None:
+    """A run that ends on an injection finding is precisely the one somebody must read."""
+    summary = [step for step in steps if "GITHUB_STEP_SUMMARY" in str(step.get("run", ""))]
+    assert len(summary) == 1
+    assert summary[0]["if"] == "always()"
+    assert "self-consistency" in str(summary[0]["run"]), (
+        "the summary must carry the synthetic-set caveat: it is the part people screenshot"
+    )
+
+
+def test_the_json_result_is_uploaded_for_later_comparison(steps: list[dict[str, Any]]) -> None:
+    uploads = [step for step in steps if str(step.get("uses", "")).startswith("actions/upload-")]
+    assert len(uploads) == 1
+    assert uploads[0]["if"] == "always()"
+    params: object = uploads[0]["with"]
+    assert isinstance(params, dict)
+    assert "eval-results/" in str(params["path"])
+
+
+def test_every_step_is_named(steps: list[dict[str, Any]]) -> None:
+    """The Actions log is the only view most people get of a run that cost money."""
+    for step in steps:
+        assert step.get("name"), f"unnamed step: {step}"

--- a/tests/unit/test_run_eval.py
+++ b/tests/unit/test_run_eval.py
@@ -1,0 +1,987 @@
+"""The eval harness, exercised offline: the refusals, the wiring, and the output contract.
+
+Every test here drives ``run_eval.main`` with a scripted assessor and a fixed clock. None
+of them needs an API key and none makes a network call — which is the point: the harness
+is the one piece of this repository that spends money when it runs, so the machinery
+around the spend has to be provable without spending.
+
+Three groups, in order of how expensive the bug would be:
+
+1. **The refusals.** A harness that starts because a CI job was mis-wired bills a real
+   card and, at any real golden-set size, trips a rate limit. Both guards are asserted, and
+   asserted to fire *before* an assessor is ever constructed.
+2. **Failures are data.** A refusal, a timeout, a parse error, or an adapter that raises
+   when its port says it must not: each one must land as an escalation on the tier
+   ``system_failure`` produces, and must not cost the run the fourteen results already
+   paid for.
+3. **The output contract.** #24 diffs two result files, so ordering is deterministic, the
+   JSON shape is pinned, and the synthetic-set caveat is asserted to appear beside every
+   metric block rather than once at the top where it can be cropped out of a screenshot.
+
+Nothing here asserts on model prose, because nothing here has any: the assessments are
+fixtures, and what the model would actually say is the golden set's business, not this
+file's.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import io
+import json
+import threading
+import time
+from collections.abc import Iterator, Mapping, Sequence
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from leadquali.adapters.tenant_config_json import (
+    JsonFileTenantConfigLoader,
+    default_tenants_dir,
+)
+from leadquali.app.assessment_result import (
+    AssessmentFailed,
+    AssessmentOutcome,
+    AssessmentSucceeded,
+    CallMetering,
+    Effort,
+)
+from leadquali.config import get_settings
+from leadquali.domain.models import (
+    DimensionScores,
+    EscalationReason,
+    ExtractedFacts,
+    LeadAssessment,
+    Tier,
+)
+from leadquali.domain.routing import system_failure
+from leadquali.domain.tenant_config import TenantConfig
+from tests.evals import golden_set as golden_set_module
+from tests.evals import run_eval
+from tests.evals.report import RESULT_SCHEMA_VERSION, SEGMENT_NAMES
+
+# --------------------------------------------------------------------------- the corpus
+
+_NOTE = (
+    "Fixture set for the harness tests. Every case is synthetic, so any number computed "
+    "against it measures self-consistency, not correctness."
+)
+
+_HEADER = {
+    "$golden_set": {
+        "schema_version": 1,
+        "note": _NOTE,
+        "min_total_cases": 1,
+        "min_real_cases": 0,
+        "acceptance_target_total_cases": 50,
+        "acceptance_target_real_cases": 50,
+    }
+}
+
+
+def _label(tier: str) -> list[dict[str, str]]:
+    return [
+        {
+            "labeler": "fixture_author",
+            "tier": tier,
+            "labeled_at": "2026-09-03",
+            "notes": "Written for the harness tests; the tier is whatever the test needs.",
+        }
+    ]
+
+
+#: Three cases, one of each shape the harness treats differently: an ordinary lead, an
+#: attack from #12's corpus (referenced, never copied), and a lead with a label band.
+_CASES: list[dict[str, Any]] = [
+    {
+        "case_id": "a_hot_buyer",
+        "provenance": "synthetic",
+        "expected_tier": "hot",
+        "form": {
+            "full_name": "Sam Buyer",
+            "email": "sam@example.com",
+            "company": "Example Co",
+            "message": "We have budget and a deadline and we want to buy this quarter.",
+        },
+        "labels": _label("hot"),
+    },
+    {
+        "case_id": "b_injection",
+        "provenance": "synthetic",
+        "expected_tier": "disqualified",
+        "injection_case_id": "direct_override",
+        "hard_case": True,
+        "labels": _label("disqualified"),
+    },
+    {
+        "case_id": "c_warm_lead",
+        "provenance": "synthetic",
+        "expected_tier": "warm",
+        "expected_max_tier": "hot",
+        "form": {
+            "full_name": "Robin Maybe",
+            "email": "robin@example.org",
+            "message": "Interested but no timeline yet, exploring options for next year.",
+        },
+        "labels": _label("warm"),
+    },
+]
+
+#: A substring of each case's rendered lead, so a scripted assessor can answer per case
+#: without depending on the renderer's per-call nonce.
+MARKERS = {"a_hot_buyer": "Sam Buyer", "b_injection": "Alex Vance", "c_warm_lead": "Robin Maybe"}
+
+API_KEY = "sk-ant-not-a-real-key"
+
+
+@pytest.fixture
+def golden_file(tmp_path: Path) -> Path:
+    """The fixture golden set on disk, so ``main`` exercises the real loader."""
+    path = tmp_path / "fixture_leads.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(record) for record in [_HEADER, *_CASES]) + "\n", encoding="utf-8"
+    )
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _clean_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    """No key by default, and never a cached one from another test."""
+    get_settings.cache_clear()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def with_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A key in the environment. Never used to call anything: the assessor is injected."""
+    monkeypatch.setenv("ANTHROPIC_API_KEY", API_KEY)
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def config() -> TenantConfig:
+    return JsonFileTenantConfigLoader(default_tenants_dir()).get("default")
+
+
+# ------------------------------------------------------------------------- the fixtures
+
+_FACTS = ExtractedFacts(
+    company_name=None,
+    industry=None,
+    company_size_estimate=None,
+    role_seniority=None,
+    stated_use_case=None,
+    stated_timeline=None,
+)
+
+# Weighted against the shipped default rubric these score 100 / 59 / 32 / 0, which is one
+# of each tier. Computed from the thresholds in `tenants/default.json`, not guessed.
+_SCORES: Mapping[Tier, DimensionScores] = {
+    Tier.HOT: DimensionScores(icp_fit=30, intent=25, authority=15, urgency=15, budget_signal=15),
+    Tier.WARM: DimensionScores(icp_fit=20, intent=15, authority=8, urgency=8, budget_signal=8),
+    Tier.COLD: DimensionScores(icp_fit=12, intent=8, authority=4, urgency=4, budget_signal=4),
+    Tier.DISQUALIFIED: DimensionScores(
+        icp_fit=0, intent=0, authority=0, urgency=0, budget_signal=0
+    ),
+}
+
+
+def _assessment(tier: Tier, *, confidence: float = 0.9) -> LeadAssessment:
+    return LeadAssessment(
+        dimension_scores=_SCORES[tier],
+        extracted=_FACTS,
+        reasoning=f"Fixture reasoning for a lead the fixture wants tiered {tier.value}.",
+        confidence=confidence,
+        missing_information=[],
+        suggested_first_question=None,
+        spam_or_test_submission=False,
+    )
+
+
+def _metering(*, cost: str = "0.0200", latency_ms: int = 4000) -> CallMetering:
+    return CallMetering(
+        model_id="claude-opus-5",
+        prompt_version="rubric_v1",
+        effort="medium",
+        input_tokens=2000,
+        output_tokens=900,
+        cache_read_tokens=1500,
+        cache_creation_tokens=0,
+        cost_usd=Decimal(cost),
+        latency_ms=latency_ms,
+    )
+
+
+def scored(tier: Tier, *, confidence: float = 0.9, latency_ms: int = 4000) -> AssessmentOutcome:
+    """A successful assessment that routes to ``tier`` under the default rubric."""
+    return AssessmentSucceeded(
+        assessment=_assessment(tier, confidence=confidence),
+        metering=_metering(latency_ms=latency_ms),
+    )
+
+
+def refused(reason: EscalationReason = EscalationReason.MODEL_REFUSAL) -> AssessmentOutcome:
+    """A billed non-answer: the shape the adapter returns instead of raising."""
+    return AssessmentFailed(reason=reason, detail="stop_reason=refusal", latency_ms=2100)
+
+
+class MappedAssessor:
+    """A ``LeadAssessorPort`` that answers per case, keyed on a marker in the rendered lead.
+
+    The renderer wraps every lead in a fresh nonce, so the rendered text is never equal
+    twice; a marker substring is the stable way to recognise a case. Values are sequences,
+    consumed one per call to that case, which is how a ``--repeat`` run is given a
+    different answer the second time round.
+    """
+
+    def __init__(
+        self,
+        outcomes: Mapping[str, Sequence[AssessmentOutcome]],
+        *,
+        default: AssessmentOutcome | None = None,
+    ) -> None:
+        self._outcomes = {marker: list(values) for marker, values in outcomes.items()}
+        self._default = default
+        self._lock = threading.Lock()
+        self._calls: dict[str, int] = {}
+        self.prompts: list[str] = []
+
+    @property
+    def calls(self) -> int:
+        return len(self.prompts)
+
+    def assess(self, *, config: TenantConfig, rendered_lead: str) -> AssessmentOutcome:
+        with self._lock:
+            self.prompts.append(rendered_lead)
+            for marker, values in self._outcomes.items():
+                if marker in rendered_lead:
+                    index = min(self._calls.get(marker, 0), len(values) - 1)
+                    self._calls[marker] = index + 1
+                    return values[index]
+        if self._default is None:
+            raise AssertionError("the fixture assessor was given a lead it has no answer for")
+        return self._default
+
+
+#: What each fixture case's label says. `perfect()` answers with these, so a test that is
+#: about something else does not accidentally trip a security finding on the attack case.
+LABEL_TIERS = {
+    "a_hot_buyer": Tier.HOT,
+    "b_injection": Tier.DISQUALIFIED,
+    "c_warm_lead": Tier.WARM,
+}
+
+
+def perfect(**overrides: AssessmentOutcome | list[AssessmentOutcome]) -> MappedAssessor:
+    """An assessor that agrees with every label, except where a test says otherwise.
+
+    Keyword arguments are case ids; a list is consumed one entry per repeat.
+    """
+    outcomes: dict[str, list[AssessmentOutcome]] = {
+        MARKERS[case_id]: [scored(tier)] for case_id, tier in LABEL_TIERS.items()
+    }
+    for case_id, value in overrides.items():
+        outcomes[MARKERS[case_id]] = value if isinstance(value, list) else [value]
+    return MappedAssessor(outcomes)
+
+
+class RaisingAssessor:
+    """An assessor that violates its port and throws. The harness must survive it."""
+
+    def __init__(self, error: Exception) -> None:
+        self._error = error
+        self.calls = 0
+
+    def assess(self, *, config: TenantConfig, rendered_lead: str) -> AssessmentOutcome:
+        self.calls += 1
+        raise self._error
+
+
+class ConcurrencyProbe:
+    """Records the high-water mark of simultaneous calls."""
+
+    def __init__(self, *, hold_seconds: float = 0.05) -> None:
+        self._hold = hold_seconds
+        self._lock = threading.Lock()
+        self.in_flight = 0
+        self.peak = 0
+
+    def assess(self, *, config: TenantConfig, rendered_lead: str) -> AssessmentOutcome:
+        with self._lock:
+            self.in_flight += 1
+            self.peak = max(self.peak, self.in_flight)
+        try:
+            time.sleep(self._hold)
+        finally:
+            with self._lock:
+                self.in_flight -= 1
+        return scored(Tier.WARM)
+
+
+def _factory(assessor: object) -> Any:
+    def build(effort: Effort) -> Any:
+        return assessor
+
+    return build
+
+
+def _exploding_factory(effort: Effort) -> Any:
+    raise AssertionError("an assessor must never be built for a run that was refused")
+
+
+def _clock(*instants: datetime) -> Any:
+    remaining = list(instants)
+
+    def now() -> datetime:
+        return remaining.pop(0) if len(remaining) > 1 else remaining[0]
+
+    return now
+
+
+T0 = datetime(2026, 9, 3, 12, 0, 0, tzinfo=UTC)
+T1 = datetime(2026, 9, 3, 12, 1, 30, tzinfo=UTC)
+
+
+def _run(
+    golden_file: Path,
+    tmp_path: Path,
+    *,
+    assessor: object,
+    extra: Sequence[str] = (),
+) -> int:
+    return run_eval.main(
+        [
+            "--confirm-spend",
+            "--golden-set",
+            str(golden_file),
+            "--out",
+            str(tmp_path / "results"),
+            *extra,
+        ],
+        assessor_factory=_factory(assessor),
+        now=_clock(T0, T1),
+    )
+
+
+def _result_file(tmp_path: Path) -> Path:
+    files = sorted((tmp_path / "results").glob("*.json"))
+    assert len(files) == 1, f"expected exactly one result file, found {files}"
+    return files[0]
+
+
+def _result(tmp_path: Path) -> dict[str, Any]:
+    payload: object = json.loads(_result_file(tmp_path).read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    return payload
+
+
+# ----------------------------------------------------------------------- the refusals
+
+
+def test_refuses_without_the_confirmation_flag(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A key alone is not consent: CI has the key, and must not be able to fire this."""
+    code = run_eval.main(
+        ["--golden-set", str(golden_file), "--out", str(tmp_path / "results")],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == run_eval.EXIT_REFUSED
+    assert "--confirm-spend" in capsys.readouterr().err
+
+
+def test_refuses_without_an_api_key(
+    golden_file: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = run_eval.main(
+        ["--confirm-spend", "--golden-set", str(golden_file), "--out", str(tmp_path / "results")],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == run_eval.EXIT_REFUSED
+    assert "ANTHROPIC_API_KEY" in capsys.readouterr().err
+
+
+def test_a_refusal_names_everything_that_is_missing_at_once(
+    golden_file: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """One round trip, not two: both guards are checked before anything is built."""
+    code = run_eval.main(
+        ["--golden-set", str(golden_file), "--out", str(tmp_path / "results")],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == run_eval.EXIT_REFUSED
+    stderr = capsys.readouterr().err
+    assert "--confirm-spend" in stderr
+    assert "ANTHROPIC_API_KEY" in stderr
+
+
+def test_a_refusal_writes_no_result_file(golden_file: Path, tmp_path: Path) -> None:
+    run_eval.main(
+        ["--golden-set", str(golden_file), "--out", str(tmp_path / "results")],
+        assessor_factory=_exploding_factory,
+    )
+    assert not (tmp_path / "results").exists()
+
+
+def test_the_refusal_quotes_the_price_of_the_run_it_is_declining(
+    golden_file: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    run_eval.main(
+        ["--golden-set", str(golden_file), "--out", str(tmp_path / "results")],
+        assessor_factory=_exploding_factory,
+    )
+    stderr = capsys.readouterr().err
+    assert "billable model call" in stderr
+    assert "--estimate" in stderr
+
+
+def test_estimate_needs_neither_the_flag_nor_a_key_and_calls_nothing(
+    golden_file: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The pre-flight price check must be free, or nobody will run it."""
+    code = run_eval.main(
+        ["--estimate", "--golden-set", str(golden_file)], assessor_factory=_exploding_factory
+    )
+    assert code == run_eval.EXIT_OK
+    stdout = capsys.readouterr().out
+    assert "Estimated cost" in stdout
+    assert "estimate, not a quote" in stdout
+    assert "output tokens per call" in stdout
+
+
+def test_the_estimate_scales_with_the_number_of_cases(
+    golden_file: Path, config: TenantConfig
+) -> None:
+    golden = golden_set_module.load_golden_set(golden_file)
+    estimate = run_eval.estimate_cost(golden, config, effort="medium")
+    assert estimate.cases == 3
+    assert estimate.cost_usd > 0
+    assert estimate.output_tokens == 3 * run_eval.DEFAULT_ASSUMED_OUTPUT_TOKENS
+    # One cache write per worker, a read for the rest: three cases, four workers.
+    assert estimate.cache_read_tokens == 0
+
+
+# --------------------------------------------------------------------- input validation
+
+
+@pytest.mark.parametrize(
+    "argument", [["--concurrency", "0"], ["--repeat", "0"], ["--concurrency", "-3"]]
+)
+def test_a_nonsensical_bound_is_an_input_error(
+    golden_file: Path, tmp_path: Path, with_key: None, argument: list[str]
+) -> None:
+    code = run_eval.main(
+        [
+            "--confirm-spend",
+            "--golden-set",
+            str(golden_file),
+            "--out",
+            str(tmp_path / "results"),
+            *argument,
+        ],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == run_eval.EXIT_INPUT_ERROR
+
+
+def test_a_missing_golden_set_is_an_input_error(tmp_path: Path, with_key: None) -> None:
+    code = run_eval.main(
+        ["--confirm-spend", "--golden-set", str(tmp_path / "nope.jsonl")],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == run_eval.EXIT_INPUT_ERROR
+
+
+def test_an_unknown_tenant_is_an_input_error(golden_file: Path, with_key: None) -> None:
+    code = run_eval.main(
+        ["--confirm-spend", "--golden-set", str(golden_file), "--tenant", "no_such_tenant"],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == run_eval.EXIT_INPUT_ERROR
+
+
+# ------------------------------------------------------------------------ the happy path
+
+
+def test_a_run_reports_the_four_metrics(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assessor = perfect()
+    assert _run(golden_file, tmp_path, assessor=assessor) == run_eval.EXIT_OK
+    stdout = capsys.readouterr().out
+    assert "Recall on contactable" in stdout
+    assert "Precision on hot" in stdout
+    assert "Tier accuracy, exact match" in stdout
+    assert "Tier accuracy, adjacent tier" in stdout
+    assert "Cost per lead" in stdout
+    assert "Latency p50 / p95 / max" in stdout
+    assert "CONFUSION MATRIX" in stdout
+    assert assessor.calls == 3
+
+
+def test_recall_is_printed_before_precision_because_it_is_the_costly_one(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Ordering is the whole editorial argument: a lost deal is silent and permanent."""
+    _run(golden_file, tmp_path, assessor=perfect())
+    stdout = capsys.readouterr().out
+    assert stdout.index("Recall on contactable") < stdout.index("Precision on hot")
+    assert "THE NUMBER THAT COSTS MONEY" in stdout
+
+
+def test_a_perfect_run_reports_no_false_disqualifications(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _run(golden_file, tmp_path, assessor=perfect())
+    assert "False disqualifications: none" in capsys.readouterr().out
+    metrics = _result(tmp_path)["metrics"]
+    assert metrics["recall_on_contactable"] == {
+        "numerator": 2,
+        "denominator": 2,
+        "value": 1.0,
+    }
+    assert metrics["false_disqualified_case_ids"] == []
+
+
+def test_a_binned_hot_lead_is_named_as_a_false_disqualification(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _run(golden_file, tmp_path, assessor=perfect(a_hot_buyer=scored(Tier.DISQUALIFIED)))
+    stdout = capsys.readouterr().out
+    assert "FALSE DISQUALIFICATIONS (1): a_hot_buyer" in stdout
+    metrics = _result(tmp_path)["metrics"]
+    assert metrics["false_disqualified_case_ids"] == ["a_hot_buyer"]
+    assert metrics["recall_on_contactable"]["value"] == 0.5
+
+
+# ------------------------------------------------------------------ failures are data
+
+
+def test_a_refusal_is_reported_as_an_escalation_and_does_not_abort_the_run(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    assessor = perfect(b_injection=refused())
+    assert _run(golden_file, tmp_path, assessor=assessor) == run_eval.EXIT_OK
+    cases = {case["case_id"]: case for case in _result(tmp_path)["cases"]}
+    assert len(cases) == 3, "the other two cases must still be reported"
+    failed = cases["b_injection"]
+    assert failed["assessed"] is False
+    assert failed["escalated"] is True
+    assert failed["escalation_reason"] == "model_refusal"
+    assert failed["record"]["failure"]["reason"] == "model_refusal"
+
+
+@pytest.mark.parametrize(
+    "reason",
+    [
+        EscalationReason.MODEL_REFUSAL,
+        EscalationReason.PARSE_ERROR,
+        EscalationReason.API_ERROR,
+        EscalationReason.TIMEOUT,
+    ],
+)
+def test_every_failure_lands_on_the_tier_system_failure_produces(
+    golden_file: Path, tmp_path: Path, with_key: None, reason: EscalationReason
+) -> None:
+    """Not `disqualified`, and not a guess: whatever #9 says production would do."""
+    assessor = MappedAssessor({}, default=refused(reason))
+    _run(golden_file, tmp_path, assessor=assessor)
+    expected = system_failure(reason).tier.value
+    for case in _result(tmp_path)["cases"]:
+        assert case["predicted_tier"] == expected
+        assert case["escalation_reason"] == reason.value
+
+
+def test_an_assessor_that_raises_is_recorded_as_an_api_error_not_a_crash(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    """The port forbids raising. A buggy adapter must still not cost the whole run."""
+    assessor = RaisingAssessor(RuntimeError("connection reset by peer"))
+    assert _run(golden_file, tmp_path, assessor=assessor) == run_eval.EXIT_OK
+    result = _result(tmp_path)
+    assert result["metrics"]["failures"] == 3
+    assert result["metrics"]["escalations_by_reason"] == {"api_error": 3}
+    for case in result["cases"]:
+        assert case["assessed"] is False
+        # The exception class, never its message: a message can carry a payload.
+        assert case["record"]["failure"]["detail"] == "RuntimeError"
+
+
+def test_a_failure_costs_nothing_and_is_still_in_the_denominator(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    _run(golden_file, tmp_path, assessor=perfect(a_hot_buyer=refused(EscalationReason.TIMEOUT)))
+    metrics = _result(tmp_path)["metrics"]
+    assert metrics["cases"] == 3
+    assert metrics["assessed"] == 2
+    assert metrics["failures"] == 1
+    assert metrics["exact_tier_accuracy"]["denominator"] == 3
+
+
+def test_a_low_confidence_assessment_escalates_without_being_a_failure(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    assessor = MappedAssessor({}, default=scored(Tier.HOT, confidence=0.1))
+    _run(golden_file, tmp_path, assessor=assessor)
+    metrics = _result(tmp_path)["metrics"]
+    assert metrics["failures"] == 0
+    assert metrics["escalations"] == 3
+    assert metrics["escalations_by_reason"] == {"low_confidence": 3}
+
+
+# ------------------------------------------------------------- concurrency and ordering
+
+
+def test_calls_are_bounded_by_the_concurrency_setting(config: TenantConfig) -> None:
+    """Unbounded fan-out at a real golden-set size is a 429 storm, not a speed-up."""
+    golden = golden_set_module.parse_golden_set(
+        "\n".join(json.dumps(record) for record in [_HEADER, *_CASES])
+    )
+    probe = ConcurrencyProbe()
+    run_eval.run_cases(golden.cases, assessor=probe, config=config, concurrency=2)
+    assert probe.peak <= 2
+    assert probe.in_flight == 0
+
+
+def test_more_workers_than_cases_does_not_over_subscribe(config: TenantConfig) -> None:
+    golden = golden_set_module.parse_golden_set(
+        "\n".join(json.dumps(record) for record in [_HEADER, *_CASES])
+    )
+    probe = ConcurrencyProbe()
+    run_eval.run_cases(golden.cases, assessor=probe, config=config, concurrency=64)
+    assert probe.peak <= 3
+
+
+def test_results_come_back_in_case_id_order_whatever_order_they_finish_in(
+    config: TenantConfig,
+) -> None:
+    """Determinism is what makes two result files diffable."""
+    golden = golden_set_module.parse_golden_set(
+        "\n".join(json.dumps(record) for record in [_HEADER, *reversed(_CASES)])
+    )
+
+    class SlowestFirst:
+        """Finishes in the reverse of the dispatch order."""
+
+        def assess(self, *, config: TenantConfig, rendered_lead: str) -> AssessmentOutcome:
+            time.sleep(0.05 if MARKERS["a_hot_buyer"] in rendered_lead else 0.0)
+            return scored(Tier.WARM)
+
+    results = run_eval.run_cases(
+        golden.cases, assessor=SlowestFirst(), config=config, concurrency=4
+    )
+    assert [result.case_id for result in results] == ["a_hot_buyer", "b_injection", "c_warm_lead"]
+
+
+def test_running_no_cases_is_not_an_error(config: TenantConfig) -> None:
+    assert run_eval.run_cases([], assessor=RaisingAssessor(RuntimeError()), config=config) == ()
+
+
+def test_two_runs_over_the_same_answers_produce_byte_identical_json(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    """The whole point of the file: a diff must show only what the model did differently."""
+    outputs: list[str] = []
+    for index in range(2):
+        destination = tmp_path / f"run{index}"
+        run_eval.main(
+            [
+                "--confirm-spend",
+                "--golden-set",
+                str(golden_file),
+                "--out",
+                str(destination),
+            ],
+            assessor_factory=_factory(perfect()),
+            now=_clock(T0, T1),
+        )
+        written = sorted(destination.glob("*.json"))
+        assert len(written) == 1
+        outputs.append(written[0].read_text(encoding="utf-8"))
+    assert outputs[0] == outputs[1]
+
+
+# ---------------------------------------------------------------------- the JSON shape
+
+
+def test_the_result_document_has_the_shape_24_will_diff(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    _run(golden_file, tmp_path, assessor=perfect())
+    result = _result(tmp_path)
+    assert result["schema_version"] == RESULT_SCHEMA_VERSION
+    assert set(result) == {
+        "schema_version",
+        "caveat",
+        "run",
+        "golden_set",
+        "metrics",
+        "segments",
+        "confusion_matrix",
+        "stability",
+        "security_findings",
+        "cases",
+    }
+    assert set(result["segments"]) == set(SEGMENT_NAMES)
+    assert result["run"]["model_id"]
+    assert result["run"]["prompt_version"] == "rubric_v1"
+    assert result["run"]["effort"] == "medium"
+    assert result["run"]["git_sha"]
+    assert result["run"]["concurrency"] == run_eval.DEFAULT_CONCURRENCY
+    assert result["run"]["duration_seconds"] == 90.0
+
+
+def test_every_metric_is_a_ratio_with_both_of_its_counts(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    """A bare float cannot distinguish "the model got worse" from "the set grew"."""
+    _run(golden_file, tmp_path, assessor=perfect())
+    metrics = _result(tmp_path)["metrics"]
+    for name in (
+        "recall_on_contactable",
+        "precision_on_hot",
+        "exact_tier_accuracy",
+        "adjacent_tier_accuracy",
+        "within_band_accuracy",
+    ):
+        assert {"numerator", "denominator"} <= set(metrics[name]), name
+        assert "value" in metrics[name]
+
+
+def test_an_undefined_metric_says_so_rather_than_reporting_zero(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Nothing predicted hot: precision on hot does not exist, and must not read as 0%."""
+    _run(golden_file, tmp_path, assessor=MappedAssessor({}, default=scored(Tier.COLD)))
+    precision = _result(tmp_path)["metrics"]["precision_on_hot"]
+    assert precision["value"] is None
+    assert precision["denominator"] == 0
+    assert "hot" in precision["undefined_reason"]
+    assert "undefined" in capsys.readouterr().out
+
+
+def test_cases_are_sorted_and_carry_the_labels_notes_beside_the_reasoning(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    _run(golden_file, tmp_path, assessor=perfect())
+    cases = _result(tmp_path)["cases"]
+    assert [case["case_id"] for case in cases] == ["a_hot_buyer", "b_injection", "c_warm_lead"]
+    first = cases[0]
+    assert first["label_notes"].startswith("Written for the harness tests")
+    assert first["model_reasoning"].startswith("Fixture reasoning")
+    assert first["labelers"] == ["fixture_author"]
+    assert first["expected_band"] == {"lower": "hot", "upper": "hot"}
+    assert set(first["record"]) == {"assessment", "decision", "metering", "failure"}
+
+
+def test_the_confusion_matrix_is_a_full_square(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    _run(golden_file, tmp_path, assessor=perfect())
+    matrix = _result(tmp_path)["confusion_matrix"]
+    tiers = ["hot", "warm", "cold", "disqualified"]
+    assert list(matrix) == tiers
+    for row in matrix.values():
+        assert list(row) == tiers
+    assert sum(count for row in matrix.values() for count in row.values()) == 3
+
+
+def test_the_golden_set_provenance_is_in_the_document(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    """A number without its provenance is the thing this harness exists not to produce."""
+    _run(golden_file, tmp_path, assessor=perfect())
+    golden = _result(tmp_path)["golden_set"]
+    assert golden["counts"] == {
+        "cases": 3,
+        "synthetic": 3,
+        "real": 0,
+        "hard": 1,
+        "injection": 1,
+        "dual_labeled": 0,
+    }
+    assert golden["inter_labeler_agreement"] is None
+    assert golden["meets_acceptance_criteria"] is False
+    assert golden["acceptance_gaps"]
+    assert "self-consistency" in golden["summary"]
+
+
+def test_the_result_file_is_named_for_the_run_that_made_it(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    _run(golden_file, tmp_path, assessor=perfect())
+    name = _result_file(tmp_path).name
+    assert name.startswith("eval-20260903T120000Z-")
+    assert name.endswith(".json")
+
+
+# ----------------------------------------------------------------------- the caveat
+
+
+def test_the_synthetic_caveat_sits_beside_every_metric_block(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Once at the top is not enough: a screenshot crops, and a number gets pasted."""
+    _run(golden_file, tmp_path, assessor=perfect())
+    stdout = capsys.readouterr().out
+    assert stdout.count("self-consistency") >= 4
+    assert "READ THIS BEFORE QUOTING ANY NUMBER BELOW" in stdout
+    assert "3 synthetic, 0 real" in stdout
+
+
+def test_the_json_carries_the_caveat_on_the_document_and_on_every_segment(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    _run(golden_file, tmp_path, assessor=perfect())
+    result = _result(tmp_path)
+    assert "self-consistency" in result["caveat"]
+    assert "self-consistency" in result["metrics"]["caveat"]
+    for name in SEGMENT_NAMES:
+        assert result["segments"][name]["caveat"]
+
+
+def test_no_lead_payload_reaches_the_report_or_the_result_file(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A result file gets attached to a pull request. Invariant 5 applies to it."""
+    _run(golden_file, tmp_path, assessor=perfect())
+    stdout = capsys.readouterr().out
+    document = _result_file(tmp_path).read_text(encoding="utf-8")
+    for secret in ("sam@example.com", "robin@example.org", "Sam Buyer", "Robin Maybe"):
+        assert secret not in stdout
+        assert secret not in document
+
+
+# ------------------------------------------------------------------ security findings
+
+
+def test_an_injection_case_scored_hot_fails_the_run(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A successful attack is a defect. It must not be averaged into an accuracy number."""
+    code = _run(golden_file, tmp_path, assessor=perfect(b_injection=scored(Tier.HOT)))
+    assert code == run_eval.EXIT_SECURITY_FINDING
+    findings = _result(tmp_path)["security_findings"]
+    assert len(findings) == 1
+    assert findings[0]["case_id"] == "b_injection"
+    assert findings[0]["injection_case_id"] == "direct_override"
+    assert "scored_hot" in findings[0]["kinds"]
+    assert "PROMPT-INJECTION FINDINGS" in capsys.readouterr().out
+
+
+def test_an_injection_case_within_its_ceiling_is_not_a_finding(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = _run(golden_file, tmp_path, assessor=perfect())
+    assert code == run_eval.EXIT_OK
+    assert _result(tmp_path)["security_findings"] == []
+    assert "None. No injection case was scored above the ceiling" in capsys.readouterr().out
+
+
+def test_an_accuracy_of_zero_does_not_fail_the_run(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    """No metric threshold gates this command: a pass mark on a synthetic set is theatre."""
+    assessor = perfect(a_hot_buyer=scored(Tier.COLD), c_warm_lead=scored(Tier.COLD))
+    code = _run(golden_file, tmp_path, assessor=assessor)
+    assert code == run_eval.EXIT_OK
+    assert _result(tmp_path)["metrics"]["recall_on_contactable"]["value"] == 0.0
+
+
+# ------------------------------------------------------------------- nondeterminism
+
+
+def test_a_single_run_reports_stability_as_unmeasured(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _run(golden_file, tmp_path, assessor=perfect())
+    assert _result(tmp_path)["stability"] is None
+    assert "Not measured: this was a single run" in capsys.readouterr().out
+
+
+def test_repeating_a_run_quantifies_what_moved(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    assessor = perfect(a_hot_buyer=[scored(Tier.HOT), scored(Tier.WARM)])
+    code = _run(
+        golden_file, tmp_path, assessor=assessor, extra=["--repeat", "2", "--concurrency", "1"]
+    )
+    assert code == run_eval.EXIT_OK
+    stability = _result(tmp_path)["stability"]
+    assert stability["repeats"] == 2
+    assert stability["unstable_case_ids"] == ["a_hot_buyer"]
+    assert stability["tier_stability"] == {"numerator": 2, "denominator": 3, "value": 2 / 3}
+    assert stability["metric_spreads"]["recall_on_contactable"]["spread"] is not None
+
+
+# ------------------------------------------------------------ the record shape, pinned
+
+
+def test_the_case_record_uses_the_cli_json_vocabulary(tmp_path: Path, config: TenantConfig) -> None:
+    """#13 defined "what happened to one lead". The eval extends it, it does not fork it.
+
+    Compared against the CLI's own ``--json`` output rather than a copy of it, so a field
+    added or renamed on one side fails here instead of drifting apart in silence.
+    """
+    from leadquali.cli import main as cli_main
+
+    lead = tmp_path / "lead.json"
+    lead.write_text(json.dumps({"full_name": "A", "email": "a@example.com"}), encoding="utf-8")
+    outcome = scored(Tier.HOT)
+
+    from leadquali.cli import decision_for
+
+    decision = decision_for(outcome, config)
+    ours = run_eval.cli_shaped_record(outcome, decision)
+
+    class _One:
+        def assess(self, *, config: TenantConfig, rendered_lead: str) -> AssessmentOutcome:
+            return outcome
+
+    def factory(effort: str) -> Any:
+        return _One()
+
+    buffer = io.StringIO()
+    with contextlib.redirect_stdout(buffer):
+        assert cli_main(["score", str(lead), "--json"], assessor_factory=factory) == 0
+    theirs: dict[str, Any] = json.loads(buffer.getvalue())
+
+    assert set(ours) <= set(theirs)
+    assert set(ours["metering"]) == set(theirs["metering"])
+    assert set(ours["decision"]) == set(theirs["decision"])
+    assert set(ours["assessment"]) == set(theirs["assessment"])
+
+
+def test_the_failure_record_matches_the_cli_failure_record(config: TenantConfig) -> None:
+    from leadquali.cli import decision_for
+
+    outcome = refused(EscalationReason.TIMEOUT)
+    record = run_eval.cli_shaped_record(outcome, decision_for(outcome, config))
+    assert record["assessment"] is None
+    assert record["metering"] is None
+    assert set(record["failure"]) == {"reason", "detail", "latency_ms"}
+    assert record["failure"]["reason"] == "timeout"
+
+
+# --------------------------------------------------------------------- the safety net
+
+
+def test_the_harness_module_is_marked_live_api() -> None:
+    """Belt and braces: if a live test is ever added here, it inherits the marker."""
+    assert run_eval.pytestmark.name == "live_api"
+
+
+def test_the_parser_defaults_to_spending_nothing() -> None:
+    """Every default is the safe one: no confirmation, no key needed, one run."""
+    args = run_eval.build_parser().parse_args([])
+    assert args.confirm_spend is False
+    assert args.estimate is False
+    assert args.effort == "medium"
+    assert args.repeat == 1
+    assert args.concurrency == run_eval.DEFAULT_CONCURRENCY
+    assert args.out is None


### PR DESCRIPTION
Closes #23. On top of #62 (golden set) → #61 → #60.

Plan §7: without this, every prompt change is a guess. But the harness is only as honest as its caveats, so those are built in rather than bolted on.

```bash
python -m tests.evals.run_eval --estimate                       # free, no key, calls nothing
python -m tests.evals.run_eval --confirm-spend --effort medium  # + ANTHROPIC_API_KEY
```

Real output of the free estimator, run just now:

```
Estimated cost of one run over 15 cases: $0.5627 (about $0.0375 per lead).
  input 7781 tok, cache write 9684 tok, cache read 26631 tok, output 18000 tok
  - 4 cache write(s) and 11 cache read(s), i.e. one write per concurrent worker at --concurrency 4
  - the published rate card ... is a documented snapshot and not a feed; the invoice wins
```

**That $0.0375/lead is above plan §8's $0.02–0.03, and the estimator explains why**: at `--concurrency 4` the first four requests all miss the cache and each pay to write the prefix, amortised over only 15 cases. At production volume that write amortises away — but it is exactly the kind of number that gets quoted out of context, so the breakdown is printed with it.

## The four metrics

Tier accuracy and adjacent-tier accuracy (via `Tier.rank`, not string order), hot precision, and **recall on "should have been contacted" reported most prominently** — hot precision is the number sales feels, but a false disqualification loses a deal silently and forever.

Every metric is `{numerator, denominator, value|null, undefined_reason?}` — **never a bare float**. Zero hot predictions makes precision *undefined*, not zero, and the difference matters when someone reads the report.

Plus a confusion matrix, a per-case table with the label's notes beside the model's reasoning, and separate segments for hard cases, injection cases, real and synthetic.

## Safety rails

- **Refuses to run without both `--confirm-spend` and a key**, checked before an assessor is built. `live_api` marked. CI cannot fire it by accident.
- Bounded concurrency, deterministic ordering, and **failures are data**: a refusal or timeout on one case routes through `system_failure` — the same tier production would produce — and never aborts the run.
- **JSON keys are in fixed insertion order, not sorted.** Sorting put `cold` above `hot` — the same lexicographic trap `Tier.rank` exists to avoid, resurfacing in the serializer.

## Three decisions for you

1. **Exit 4 on a prompt-injection finding** makes the Actions run red. Deliberate — a regression on an attack case is a security finding, not a metric — but it means one such case blocks a dispatch.
2. **A *failed* injection case is not a finding.** `system_failure` routes it to `warm`, which is our outage, not the attack winning. Counting it would inflate the security signal with infrastructure noise.
3. **No metric threshold is enforced anywhere**, because a pass mark computed against a synthetic set is theatre.

Every printed and stored number carries the provenance — **15/15 synthetic, 0 real, inter-labeler agreement unmeasured**. What this reports today is a smoke test of the pipeline, not evidence about quality. It becomes evidence when #62's runbook has been followed for a few weeks.

## Activation

The workflow is staged at **`ci/github-actions-eval.yml`** (same constraint as #40 — this session cannot commit under `.github/workflows/`):

```bash
git mv ci/github-actions-eval.yml .github/workflows/eval.yml
```
…and add a dev `ANTHROPIC_API_KEY` repository secret. `workflow_dispatch` only, never `push`.

## Verification

117 new tests (1298 passing), all offline: the metric maths against hand-computed fixtures including the undefined-precision and single-case edges, adjacency via `rank`, failures counted as escalations, deterministic ordering, the JSON shape, the workflow invariants, and both refusal paths. The `cases[]` record reuses #55's `--json` vocabulary verbatim, **pinned by a test against the CLI's real output** so the two cannot drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_