### PR TITLE
[P3.3] Effort sweep, result diff, and the noise floor that qualifies both

### DIFF
--- a/docs/rubric-tuning.md
+++ b/docs/rubric-tuning.md
@@ -1,0 +1,258 @@
+# Tuning the rubric, and choosing an effort level
+
+**Audience:** whoever owns the ICP definition and the prompt (default D3:
+`aron@vendoworks.com`).
+**Files you will touch:** `src/leadquali/prompts/rubric_vN.md`, `tenants/<tenant>.json`.
+**Tools:** `tests/evals/sweep.py`, `tests/evals/diff_results.py`, `tests/evals/run_eval.py`.
+
+This is the procedure for changing the rubric or the effort level *and being able to say
+what the change did*. Labeling the golden set is a different job with its own runbook —
+[`labeling-golden-set.md`](labeling-golden-set.md), from #62 — and this document does not
+repeat it. Read §0 of that file before you read any number in this one.
+
+---
+
+## 0. The one thing to understand before tuning anything
+
+The golden set is **fifteen synthetic cases, written and labeled by the same person, with
+inter-labeler agreement unmeasured.** Two consequences, and they are not caveats, they are
+the operating conditions:
+
+> **Tuning a rubric against a self-labeled synthetic set optimises the model for agreement
+> with the person who wrote the cases.** It does not optimise it for revenue. Every point
+> of "accuracy" you win is a point of closer agreement with one person's guess about what a
+> good lead looks like — and if that guess is wrong, tuning makes the product worse while
+> the dashboard goes up.
+
+> **Fifteen cases cannot resolve a difference smaller than one case.** One case is 6.7
+> percentage points. A proportion measured over fifteen items takes only the values `k/15`,
+> so a "three-point improvement" does not exist, and a one-case difference between two
+> effort levels is a coin flip with a number printed beside it.
+
+The tools enforce both. Every report carries the synthetic caveat next to every metric
+block, and every difference is printed beside the smallest difference the set could have
+detected. When nothing clears that floor the report says, verbatim:
+
+```
+This golden set cannot distinguish these effort levels.
+```
+
+That sentence is the honest output of this procedure today, and it is a result, not a
+failure. Act on it by growing the golden set, not by picking the cheaper level anyway.
+
+### What the current set can and cannot see
+
+| Question | Answer at 15 cases |
+|---|---|
+| Smallest representable difference | **6.7pp** — one case |
+| Stated minimum detectable difference | **13.3pp** — two cases (see below) |
+| Cases needed to resolve 5pp | 20 |
+| Cases needed to resolve 2pp | 50 — the acceptance target in #62 |
+| p95 latency | The **slowest single call**. Nearest-rank p95 selects the maximum for any set under 20 cases, so "p95" is a max wearing a percentile's name |
+| Inter-labeler agreement | Unmeasured. There is one labeler |
+
+The **minimum detectable difference is a stated convention, not a significance test.** It
+is `MIN_MEANINGFUL_CASES` (two) times the resolution, raised to the observed run-to-run
+spread whenever `--repeat` measured one. Two cases is chosen because one case is the
+resolution limit *and* is exactly what an unchanged prompt moves between two repeats — the
+model samples, and a lead near a threshold lands either side of it. There is deliberately
+no p-value anywhere in this toolchain: fifteen leads invented by one person have no
+sampling model that would justify one, and an unjustifiable test that says `p < 0.05` is
+more dangerous than no test at all. A stated floor and a measured spread are defensible,
+and they are what the tools report.
+
+---
+
+## 1. Changing the rubric
+
+The rubric is `src/leadquali/prompts/rubric_v1.md`, served as the cached prefix of every
+call. **The text of a released version never changes.** A revision is a new file:
+
+1. `cp src/leadquali/prompts/rubric_v1.md src/leadquali/prompts/rubric_v2.md` and edit the
+   copy.
+2. Bump `PROMPT_VERSION` in `src/leadquali/prompts/rubric.py` to `"rubric_v2"`.
+3. Bump `prompt_version` in every `tenants/*.json` that should move to it. A tenant pinned
+   to a version this build does not ship is refused at render time rather than silently
+   served the new text (`rubric.py` checks it), so a tenant can be held back deliberately.
+
+**Why the version must be bumped rather than the file edited in place.** Every result file
+records the `prompt_version` the run used, and `diff_results.py` prints it as attribution
+on any comparison. Edit `rubric_v1.md` in place and last Tuesday's result file still says
+`rubric_v1` — so the diff shows two runs of "the same prompt" that were not the same
+prompt, and the tool cannot warn you, because nothing in the artifacts records that
+anything changed. The version string is the only thing that makes an old result file
+comparable to a new one. Bumping it is not bookkeeping; it is the entire basis of the
+comparison.
+
+The same rule applies to what is *inside* the cached prefix. Anything volatile there — a
+timestamp, a lead-specific string — breaks prompt caching, which changes the cost of every
+run for reasons that have nothing to do with the rubric. See §4.
+
+---
+
+## 2. The loop
+
+```bash
+# 0. See the price before spending it. Needs no key, calls nothing.
+python -m tests.evals.sweep --estimate
+
+# 1. Measure the current state. Two repeats, so the noise floor is measured
+#    rather than assumed.
+python -m tests.evals.sweep --confirm-spend --repeat 2
+
+# 2. Change one thing: the rubric text, a weight, a threshold, min_confidence.
+#    One thing. Two changes and a moved number attributes to neither.
+
+# 3. Re-measure at the level you actually ship.
+python -m tests.evals.run_eval --confirm-spend --effort medium --repeat 2
+
+# 4. Compare the two saved result files. Free: no key, no calls, no spend.
+python -m tests.evals.diff_results \
+    tests/evals/results/eval-<before>.json \
+    tests/evals/results/eval-<after>.json
+```
+
+Step 4 is the point of the artifacts. "Did last Tuesday's prompt change make things worse?"
+is a question about two files you have already paid for; re-running the eval to answer it
+is paying twice for evidence you already own.
+
+### Deciding
+
+Read the diff in this order, and stop at the first line that answers you.
+
+1. **Injection findings.** A `security_findings` entry is a defect, not a metric. An attack
+   payload tiered `hot` fails the change regardless of what accuracy did. Exit code 4.
+2. **Recall on contactable.** The number that costs money: leads a human said should have
+   been called, that the pipeline surfaced. Every miss is a deal nobody called.
+3. **`LOST` cases.** Named individually in the diff. Read the label's notes beside the
+   model's reasoning — often the label is wrong, and the correct fix is to the golden set.
+4. **Everything else,** and only if the verdict line says the difference cleared the noise
+   floor. `within noise` means the measurement was not sensitive enough to answer the
+   question. It does **not** mean the change was neutral.
+
+`diff_results.py` exits `1` only on a regression larger than the floor, so it is safe to
+gate a pull request on — the gate cannot fire on a coin flip.
+
+---
+
+## 3. The effort sweep
+
+```bash
+python -m tests.evals.sweep --estimate                     # the bill, per level and total
+python -m tests.evals.sweep --confirm-spend --repeat 2     # three runs, one comparison
+python -m tests.evals.sweep --confirm-spend --effort low --effort medium --baseline medium
+```
+
+The sweep runs `run_eval` once per level through the `assessor_factory` seam — the same
+harness, three assessors — writes one result file per level, and compares those files. It
+prints accuracy, cost per lead and p95 latency side by side, the delta of every metric
+against the baseline level (`medium`, the incumbent), and a verdict.
+
+It refuses to start without both `--confirm-spend` and `ANTHROPIC_API_KEY`, and the price
+in the refusal is the sweep's, not one run's: a sweep is three times the cost, and the
+number you are asked to confirm should be the number you pay.
+
+**The sweep will not name a winner while the golden set holds no real cases.** Whatever the
+numbers say, and even when a difference clears the floor, the recommendation is:
+
+```
+No effort level is recommended from this run.
+```
+
+This is deliberate and it is not a bug to be worked around. See §0. The gate opens when
+`real_cases > 0` *and* some difference clears the noise floor; then it names the cheapest
+level with no meaningful regression against the baseline, and says which metrics decided
+it.
+
+### The comparison table this issue asks for
+
+| Metric | `low` | `medium` | `high` |
+|---|---|---|---|
+| Exact tier accuracy | not measured | not measured | not measured |
+| Precision on `hot` | not measured | not measured | not measured |
+| Recall on contactable | not measured | not measured | not measured |
+| Cost per lead | not measured | not measured | not measured |
+| p95 latency | not measured | not measured | not measured |
+| `cache_read_tokens` > 0 | not measured | not measured | not measured |
+
+**These cells are empty because no live sweep has been run.** There is no Anthropic API key
+in the environment this tooling was built in, and the sweep deliberately has no offline
+mode: a number produced without calling the model would measure nothing and would end up
+quoted as though it had. The measurement — and the "pick the cheapest effort that holds
+accuracy" decision it feeds — is the owner's to execute, **once the golden set has real
+cases in it**, per #62. Running the sweep against the synthetic seed first is still worth
+doing as a smoke test of the pipeline and a real cost figure; it is not worth doing as a
+basis for choosing an effort level.
+
+Fill the table in by running the sweep and pasting the numbers, and record the sweep's
+`sweep-*.json` path beside it so the row can be traced to an artifact.
+
+---
+
+## 4. Before drawing any cost conclusion: check the cache
+
+`cache_read_tokens` must be **greater than zero** across a run. Every result file records
+it per case (`record.metering.cache_read_tokens`). If it is zero, prompt caching is not
+working: something volatile has leaked into the cached prefix, every call is paying full
+input price, and every cost number in the sweep is wrong in the same direction.
+
+Fix that before comparing costs between effort levels. A cost difference measured with a
+broken cache is a measurement of the bug, not of the effort level.
+
+---
+
+## 5. Setting `min_confidence` from data
+
+`min_confidence` (default `0.6` in `tenants/default.json`) is the threshold below which a
+lead escalates to a human instead of being routed on the model's judgement. It trades two
+costs against each other:
+
+- **Too high:** everything escalates, sales drowns, and the product is a mailing list.
+- **Too low:** mislabels route silently, and invariant 3 — no lead is ever silently dropped
+  — is satisfied only on paper.
+
+Pick it from the recorded numbers rather than by feel. Every result file carries each
+case's `confidence` beside its `status`. The threshold you want is the one where most cases
+that landed `MISS` or `LOST` sit *below* it and most cases that landed `ok` sit above it.
+
+**At fifteen cases you cannot do this yet.** A threshold fitted to fifteen synthetic cases
+is fitted to noise, and it will move the first time a real lead arrives. Leave
+`min_confidence` at its default until the golden set has real cases, then read the
+distribution off a real run.
+
+---
+
+## 6. Recording the outcome
+
+When a revision ships:
+
+1. The new `rubric_vN.md`, with `PROMPT_VERSION` and the tenants' `prompt_version` bumped.
+2. The before and after result files, and the `diff_results` output, attached to the pull
+   request. The numbers in the PR body must carry the synthetic caveat with them — the
+   reports print it beside every metric block precisely so it cannot be cropped out.
+3. The chosen effort level in the default `TenantConfig`, **with the sweep artifact that
+   justifies it**. An effort level in config with no result file behind it is a guess, and
+   `medium` is currently exactly that: a documented starting point (plan §5), not a
+   measurement.
+4. The measured cost per lead into §8 of the implementation plan — from a run with a
+   working cache (§4).
+
+---
+
+## 7. Reference
+
+| Command | Spends? | Purpose |
+|---|---|---|
+| `python -m tests.evals.run_eval --estimate` | no | Price one run |
+| `python -m tests.evals.run_eval --confirm-spend` | **yes** | One run, one result file |
+| `python -m tests.evals.sweep --estimate` | no | Price the whole sweep, per level and total |
+| `python -m tests.evals.sweep --confirm-spend` | **yes** | Every level, one comparison |
+| `python -m tests.evals.diff_results A.json B.json` | no | Compare two saved runs |
+| `python -m tests.evals.diff_results A.json B.json --json` | no | The same, machine-readable |
+
+Exit codes: `0` fine, `1` a regression beyond the noise floor (`diff_results` only), `2` an
+input problem, `3` the run was never authorised, `4` an injection finding.
+
+Related: [`labeling-golden-set.md`](labeling-golden-set.md) (#62) for growing the set,
+[`observability.md`](observability.md) for the metrics the same fields produce in
+production.

--- a/tests/evals/compare.py
+++ b/tests/evals/compare.py
@@ -1,0 +1,1473 @@
+"""Comparing saved eval results: two of them, or one per effort level.
+
+Everything here reads result files that :mod:`tests.evals.run_eval` already wrote. Nothing
+in this module calls a model, needs a key, or costs anything — which is the point. Once a
+run is paid for, "did last Tuesday's prompt change make things worse?" and "does ``low``
+hold up against ``medium``?" are questions about two JSON files, and re-running the eval to
+answer them is paying twice for evidence you already have.
+
+**The statistics are the substance, not a caveat.** The seed golden set is fifteen
+synthetic cases (``docs/labeling-golden-set.md`` §0). A proportion measured over fifteen
+cases moves in steps of ``1/15`` — 6.7 percentage points — so a "3-point improvement"
+cannot exist, and a one-case difference between two effort levels is a coin flip with a
+number printed next to it. This module therefore refuses to report a difference without
+also reporting what difference the set could have detected:
+
+* :attr:`NoiseFloor.resolution_pp` is arithmetic: ``100 / cases``, the finest difference
+  the set can represent at all.
+* :attr:`NoiseFloor.floor_pp` is the *stated* minimum detectable difference:
+  :data:`MIN_MEANINGFUL_CASES` cases, raised to the observed run-to-run spread whenever
+  ``--repeat`` measured one. It is a declared convention, and it is labeled as one
+  everywhere it is printed. **There is no significance test in this module**, because there
+  is no sampling model for "fifteen leads one person invented" that would justify one.
+* Anything at or below that floor is reported as :data:`VERDICT_WITHIN_NOISE`, and a sweep
+  in which every difference lands there reports :data:`VERDICT_INDISTINGUISHABLE` —
+  verbatim, because "this set cannot tell these apart" is the finding.
+
+**Indistinguishable is not equivalent.** Two levels the set cannot separate have not been
+shown to be interchangeable; nothing has been shown. :meth:`SweepComparison.recommendation`
+therefore declines to name a winner in that case, and declines again — whatever the numbers
+say — while the golden set holds no real cases at all, because tuning against a
+self-labeled synthetic set optimises for agreement with its author.
+
+**Two runs are compared, never merged.** A pair of results whose ``prompt_version``,
+``model_id``, ``git_sha`` or golden set differ are two different experiments; the tool
+still compares them, because comparing across a prompt change is the entire use case, but
+every such difference is listed as attribution so that no one reads a single cause into a
+number that has several.
+"""
+
+from __future__ import annotations
+
+import json
+import math
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from decimal import Decimal
+from pathlib import Path
+from typing import Any, Final, Self
+
+from leadquali.app.assessment_result import EFFORT_LEVELS
+from tests.evals.metrics import TAIL_QUANTILE
+from tests.evals.report import HEADLINE_CAVEAT, RESULT_SCHEMA_VERSION
+
+#: Metrics compared between runs, in reporting order: the one that costs money first.
+#: Every one of them is a :class:`~tests.evals.metrics.Ratio` in the result file, so a
+#: delta can always be expressed in whole cases as well as in points.
+COMPARED_METRICS: Final[tuple[str, ...]] = (
+    "recall_on_contactable",
+    "precision_on_hot",
+    "exact_tier_accuracy",
+    "adjacent_tier_accuracy",
+    "within_band_accuracy",
+)
+
+#: How many whole cases must move before a difference is reported as a difference.
+#:
+#: **A stated convention, not a test statistic.** Two is the smallest number that is not a
+#: single case, and a single case is both the resolution limit of the set and precisely
+#: what an unchanged prompt moves between two repeats — ``compute_stability`` exists
+#: because the same lead lands either side of a threshold on consecutive runs. Requiring
+#: two is deliberately conservative: at fifteen cases it means nothing below 13.3 points
+#: is reported as a finding, which is the correct amount of scepticism for a set this
+#: small. It is not a confidence level and must never be quoted as one.
+MIN_MEANINGFUL_CASES: Final[int] = 2
+
+#: The difference is larger than the set's floor: it may be real. "May": the floor says
+#: what the set *cannot* detect, never that what it can detect is causal.
+VERDICT_MEANINGFUL: Final[str] = "meaningful"
+
+#: The difference is at or below the floor. Not "no difference" — no detectable one.
+VERDICT_WITHIN_NOISE: Final[str] = "within noise"
+
+#: One side of the comparison has no number at all (an undefined ratio, an empty segment).
+VERDICT_NOT_COMPARABLE: Final[str] = "not comparable"
+
+#: Printed verbatim when no difference in a sweep clears the floor. This sentence is the
+#: honest output of #24 against the seed set, and it is a constant so that the report, the
+#: JSON and the tests all say exactly the same thing.
+VERDICT_INDISTINGUISHABLE: Final[str] = "This golden set cannot distinguish these effort levels."
+
+#: Printed verbatim whenever the tool declines to name a winner.
+NO_RECOMMENDATION: Final[str] = "No effort level is recommended from this run."
+
+_RULE: Final[str] = "=" * 92
+_THIN: Final[str] = "-" * 92
+
+
+class ComparisonError(ValueError):
+    """A result file cannot be read, or two of them cannot honestly be compared."""
+
+
+# ------------------------------------------------------------------------ result files
+
+
+@dataclass(frozen=True, slots=True)
+class RatioSnapshot:
+    """One metric as it was recorded: the two counts, and why it may not exist.
+
+    A mirror of :class:`~tests.evals.metrics.Ratio` reconstructed from JSON rather than the
+    class itself, because a result file may have been written by an older checkout and a
+    comparison tool that imported the live class would silently acquire whatever that class
+    means today.
+    """
+
+    numerator: int
+    denominator: int
+    undefined_reason: str = ""
+
+    @property
+    def defined(self) -> bool:
+        """Whether there was anything to divide."""
+        return self.denominator > 0
+
+    @property
+    def value(self) -> float | None:
+        """The fraction, or ``None`` when the denominator is zero."""
+        return None if not self.defined else self.numerator / self.denominator
+
+    @property
+    def percent(self) -> float | None:
+        """The fraction in percentage points."""
+        value = self.value
+        return None if value is None else value * 100.0
+
+    @property
+    def text(self) -> str:
+        """One cell: ``86.7% (13/15)``, or the sentence saying why there is no number."""
+        if not self.defined:
+            return f"undefined ({self.undefined_reason or 'nothing to measure'})"
+        return f"{self.numerator / self.denominator:.1%} ({self.numerator}/{self.denominator})"
+
+    def as_json(self) -> dict[str, Any]:
+        """The machine-readable form, matching what the result file carried."""
+        payload: dict[str, Any] = {
+            "numerator": self.numerator,
+            "denominator": self.denominator,
+            "value": self.value,
+        }
+        if not self.defined:
+            payload["undefined_reason"] = self.undefined_reason or "nothing to measure"
+        return payload
+
+
+@dataclass(frozen=True, slots=True)
+class CaseSnapshot:
+    """What one run did with one case. Enough to say what moved, and nothing more."""
+
+    case_id: str
+    expected_tier: str
+    predicted_tier: str
+    status: str
+    exact_match: bool
+    false_disqualification: bool
+    escalated: bool
+    latency_ms: int
+    cost_usd: Decimal
+
+
+@dataclass(frozen=True, slots=True)
+class ResultSnapshot:
+    """One saved eval result, reduced to what a comparison needs.
+
+    ``label`` is how this run is named in reports: the effort level in a sweep, the file
+    name in an ad-hoc diff.
+    """
+
+    label: str
+    source: str
+    schema_version: int
+    started_at: str
+    effort: str
+    model_id: str
+    prompt_version: str
+    tenant_id: str
+    git_sha: str
+    git_dirty: bool
+    repeats: int
+    golden_set_path: str
+    cases_total: int
+    real_cases: int
+    synthetic_cases: int
+    failures: int
+    escalations: int
+    inter_labeler_agreement: float | None
+    metrics: Mapping[str, RatioSnapshot]
+    metric_spreads: Mapping[str, float | None]
+    total_cost_usd: Decimal
+    cost_usd_per_lead: Decimal | None
+    latency_p50_ms: int | None
+    latency_p95_ms: int | None
+    latency_max_ms: int | None
+    security_finding_case_ids: tuple[str, ...]
+    caveat: str
+    cases: Mapping[str, CaseSnapshot]
+
+    @property
+    def effort_rank(self) -> int:
+        """Position in :data:`~leadquali.app.assessment_result.EFFORT_LEVELS`.
+
+        Levels are ordered by spend rather than alphabetically, for the same reason
+        ``Tier`` needed a ``rank``: ``"high" < "low" < "medium"`` as strings, and a sweep
+        table in that order is unreadable.
+        """
+        try:
+            return EFFORT_LEVELS.index(self.effort)
+        except ValueError:
+            return len(EFFORT_LEVELS)
+
+    def as_json(self) -> dict[str, Any]:
+        """The per-level block of a comparison document."""
+        return {
+            "label": self.label,
+            "source": self.source,
+            "effort": self.effort,
+            "started_at": self.started_at,
+            "model_id": self.model_id,
+            "prompt_version": self.prompt_version,
+            "tenant_id": self.tenant_id,
+            "git_sha": self.git_sha,
+            "git_dirty": self.git_dirty,
+            "repeats": self.repeats,
+            "golden_set_path": self.golden_set_path,
+            "cases": self.cases_total,
+            "real_cases": self.real_cases,
+            "synthetic_cases": self.synthetic_cases,
+            "failures": self.failures,
+            "escalations": self.escalations,
+            "inter_labeler_agreement": self.inter_labeler_agreement,
+            "metrics": {name: ratio.as_json() for name, ratio in self.metrics.items()},
+            "total_cost_usd": str(self.total_cost_usd),
+            "cost_usd_per_lead": None
+            if self.cost_usd_per_lead is None
+            else str(self.cost_usd_per_lead),
+            "latency": {
+                "p50_ms": self.latency_p50_ms,
+                "p95_ms": self.latency_p95_ms,
+                "max_ms": self.latency_max_ms,
+            },
+            "security_findings": list(self.security_finding_case_ids),
+            "caveat": self.caveat,
+        }
+
+
+def load_result(path: Path, *, label: str | None = None) -> ResultSnapshot:
+    """Read one result file written by ``run_eval``.
+
+    Args:
+        path: the JSON file.
+        label: how to name this run in reports. Defaults to the file's stem.
+
+    Raises:
+        ComparisonError: the file is not a result document this tool can read.
+        OSError: the file cannot be opened. Deliberately not wrapped — the path is in the
+            message and the caller wants to print it verbatim.
+    """
+    try:
+        payload: object = json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as error:
+        raise ComparisonError(f"{path} is not valid JSON: {error}") from error
+    return parse_result(payload, label=label or path.stem, source=str(path))
+
+
+def parse_result(payload: object, *, label: str, source: str = "<memory>") -> ResultSnapshot:
+    """Turn a decoded result document into a :class:`ResultSnapshot`.
+
+    The schema version is checked before anything else is read. A file written by a
+    different version of :mod:`tests.evals.report` may have moved or redefined any key
+    below, and a comparison built by guessing at it would be confidently wrong — which is
+    worse than no comparison, because someone would act on it.
+
+    Raises:
+        ComparisonError: the document is not an object, carries no ``schema_version``,
+            carries a version this tool does not read, or is missing a required key.
+    """
+    if not isinstance(payload, Mapping):
+        raise ComparisonError(f"{source}: expected a JSON object, got {type(payload).__name__}")
+    version = payload.get("schema_version")
+    if version is None:
+        raise ComparisonError(
+            f"{source}: no schema_version key. This is not an eval result file — "
+            f"run_eval writes one per run into its --out directory."
+        )
+    if version != RESULT_SCHEMA_VERSION:
+        raise ComparisonError(
+            f"{source}: result schema version {version}, but this tool reads version "
+            f"{RESULT_SCHEMA_VERSION}. Keys may have moved between the two, so refusing to "
+            f"compare rather than guessing. Re-run the eval on this checkout, or use the "
+            f"checkout that wrote the file."
+        )
+    run = _mapping(payload, "run", source)
+    metrics = _mapping(payload, "metrics", source)
+    golden = _mapping(payload, "golden_set", source)
+    latency = _mapping(metrics, "latency", source)
+    return ResultSnapshot(
+        label=label,
+        source=source,
+        schema_version=int(version),
+        started_at=_text(run, "started_at", source),
+        effort=_text(run, "effort", source),
+        model_id=_text(run, "model_id", source),
+        prompt_version=_text(run, "prompt_version", source),
+        tenant_id=_text(run, "tenant_id", source),
+        git_sha=_text(run, "git_sha", source),
+        git_dirty=bool(run.get("git_dirty", False)),
+        repeats=int(run.get("repeats", 1)),
+        golden_set_path=_text(run, "golden_set_path", source),
+        cases_total=_number(metrics, "cases", source),
+        real_cases=_number(metrics, "real_cases", source),
+        synthetic_cases=_number(metrics, "synthetic_cases", source),
+        failures=_number(metrics, "failures", source),
+        escalations=_number(metrics, "escalations", source),
+        inter_labeler_agreement=_optional_float(golden.get("inter_labeler_agreement")),
+        metrics={
+            name: _ratio(metrics, name, source) for name in COMPARED_METRICS if name in metrics
+        },
+        metric_spreads=_spreads(payload.get("stability")),
+        total_cost_usd=_decimal(metrics.get("total_cost_usd")) or Decimal(0),
+        cost_usd_per_lead=_decimal(metrics.get("cost_usd_per_lead")),
+        latency_p50_ms=_optional_int(latency.get("p50_ms")),
+        latency_p95_ms=_optional_int(latency.get("p95_ms")),
+        latency_max_ms=_optional_int(latency.get("max_ms")),
+        security_finding_case_ids=_finding_ids(payload.get("security_findings")),
+        caveat=str(payload.get("caveat", "")),
+        cases=_cases(payload.get("cases"), source),
+    )
+
+
+def _mapping(payload: Mapping[str, Any], key: str, source: str) -> Mapping[str, Any]:
+    value = payload.get(key)
+    if not isinstance(value, Mapping):
+        raise ComparisonError(f"{source}: expected an object at {key!r}")
+    return value
+
+
+def _text(payload: Mapping[str, Any], key: str, source: str) -> str:
+    value = payload.get(key)
+    if not isinstance(value, str):
+        raise ComparisonError(f"{source}: expected a string at {key!r}")
+    return value
+
+
+def _number(payload: Mapping[str, Any], key: str, source: str) -> int:
+    value = payload.get(key)
+    if not isinstance(value, int) or isinstance(value, bool):
+        raise ComparisonError(f"{source}: expected an integer at {key!r}")
+    return value
+
+
+def _ratio(payload: Mapping[str, Any], key: str, source: str) -> RatioSnapshot:
+    body = payload.get(key)
+    if not isinstance(body, Mapping):
+        raise ComparisonError(f"{source}: expected a ratio object at {key!r}")
+    numerator = body.get("numerator")
+    denominator = body.get("denominator")
+    if not isinstance(numerator, int) or not isinstance(denominator, int):
+        raise ComparisonError(
+            f"{source}: {key!r} is not a ratio - it must carry integer numerator and "
+            f"denominator, never a bare float"
+        )
+    return RatioSnapshot(numerator, denominator, str(body.get("undefined_reason", "")))
+
+
+def _spreads(stability: object) -> Mapping[str, float | None]:
+    """Per-metric run-to-run spread, as a fraction, from a ``--repeat`` run."""
+    if not isinstance(stability, Mapping):
+        return {}
+    raw = stability.get("metric_spreads")
+    if not isinstance(raw, Mapping):
+        return {}
+    spreads: dict[str, float | None] = {}
+    for name, body in raw.items():
+        spreads[str(name)] = (
+            _optional_float(body.get("spread")) if isinstance(body, Mapping) else None
+        )
+    return spreads
+
+
+def _cases(raw: object, source: str) -> Mapping[str, CaseSnapshot]:
+    if not isinstance(raw, Sequence) or isinstance(raw, str | bytes):
+        raise ComparisonError(f"{source}: expected a list at 'cases'")
+    cases: dict[str, CaseSnapshot] = {}
+    for entry in raw:
+        if not isinstance(entry, Mapping):
+            raise ComparisonError(f"{source}: every entry in 'cases' must be an object")
+        case_id = _text(entry, "case_id", source)
+        cases[case_id] = CaseSnapshot(
+            case_id=case_id,
+            expected_tier=_text(entry, "expected_tier", source),
+            predicted_tier=_text(entry, "predicted_tier", source),
+            status=str(entry.get("status", "")),
+            exact_match=bool(entry.get("exact_match", False)),
+            false_disqualification=bool(entry.get("false_disqualification", False)),
+            escalated=bool(entry.get("escalated", False)),
+            latency_ms=int(entry.get("latency_ms", 0)),
+            cost_usd=_decimal(entry.get("cost_usd")) or Decimal(0),
+        )
+    return cases
+
+
+def _finding_ids(raw: object) -> tuple[str, ...]:
+    if not isinstance(raw, Sequence) or isinstance(raw, str | bytes):
+        return ()
+    return tuple(
+        sorted(
+            str(entry["case_id"])
+            for entry in raw
+            if isinstance(entry, Mapping) and "case_id" in entry
+        )
+    )
+
+
+def _decimal(value: object) -> Decimal | None:
+    if value is None:
+        return None
+    if isinstance(value, Decimal):
+        return value
+    if isinstance(value, str | int):
+        return Decimal(value)
+    if isinstance(value, float):
+        return Decimal(str(value))
+    return None
+
+
+def _optional_float(value: object) -> float | None:
+    return float(value) if isinstance(value, int | float) and not isinstance(value, bool) else None
+
+
+def _optional_int(value: object) -> int | None:
+    return int(value) if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+# ------------------------------------------------------------------------- noise floor
+
+
+@dataclass(frozen=True, slots=True)
+class NoiseFloor:
+    """The smallest difference this set could have detected, and how that was decided.
+
+    Two ingredients, both stated rather than inferred:
+
+    * ``cases`` gives the *resolution*: a proportion over ``n`` cases can only take values
+      ``k/n``, so nothing finer than ``100/n`` points exists to be measured.
+    * ``observed_spread_pp`` is what the same configuration actually did across repeats.
+      When it is present it replaces the convention wherever it is larger, because a
+      measurement of the noise beats an assumption about it.
+    """
+
+    cases: int
+    observed_spread_pp: float | None
+    repeats: int
+
+    @property
+    def resolution_pp(self) -> float | None:
+        """Points per case: the finest difference the set can represent."""
+        return None if self.cases <= 0 else 100.0 / self.cases
+
+    @property
+    def measured(self) -> bool:
+        """Whether ``--repeat`` gave this floor an observed spread to stand on."""
+        return self.observed_spread_pp is not None
+
+    @property
+    def floor_pp(self) -> float | None:
+        """The minimum detectable difference, in percentage points."""
+        resolution = self.resolution_pp
+        if resolution is None:
+            return None
+        stated = MIN_MEANINGFUL_CASES * resolution
+        if self.observed_spread_pp is None:
+            return stated
+        return max(stated, self.observed_spread_pp)
+
+    def is_meaningful(self, delta_pp: float | None) -> bool:
+        """Whether a difference of ``delta_pp`` points clears the floor."""
+        floor = self.floor_pp
+        if delta_pp is None or floor is None:
+            return False
+        return abs(delta_pp) > floor
+
+    def verdict_for(self, delta_pp: float | None) -> str:
+        """:data:`VERDICT_MEANINGFUL`, :data:`VERDICT_WITHIN_NOISE`, or not comparable."""
+        if delta_pp is None or self.floor_pp is None:
+            return VERDICT_NOT_COMPARABLE
+        return VERDICT_MEANINGFUL if self.is_meaningful(delta_pp) else VERDICT_WITHIN_NOISE
+
+    def describe(self) -> str:
+        """One sentence: the floor, and whether anything measured it."""
+        floor = self.floor_pp
+        if floor is None:
+            return "no cases, so this set can detect nothing at all"
+        stated = (
+            f"{floor:.1f}pp minimum detectable difference "
+            f"({MIN_MEANINGFUL_CASES} of {self.cases} cases)"
+        )
+        if self.observed_spread_pp is None:
+            return (
+                f"{stated}; run-to-run spread not measured on a single run - "
+                f"re-run with --repeat 2 or more to measure it"
+            )
+        return (
+            f"{stated}; run-to-run spread {self.observed_spread_pp:.1f}pp "
+            f"measured over {self.repeats} repeats"
+        )
+
+    def as_json(self) -> dict[str, Any]:
+        """The machine-readable form."""
+        return {
+            "cases": self.cases,
+            "resolution_pp": self.resolution_pp,
+            "minimum_meaningful_cases": MIN_MEANINGFUL_CASES,
+            "minimum_detectable_difference_pp": self.floor_pp,
+            "observed_spread_pp": self.observed_spread_pp,
+            "spread_measured": self.measured,
+            "repeats": self.repeats,
+            "description": self.describe(),
+        }
+
+
+def noise_floor(snapshots: Sequence[ResultSnapshot], metric: str) -> NoiseFloor:
+    """The floor for ``metric`` across every run being compared.
+
+    The coarsest resolution and the widest observed spread win: a comparison is only as
+    sensitive as its least sensitive side, and rounding that off would manufacture
+    precision the runs do not have.
+    """
+    if not snapshots:
+        return NoiseFloor(cases=0, observed_spread_pp=None, repeats=1)
+    cases = min(snapshot.cases_total for snapshot in snapshots)
+    spreads = [
+        spread
+        for snapshot in snapshots
+        if (spread := snapshot.metric_spreads.get(metric)) is not None
+    ]
+    return NoiseFloor(
+        cases=cases,
+        observed_spread_pp=max(spreads) * 100.0 if spreads else None,
+        repeats=max(snapshot.repeats for snapshot in snapshots),
+    )
+
+
+def cases_needed_for(difference_pp: float) -> int:
+    """How many cases a set needs before ``difference_pp`` points is representable.
+
+    ``ceil(100 / difference)``. Twenty cases to see five points, fifty to see two. This is
+    the honest answer to "how big does the golden set have to get", and it is arithmetic
+    rather than a power calculation — a power calculation would need an effect size and a
+    variance nobody has measured yet.
+    """
+    if difference_pp <= 0:
+        raise ValueError(f"a difference must be positive, got {difference_pp}")
+    return math.ceil(100.0 / difference_pp)
+
+
+def p95_is_max(cases: int) -> bool:
+    """Whether nearest-rank p95 over ``cases`` samples just returns the slowest one.
+
+    True for any set below twenty cases, which is every set this project has. Worth saying
+    in the report: a "p95 latency" that is really the single worst observation is a much
+    noisier number than the name suggests.
+    """
+    return cases > 0 and math.ceil(TAIL_QUANTILE * cases) >= cases
+
+
+# -------------------------------------------------------------------- comparing two runs
+
+
+@dataclass(frozen=True, slots=True)
+class MetricDelta:
+    """One metric, before and after, with the floor it has to clear to count."""
+
+    name: str
+    baseline: RatioSnapshot
+    candidate: RatioSnapshot
+    noise: NoiseFloor
+
+    @property
+    def comparable(self) -> bool:
+        """Whether both sides produced a number at all."""
+        return self.baseline.defined and self.candidate.defined
+
+    @property
+    def delta_pp(self) -> float | None:
+        """Candidate minus baseline, in percentage points."""
+        before, after = self.baseline.percent, self.candidate.percent
+        if before is None or after is None:
+            return None
+        return after - before
+
+    @property
+    def same_denominator(self) -> bool:
+        """Whether both sides measured the same number of cases."""
+        return self.baseline.denominator == self.candidate.denominator
+
+    @property
+    def delta_cases(self) -> int | None:
+        """Whole cases gained or lost, or ``None`` when the denominators differ.
+
+        ``12/15`` against ``12/16`` is the golden set growing, not the model moving, and a
+        "-3.3 points" headline on that pair is a lie of arithmetic. Points are still
+        reported; cases are withheld, because there is no case count to report.
+        """
+        if not self.same_denominator:
+            return None
+        return self.candidate.numerator - self.baseline.numerator
+
+    @property
+    def meaningful(self) -> bool:
+        """Whether the difference clears the set's minimum detectable difference."""
+        return self.noise.is_meaningful(self.delta_pp)
+
+    @property
+    def regressed(self) -> bool:
+        """Meaningfully worse, not merely worse."""
+        delta = self.delta_pp
+        return self.meaningful and delta is not None and delta < 0
+
+    @property
+    def verdict(self) -> str:
+        """:data:`VERDICT_MEANINGFUL`, :data:`VERDICT_WITHIN_NOISE` or not comparable."""
+        if not self.comparable:
+            return VERDICT_NOT_COMPARABLE
+        return self.noise.verdict_for(self.delta_pp)
+
+    @property
+    def text(self) -> str:
+        """One report line: the movement, in points and in cases, and the verdict."""
+        if not self.comparable:
+            undefined = (
+                self.baseline if not self.baseline.defined else self.candidate
+            ).undefined_reason
+            return f"{self.name:<26} {VERDICT_NOT_COMPARABLE}: {undefined or 'no value'}"
+        delta = self.delta_pp
+        assert delta is not None  # comparable implies both sides have a value
+        cases = (
+            "denominators differ"
+            if self.delta_cases is None
+            else f"{self.delta_cases:+d} case{'' if abs(self.delta_cases) == 1 else 's'}"
+        )
+        return (
+            f"{self.name:<26} {self.baseline.text:>16} -> {self.candidate.text:>16}  "
+            f"{delta:+6.1f}pp ({cases})  {self.verdict}"
+        )
+
+    def as_json(self) -> dict[str, Any]:
+        """The machine-readable form."""
+        return {
+            "name": self.name,
+            "baseline": self.baseline.as_json(),
+            "candidate": self.candidate.as_json(),
+            "delta_pp": self.delta_pp,
+            "delta_cases": self.delta_cases,
+            "comparable": self.comparable,
+            "meaningful": self.meaningful,
+            "regressed": self.regressed,
+            "verdict": self.verdict,
+            "noise_floor": self.noise.as_json(),
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CaseChange:
+    """One case the two runs tiered differently."""
+
+    case_id: str
+    expected_tier: str
+    baseline_tier: str
+    candidate_tier: str
+    baseline_status: str
+    candidate_status: str
+    baseline_exact: bool
+    candidate_exact: bool
+    baseline_lost: bool
+    candidate_lost: bool
+
+    @property
+    def regressed(self) -> bool:
+        """The candidate lost a lead the baseline kept, or missed a label it hit."""
+        return (self.candidate_lost and not self.baseline_lost) or (
+            self.baseline_exact and not self.candidate_exact
+        )
+
+    @property
+    def improved(self) -> bool:
+        """The mirror image."""
+        return (self.baseline_lost and not self.candidate_lost) or (
+            self.candidate_exact and not self.baseline_exact
+        )
+
+    def as_json(self) -> dict[str, Any]:
+        """The machine-readable form."""
+        return {
+            "case_id": self.case_id,
+            "expected_tier": self.expected_tier,
+            "baseline_tier": self.baseline_tier,
+            "candidate_tier": self.candidate_tier,
+            "baseline_status": self.baseline_status,
+            "candidate_status": self.candidate_status,
+            "regressed": self.regressed,
+            "improved": self.improved,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class CaseSetDiff:
+    """Which cases the two runs share, and what moved among the shared ones."""
+
+    shared: tuple[str, ...]
+    only_in_baseline: tuple[str, ...]
+    only_in_candidate: tuple[str, ...]
+    changes: tuple[CaseChange, ...]
+
+    @property
+    def comparable(self) -> bool:
+        """Whether both runs covered exactly the same cases."""
+        return not self.only_in_baseline and not self.only_in_candidate
+
+    @property
+    def regressions(self) -> tuple[CaseChange, ...]:
+        """Shared cases the candidate handled worse."""
+        return tuple(change for change in self.changes if change.regressed)
+
+    @property
+    def improvements(self) -> tuple[CaseChange, ...]:
+        """Shared cases the candidate handled better."""
+        return tuple(change for change in self.changes if change.improved)
+
+    @classmethod
+    def of(cls, baseline: ResultSnapshot, candidate: ResultSnapshot) -> Self:
+        """Diff two runs' case sets, sorted by ``case_id`` throughout."""
+        before, after = baseline.cases, candidate.cases
+        shared = tuple(sorted(set(before) & set(after)))
+        return cls(
+            shared=shared,
+            only_in_baseline=tuple(sorted(set(before) - set(after))),
+            only_in_candidate=tuple(sorted(set(after) - set(before))),
+            changes=tuple(
+                CaseChange(
+                    case_id=case_id,
+                    expected_tier=before[case_id].expected_tier,
+                    baseline_tier=before[case_id].predicted_tier,
+                    candidate_tier=after[case_id].predicted_tier,
+                    baseline_status=before[case_id].status,
+                    candidate_status=after[case_id].status,
+                    baseline_exact=before[case_id].exact_match,
+                    candidate_exact=after[case_id].exact_match,
+                    baseline_lost=before[case_id].false_disqualification,
+                    candidate_lost=after[case_id].false_disqualification,
+                )
+                for case_id in shared
+                if before[case_id].predicted_tier != after[case_id].predicted_tier
+            ),
+        )
+
+    def as_json(self) -> dict[str, Any]:
+        """The machine-readable form."""
+        return {
+            "shared": list(self.shared),
+            "only_in_baseline": list(self.only_in_baseline),
+            "only_in_candidate": list(self.only_in_candidate),
+            "comparable": self.comparable,
+            "changes": [change.as_json() for change in self.changes],
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class Comparison:
+    """Two runs, compared: metric deltas, case movement, and what else changed."""
+
+    baseline: ResultSnapshot
+    candidate: ResultSnapshot
+    metrics: tuple[MetricDelta, ...]
+    cases: CaseSetDiff
+    warnings: tuple[str, ...]
+    noise: NoiseFloor
+
+    @classmethod
+    def of(cls, baseline: ResultSnapshot, candidate: ResultSnapshot) -> Self:
+        """Compare two snapshots. Never refuses: differences are attributed, not hidden."""
+        pair = (baseline, candidate)
+        metrics = tuple(
+            MetricDelta(
+                name=name,
+                baseline=baseline.metrics[name],
+                candidate=candidate.metrics[name],
+                noise=_metric_noise(pair, name),
+            )
+            for name in COMPARED_METRICS
+            if name in baseline.metrics and name in candidate.metrics
+        )
+        return cls(
+            baseline=baseline,
+            candidate=candidate,
+            metrics=metrics,
+            cases=CaseSetDiff.of(baseline, candidate),
+            warnings=_attribution(baseline, candidate),
+            noise=NoiseFloor(
+                cases=min(baseline.cases_total, candidate.cases_total),
+                observed_spread_pp=_widest_spread(pair),
+                repeats=max(baseline.repeats, candidate.repeats),
+            ),
+        )
+
+    def metric(self, name: str) -> MetricDelta:
+        """One delta by name.
+
+        Raises:
+            KeyError: neither run recorded that metric.
+        """
+        for delta in self.metrics:
+            if delta.name == name:
+                return delta
+        raise KeyError(f"{name!r} was not recorded by both runs")
+
+    @property
+    def any_meaningful(self) -> bool:
+        """Whether any metric moved further than the set could have moved by itself."""
+        return any(delta.meaningful for delta in self.metrics)
+
+    @property
+    def meaningful_metrics(self) -> tuple[str, ...]:
+        """Names of the metrics that cleared the floor, in reporting order."""
+        return tuple(delta.name for delta in self.metrics if delta.meaningful)
+
+    @property
+    def regressions(self) -> tuple[str, ...]:
+        """Names of the metrics that are meaningfully *worse* in the candidate."""
+        return tuple(delta.name for delta in self.metrics if delta.regressed)
+
+    @property
+    def cost_per_lead_delta(self) -> Decimal | None:
+        """Candidate cost per lead minus the baseline's, or ``None`` if either is absent."""
+        before, after = self.baseline.cost_usd_per_lead, self.candidate.cost_usd_per_lead
+        return None if before is None or after is None else after - before
+
+    @property
+    def p95_latency_delta_ms(self) -> int | None:
+        """Candidate p95 minus the baseline's, or ``None`` if either is absent."""
+        before, after = self.baseline.latency_p95_ms, self.candidate.latency_p95_ms
+        return None if before is None or after is None else after - before
+
+    @property
+    def verdict(self) -> str:
+        """One line: what, if anything, this comparison established.
+
+        Two different claims, kept apart on purpose. A *rate* that did not move further
+        than the set can resolve is not evidence of anything. An individual case that got
+        worse is still evidence about that case — a lead the pipeline used to keep and now
+        bins is a fact, whatever the denominator says — so it is reported even when the
+        rate it sits inside is noise. Collapsing the two into "no change" is how a real
+        regression gets filed under sampling error.
+        """
+        if self.any_meaningful:
+            headline = (
+                f"Moved beyond the noise floor: {', '.join(self.meaningful_metrics)} "
+                f"({self.noise.describe()})."
+            )
+        else:
+            headline = (
+                f"No metric moved further than this set can resolve "
+                f"({self.noise.describe()}), so no rate here is a finding."
+            )
+        worse = self.cases.regressions
+        if not worse:
+            return headline
+        return (
+            f"{headline} Read the cases anyway: "
+            f"{len(worse)} shared case(s) got worse "
+            f"({', '.join(change.case_id for change in worse)}). A single case is evidence "
+            f"about that case even when it is not evidence about the rate."
+        )
+
+    def as_json(self) -> dict[str, Any]:
+        """The machine-readable comparison document."""
+        return {
+            "baseline": self.baseline.as_json(),
+            "candidate": self.candidate.as_json(),
+            "noise_floor": self.noise.as_json(),
+            "metrics": [delta.as_json() for delta in self.metrics],
+            "cost_usd_per_lead_delta": None
+            if self.cost_per_lead_delta is None
+            else str(self.cost_per_lead_delta),
+            "p95_latency_delta_ms": self.p95_latency_delta_ms,
+            "cases": self.cases.as_json(),
+            "warnings": list(self.warnings),
+            "any_meaningful": self.any_meaningful,
+            "regressions": list(self.regressions),
+            "verdict": self.verdict,
+            "caveat": HEADLINE_CAVEAT,
+        }
+
+
+def _metric_noise(snapshots: Sequence[ResultSnapshot], metric: str) -> NoiseFloor:
+    """The floor for one metric, sized by that metric's own denominators.
+
+    Precision on hot is measured over the leads predicted hot, which can be three of
+    fifteen; sizing its floor by the whole set would claim a sensitivity it does not have.
+    """
+    denominators = [
+        snapshot.metrics[metric].denominator
+        for snapshot in snapshots
+        if metric in snapshot.metrics and snapshot.metrics[metric].defined
+    ]
+    spreads = [
+        spread
+        for snapshot in snapshots
+        if (spread := snapshot.metric_spreads.get(metric)) is not None
+    ]
+    return NoiseFloor(
+        cases=min(denominators) if denominators else 0,
+        observed_spread_pp=max(spreads) * 100.0 if spreads else None,
+        repeats=max((snapshot.repeats for snapshot in snapshots), default=1),
+    )
+
+
+def _widest_spread(snapshots: Sequence[ResultSnapshot]) -> float | None:
+    spreads = [
+        spread
+        for snapshot in snapshots
+        for name in COMPARED_METRICS
+        if (spread := snapshot.metric_spreads.get(name)) is not None
+    ]
+    return max(spreads) * 100.0 if spreads else None
+
+
+def _attribution(baseline: ResultSnapshot, candidate: ResultSnapshot) -> tuple[str, ...]:
+    """Everything that differs between two runs besides the numbers.
+
+    A delta caused by three simultaneous changes is not evidence about any one of them.
+    The tool still shows the delta — refusing would make the diff useless exactly when it
+    is needed — but it lists every cause it can see, so nobody attributes the movement to
+    the one change they happen to remember making.
+    """
+    warnings: list[str] = []
+    for field_name, before, after in (
+        ("prompt_version", baseline.prompt_version, candidate.prompt_version),
+        ("model_id", baseline.model_id, candidate.model_id),
+        ("tenant_id", baseline.tenant_id, candidate.tenant_id),
+        ("git_sha", baseline.git_sha, candidate.git_sha),
+        ("effort", baseline.effort, candidate.effort),
+    ):
+        if before != after:
+            warnings.append(
+                f"{field_name} differs: {before} -> {after}. Any movement below is caused "
+                f"by this and by everything else in this list at once."
+            )
+    if baseline.golden_set_path != candidate.golden_set_path:
+        warnings.append(
+            f"golden_set differs: {baseline.golden_set_path} -> {candidate.golden_set_path}. "
+            f"These are two experiments, not two measurements."
+        )
+    for snapshot in (baseline, candidate):
+        if snapshot.git_dirty:
+            warnings.append(
+                f"{snapshot.label} ran from a dirty working tree, so it is not reproducible "
+                f"from git_sha {snapshot.git_sha[:7]} alone."
+            )
+    diff = CaseSetDiff.of(baseline, candidate)
+    if not diff.comparable:
+        warnings.append(
+            f"the case set differs: {len(diff.only_in_baseline)} case(s) only in "
+            f"{baseline.label}, {len(diff.only_in_candidate)} only in {candidate.label}. "
+            f"Metric denominators are therefore not the same population."
+        )
+    if baseline.real_cases == 0 and candidate.real_cases == 0:
+        warnings.append(
+            f"the golden set carries no real leads at all ({baseline.cases_total} synthetic "
+            f"cases): every number here measures agreement with the person who wrote them."
+        )
+    return tuple(warnings)
+
+
+# ------------------------------------------------------------------- comparing a sweep
+
+
+@dataclass(frozen=True, slots=True)
+class Recommendation:
+    """Whether the run supports picking an effort level, and why or why not.
+
+    ``level`` is ``None`` far more often than it is not, and that is the correct behaviour
+    rather than a limitation: naming a winner is a claim about evidence, and most runs of
+    this harness do not have any.
+    """
+
+    level: str | None
+    rationale: str
+
+    def as_json(self) -> dict[str, Any]:
+        """The machine-readable form."""
+        return {"level": self.level, "rationale": self.rationale}
+
+
+@dataclass(frozen=True, slots=True)
+class SweepComparison:
+    """One eval result per effort level, lined up against a baseline level."""
+
+    snapshots: tuple[ResultSnapshot, ...]
+    baseline: ResultSnapshot
+    comparisons: tuple[Comparison, ...]
+    noise: NoiseFloor
+
+    @classmethod
+    def of(cls, snapshots: Sequence[ResultSnapshot], *, baseline: str) -> Self:
+        """Assemble a sweep, ordered by spend.
+
+        Raises:
+            ComparisonError: no snapshots, or the baseline level was not among them —
+                comparing against a level that was never run would silently pick a
+                different reference point than the caller asked for.
+        """
+        if not snapshots:
+            raise ComparisonError("a sweep needs at least one result to compare")
+        ordered = tuple(sorted(snapshots, key=lambda item: (item.effort_rank, item.effort)))
+        reference = next((item for item in ordered if item.effort == baseline), None)
+        if reference is None:
+            ran = ", ".join(item.effort for item in ordered)
+            raise ComparisonError(
+                f"baseline effort {baseline!r} was not one of the levels run ({ran})"
+            )
+        return cls(
+            snapshots=ordered,
+            baseline=reference,
+            comparisons=tuple(
+                Comparison.of(reference, item) for item in ordered if item is not reference
+            ),
+            noise=NoiseFloor(
+                cases=min(item.cases_total for item in ordered),
+                observed_spread_pp=_widest_spread(ordered),
+                repeats=max(item.repeats for item in ordered),
+            ),
+        )
+
+    @property
+    def distinguishable(self) -> bool:
+        """Whether any level differs from the baseline by more than the noise floor."""
+        return any(comparison.any_meaningful for comparison in self.comparisons)
+
+    @property
+    def verdict(self) -> str:
+        """The sentence the whole sweep comes down to."""
+        if not self.distinguishable:
+            return VERDICT_INDISTINGUISHABLE
+        parts = [
+            f"{comparison.candidate.effort} differs from {self.baseline.effort} on "
+            f"{', '.join(comparison.meaningful_metrics)}"
+            for comparison in self.comparisons
+            if comparison.any_meaningful
+        ]
+        return f"Some levels separate on this set: {'; '.join(parts)}."
+
+    def recommendation(self) -> Recommendation:
+        """The cheapest level the evidence supports, or nothing, with the reason.
+
+        Three gates, in order, and the first one that closes ends it:
+
+        1. **No real cases.** Every number came from leads the labeler invented, so the
+           cheapest level "holding accuracy" means the cheapest level that agrees with one
+           person's imagination. Picking on that basis is the failure this issue exists to
+           prevent, and no arrangement of the numbers opens this gate.
+        2. **Nothing separated.** Indistinguishable is not equivalent: the set failed to
+           detect a difference, which is not the same as there being none. Treating it as
+           licence to take the cheapest option is exactly the coin flip.
+        3. Otherwise the cheapest level with no meaningful regression against the
+           baseline, named together with the metrics that decided it.
+        """
+        if self.baseline.real_cases == 0:
+            return Recommendation(
+                level=None,
+                rationale=(
+                    f"{NO_RECOMMENDATION} The golden set holds no real leads - all "
+                    f"{self.baseline.cases_total} cases are synthetic and self-labeled, so "
+                    f"every number above measures agreement with their author. Choosing an "
+                    f"effort level on this evidence optimises for that agreement, not for "
+                    f"revenue. Promote real leads first (docs/labeling-golden-set.md), then "
+                    f"re-run this sweep."
+                ),
+            )
+        if not self.distinguishable:
+            return Recommendation(
+                level=None,
+                rationale=(
+                    f"{NO_RECOMMENDATION} {VERDICT_INDISTINGUISHABLE} "
+                    f"{self.noise.describe()}. Failing to detect a difference is not the "
+                    f"same as showing there is none, so the cheaper level has not been "
+                    f"shown to hold accuracy - it has been shown to be untested. Grow the "
+                    f"set to at least {cases_needed_for(5.0)} cases to resolve 5 points."
+                ),
+            )
+        for snapshot in self.snapshots:
+            if snapshot is self.baseline:
+                return Recommendation(
+                    level=snapshot.effort,
+                    rationale=(
+                        f"{snapshot.effort} is the cheapest level with no meaningful "
+                        f"regression against the baseline."
+                    ),
+                )
+            comparison = self._comparison_for(snapshot.effort)
+            if comparison is not None and not comparison.regressions:
+                return Recommendation(
+                    level=snapshot.effort,
+                    rationale=(
+                        f"{snapshot.effort} is the cheapest level whose metrics show no "
+                        f"regression against {self.baseline.effort} larger than this set "
+                        f"can resolve ({self.noise.describe()}). Metrics that separated: "
+                        f"{', '.join(comparison.meaningful_metrics) or 'none'}."
+                    ),
+                )
+        return Recommendation(
+            level=self.baseline.effort,
+            rationale=(
+                f"every cheaper level regressed meaningfully against "
+                f"{self.baseline.effort}; the baseline stands."
+            ),
+        )
+
+    def _comparison_for(self, effort: str) -> Comparison | None:
+        return next((item for item in self.comparisons if item.candidate.effort == effort), None)
+
+    def as_json(self) -> dict[str, Any]:
+        """The machine-readable sweep document."""
+        return {
+            "baseline_effort": self.baseline.effort,
+            "levels": [snapshot.as_json() for snapshot in self.snapshots],
+            "noise_floor": self.noise.as_json(),
+            "comparisons": [comparison.as_json() for comparison in self.comparisons],
+            "distinguishable": self.distinguishable,
+            "verdict": self.verdict,
+            "recommendation": self.recommendation().as_json(),
+            "caveat": HEADLINE_CAVEAT,
+        }
+
+
+# ------------------------------------------------------------------------- rendering
+
+
+def render_comparison(comparison: Comparison) -> str:
+    """The text a human reads when diffing two saved runs."""
+    baseline, candidate = comparison.baseline, comparison.candidate
+    lines = [
+        _RULE,
+        f"LeadQuali eval diff - {baseline.label} -> {candidate.label}",
+        _RULE,
+        f"baseline   {baseline.label}  effort {baseline.effort}  prompt "
+        f"{baseline.prompt_version}  commit {baseline.git_sha[:7]}  {baseline.started_at}",
+        f"candidate  {candidate.label}  effort {candidate.effort}  prompt "
+        f"{candidate.prompt_version}  commit {candidate.git_sha[:7]}  {candidate.started_at}",
+        "",
+        "READ THIS BEFORE QUOTING ANY NUMBER BELOW",
+        _wrap(HEADLINE_CAVEAT),
+        "",
+        *_resolution_section(comparison.noise),
+        _THIN,
+        "METRIC DELTAS",
+        _THIN,
+    ]
+    lines.extend(f"  {delta.text}" for delta in comparison.metrics)
+    lines.extend(["", *_cost_lines(comparison), "", *_case_section(comparison.cases)])
+    if comparison.warnings:
+        lines.extend([_THIN, "ATTRIBUTION - what else differs between these two runs", _THIN])
+        lines.extend(f"  - {_wrap(warning, indent=4).strip()}" for warning in comparison.warnings)
+        lines.append("")
+    lines.extend([_THIN, "VERDICT", _THIN, _wrap(comparison.verdict, indent=2), ""])
+    return "\n".join(lines) + "\n"
+
+
+def _resolution_section(noise: NoiseFloor) -> list[str]:
+    """What the set could have detected. Printed before any delta, never after."""
+    resolution = noise.resolution_pp
+    stated = None if resolution is None else MIN_MEANINGFUL_CASES * resolution
+    lines = [
+        _THIN,
+        "WHAT THIS SET CAN RESOLVE",
+        _THIN,
+        f"  Cases                               {noise.cases}",
+    ]
+    if resolution is None or stated is None or noise.floor_pp is None:
+        lines.extend(["  No cases, so no difference is detectable at all.", ""])
+        return lines
+    lines.extend(
+        [
+            f"  Smallest representable difference   {resolution:.1f}pp (one case)",
+            f"  Stated minimum detectable difference {stated:.1f}pp ({MIN_MEANINGFUL_CASES} cases)",
+            f"  Effective noise floor               {noise.floor_pp:.1f}pp",
+            f"  {_wrap(noise.describe(), indent=2).strip()}",
+            _wrap(
+                "The floor is a stated convention plus, where it was measured, the observed "
+                "run-to-run spread. It is not a significance test and must never be quoted "
+                "as one: with cases invented and labeled by one person there is no sampling "
+                "model that would justify a p-value.",
+                indent=2,
+            ),
+            _wrap(
+                f"To resolve 5.0pp you would need at least {cases_needed_for(5.0)} cases; "
+                f"2.0pp needs {cases_needed_for(2.0)}.",
+                indent=2,
+            ),
+        ]
+    )
+    if p95_is_max(noise.cases):
+        lines.append(
+            _wrap(
+                f"p95 latency over {noise.cases} cases is the slowest single call, not a "
+                f"tail estimate: nearest-rank p95 selects the maximum at this set size.",
+                indent=2,
+            )
+        )
+    lines.append("")
+    return lines
+
+
+def _cost_lines(comparison: Comparison) -> list[str]:
+    cost = comparison.cost_per_lead_delta
+    latency = comparison.p95_latency_delta_ms
+    return [
+        _THIN,
+        "COST AND LATENCY",
+        _THIN,
+        f"  cost per lead              {_money(comparison.baseline.cost_usd_per_lead):>16} -> "
+        f"{_money(comparison.candidate.cost_usd_per_lead):>16}  "
+        f"{'n/a' if cost is None else f'{cost:+.6f} USD'}",
+        f"  p95 latency                {_ms(comparison.baseline.latency_p95_ms):>16} -> "
+        f"{_ms(comparison.candidate.latency_p95_ms):>16}  "
+        f"{'n/a' if latency is None else f'{latency:+d}ms'}",
+        f"  failures                   {comparison.baseline.failures:>16} -> "
+        f"{comparison.candidate.failures:>16}",
+    ]
+
+
+def _case_section(diff: CaseSetDiff) -> list[str]:
+    lines = [_THIN, "CASES", _THIN]
+    if diff.only_in_baseline:
+        lines.append("  only in the baseline: " + ", ".join(diff.only_in_baseline))
+    if diff.only_in_candidate:
+        lines.append("  only in the candidate: " + ", ".join(diff.only_in_candidate))
+    if not diff.comparable:
+        lines.append(
+            "  the two runs did not cover the same cases, so the metric denominators above"
+        )
+        lines.append("  describe different populations. Compare the shared cases, not the rates.")
+    if not diff.changes:
+        lines.extend([f"  No case changed tier across the {len(diff.shared)} shared cases.", ""])
+        return lines
+    lines.append(f"  {len(diff.changes)} of {len(diff.shared)} shared cases changed tier:")
+    for change in diff.changes:
+        marker = "WORSE" if change.regressed else ("better" if change.improved else "moved")
+        lines.append(
+            f"    {marker:<7}{change.case_id:<40} label {change.expected_tier:<13} "
+            f"{change.baseline_tier} -> {change.candidate_tier}"
+        )
+    lines.append("")
+    return lines
+
+
+def render_sweep(sweep: SweepComparison) -> str:
+    """The one comparison a sweep produces: every level, side by side, with the deltas."""
+    baseline = sweep.baseline
+    labels = [snapshot.effort for snapshot in sweep.snapshots]
+    agreement = (
+        "unmeasured"
+        if baseline.inter_labeler_agreement is None
+        else f"{baseline.inter_labeler_agreement:.2f}"
+    )
+    lines = [
+        _RULE,
+        f"LeadQuali effort sweep - {', '.join(labels)}",
+        _RULE,
+        f"model {baseline.model_id}  prompt {baseline.prompt_version}  tenant "
+        f"{baseline.tenant_id}  commit {baseline.git_sha[:7]}",
+        f"golden set {baseline.golden_set_path}",
+        f"{baseline.cases_total} cases per level "
+        f"({baseline.real_cases} real, {baseline.synthetic_cases} synthetic); "
+        f"inter-labeler agreement {agreement}",
+        "",
+        "READ THIS BEFORE QUOTING ANY NUMBER BELOW",
+        _wrap(HEADLINE_CAVEAT),
+        "",
+        *_resolution_section(sweep.noise),
+        *_level_table(sweep),
+        *_delta_section(sweep, shared=_shared_warnings(sweep)),
+        *_shared_warning_section(_shared_warnings(sweep)),
+        *_verdict_section(sweep),
+    ]
+    return "\n".join(lines) + "\n"
+
+
+def _shared_warnings(sweep: SweepComparison) -> tuple[str, ...]:
+    """Attribution that applies to every level, hoisted out of the per-level blocks.
+
+    "The working tree was dirty" and "the golden set has no real leads" are facts about the
+    sweep, not about ``low``. Repeated under each level they are wallpaper, and wallpaper
+    is what a reader learns to skip.
+    """
+    if not sweep.comparisons:
+        return ()
+    shared = set(sweep.comparisons[0].warnings)
+    for comparison in sweep.comparisons[1:]:
+        shared &= set(comparison.warnings)
+    return tuple(warning for warning in sweep.comparisons[0].warnings if warning in shared)
+
+
+def _shared_warning_section(warnings: Sequence[str]) -> list[str]:
+    if not warnings:
+        return []
+    lines = [_THIN, "ATTRIBUTION - true of every level in this sweep", _THIN]
+    lines.extend(f"  - {_wrap(warning, indent=4).strip()}" for warning in warnings)
+    lines.append("")
+    return lines
+
+
+def _level_table(sweep: SweepComparison) -> list[str]:
+    width = 18
+    header = "".join(
+        f"{snapshot.effort + ('*' if snapshot is sweep.baseline else ''):>{width}}"
+        for snapshot in sweep.snapshots
+    )
+    lines = [_THIN, "EFFORT LEVELS SIDE BY SIDE", _THIN, f"  {'metric':<28}{header}"]
+    for name in COMPARED_METRICS:
+        if not all(name in snapshot.metrics for snapshot in sweep.snapshots):
+            continue
+        cells = "".join(f"{snapshot.metrics[name].text:>{width}}" for snapshot in sweep.snapshots)
+        lines.append(f"  {name:<28}{cells}")
+    rows: tuple[tuple[str, Callable[[ResultSnapshot], str]], ...] = (
+        ("cost per lead", lambda item: _money(item.cost_usd_per_lead)),
+        ("total spend", lambda item: _money(item.total_cost_usd)),
+        ("p95 latency", lambda item: _ms(item.latency_p95_ms)),
+        ("p50 latency", lambda item: _ms(item.latency_p50_ms)),
+        ("failures", lambda item: str(item.failures)),
+        ("escalations", lambda item: str(item.escalations)),
+        ("injection findings", lambda item: str(len(item.security_finding_case_ids))),
+    )
+    for label, render in rows:
+        cells = "".join(f"{render(snapshot):>{width}}" for snapshot in sweep.snapshots)
+        lines.append(f"  {label:<28}{cells}")
+    lines.extend([f"  * baseline ({sweep.baseline.effort})", ""])
+    return lines
+
+
+def _delta_section(sweep: SweepComparison, *, shared: Sequence[str] = ()) -> list[str]:
+    lines = [_THIN, f"DIFFERENCE FROM {sweep.baseline.effort}", _THIN]
+    if not sweep.comparisons:
+        lines.extend(
+            [
+                "  Only one level was run, so there is nothing to compare it against.",
+                "",
+            ]
+        )
+        return lines
+    for comparison in sweep.comparisons:
+        lines.append(f"  {comparison.candidate.effort}")
+        lines.extend(f"    {delta.text}" for delta in comparison.metrics)
+        cost = comparison.cost_per_lead_delta
+        latency = comparison.p95_latency_delta_ms
+        lines.append(
+            f"    {'cost per lead':<26} "
+            f"{'n/a' if cost is None else f'{cost:+.6f} USD per lead'}"
+            f"{'' if cost is None else f' ({_percent_change(comparison)})'}"
+        )
+        lines.append(f"    {'p95 latency':<26} {'n/a' if latency is None else f'{latency:+d}ms'}")
+        moved = comparison.cases.changes
+        lines.append(
+            f"    {'cases that moved tier':<26} "
+            + (", ".join(change.case_id for change in moved) if moved else "none")
+        )
+        for warning in comparison.warnings:
+            if warning.startswith("effort differs"):
+                continue  # effort is the variable under test, not a confounder
+            if warning in shared:
+                continue  # reported once for the whole sweep instead
+            lines.append(f"    ! {_wrap(warning, indent=6).strip()}")
+        lines.append("")
+    return lines
+
+
+def _verdict_section(sweep: SweepComparison) -> list[str]:
+    recommendation = sweep.recommendation()
+    lines = [_THIN, "VERDICT", _THIN, _wrap(sweep.verdict, indent=2), ""]
+    if not sweep.distinguishable:
+        lines.extend(
+            [
+                _wrap(
+                    "Every difference above is at or below what this set moves by itself. "
+                    "That is a statement about the set, not about the model: it means the "
+                    "measurement was not sensitive enough to answer the question, so no "
+                    "effort level has been shown better or worse than any other here.",
+                    indent=2,
+                ),
+                "",
+            ]
+        )
+    lines.extend(
+        [
+            "  RECOMMENDATION",
+            _wrap(recommendation.rationale, indent=2),
+            "",
+        ]
+    )
+    if recommendation.level is not None:
+        lines.extend([f"  Suggested effort level: {recommendation.level}", ""])
+    return lines
+
+
+def _percent_change(comparison: Comparison) -> str:
+    before = comparison.baseline.cost_usd_per_lead
+    after = comparison.candidate.cost_usd_per_lead
+    if before is None or after is None or before == 0:
+        return "n/a"
+    return f"{(after - before) / before * 100:+.1f}%"
+
+
+def _money(value: Decimal | None) -> str:
+    return "n/a" if value is None else f"${value:.6f}"
+
+
+def _ms(value: int | None) -> str:
+    return "n/a" if value is None else f"{value}ms"
+
+
+def _wrap(text: str, *, indent: int = 0, width: int = 92) -> str:
+    """Wrap prose to the report width, matching ``tests.evals.report``."""
+    prefix = " " * indent
+    words = text.split()
+    if not words:
+        return prefix
+    lines: list[str] = []
+    current = prefix
+    for word in words:
+        candidate = f"{current}{word}" if current == prefix else f"{current} {word}"
+        if len(candidate) > width and current != prefix:
+            lines.append(current)
+            current = f"{prefix}{word}"
+        else:
+            current = candidate
+    lines.append(current)
+    return "\n".join(lines)
+
+
+__all__ = [
+    "COMPARED_METRICS",
+    "MIN_MEANINGFUL_CASES",
+    "NO_RECOMMENDATION",
+    "VERDICT_INDISTINGUISHABLE",
+    "VERDICT_MEANINGFUL",
+    "VERDICT_NOT_COMPARABLE",
+    "VERDICT_WITHIN_NOISE",
+    "CaseChange",
+    "CaseSetDiff",
+    "CaseSnapshot",
+    "Comparison",
+    "ComparisonError",
+    "MetricDelta",
+    "NoiseFloor",
+    "RatioSnapshot",
+    "Recommendation",
+    "ResultSnapshot",
+    "SweepComparison",
+    "cases_needed_for",
+    "load_result",
+    "noise_floor",
+    "p95_is_max",
+    "parse_result",
+    "render_comparison",
+    "render_sweep",
+]

--- a/tests/evals/diff_results.py
+++ b/tests/evals/diff_results.py
@@ -1,0 +1,101 @@
+"""``python -m tests.evals.diff_results BEFORE.json AFTER.json`` — diff two saved runs.
+
+"Did last Tuesday's prompt change make things worse?" is a question about two files that
+have already been paid for. This command answers it without calling anything: no API key,
+no network, no spend, no ``--confirm-spend``, because there is nothing to confirm.
+
+What it prints is deliberately not just a pair of numbers. Against fifteen synthetic cases
+a one-case difference is 6.7 points of nothing, so every delta is reported beside the
+minimum difference the set could have detected, and anything at or below that floor is
+labeled :data:`~tests.evals.compare.VERDICT_WITHIN_NOISE`. See
+:mod:`tests.evals.compare` for why there is no significance test here.
+
+Exit codes are meant for a pull-request check:
+
+* :data:`EXIT_OK` — compared, and nothing moved further than the set can resolve.
+* :data:`EXIT_MEANINGFUL_REGRESSION` — a metric got meaningfully worse. Not "a number went
+  down": a number went down by more than this set moves on its own.
+* :data:`EXIT_INPUT_ERROR` — the files could not be read or cannot honestly be compared.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections.abc import Sequence
+from pathlib import Path
+from typing import Final
+
+from tests.evals.compare import (
+    Comparison,
+    ComparisonError,
+    load_result,
+    render_comparison,
+)
+from tests.evals.run_eval import EXIT_INPUT_ERROR, EXIT_OK
+
+#: A headline metric fell by more than the noise floor. Non-zero so a CI check can gate on
+#: it — and only ever raised above the floor, so the gate cannot fire on a coin flip.
+EXIT_MEANINGFUL_REGRESSION: Final[int] = 1
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The command line. Two result files in, one comparison out."""
+    parser = argparse.ArgumentParser(
+        prog="python -m tests.evals.diff_results",
+        description=(
+            "Compare two eval result files written by run_eval. Reads saved artifacts "
+            "only: no API key, no network, no spend."
+        ),
+        epilog=(
+            "Differences at or below the golden set's noise floor are reported as noise, "
+            "not as findings. Read docs/rubric-tuning.md before acting on either."
+        ),
+    )
+    parser.add_argument("baseline", type=Path, help="The earlier result file.")
+    parser.add_argument("candidate", type=Path, help="The result file to judge against it.")
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="as_json",
+        help="Emit the comparison as JSON on stdout instead of the text report.",
+    )
+    parser.add_argument(
+        "--label-baseline", default=None, help="Name for the baseline run in the report."
+    )
+    parser.add_argument(
+        "--label-candidate", default=None, help="Name for the candidate run in the report."
+    )
+    return parser
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    """Compare two result files. Returns the process exit code."""
+    args = build_parser().parse_args(list(sys.argv[1:] if argv is None else argv))
+    try:
+        baseline = load_result(args.baseline, label=args.label_baseline)
+        candidate = load_result(args.candidate, label=args.label_candidate)
+    except (OSError, ComparisonError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    comparison = Comparison.of(baseline, candidate)
+    if args.as_json:
+        print(json.dumps(comparison.as_json(), indent=2))
+    else:
+        print(render_comparison(comparison), end="")
+    return EXIT_MEANINGFUL_REGRESSION if comparison.regressions else EXIT_OK
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via the module entry point
+    raise SystemExit(main())
+
+
+__all__ = [
+    "EXIT_INPUT_ERROR",
+    "EXIT_MEANINGFUL_REGRESSION",
+    "EXIT_OK",
+    "build_parser",
+    "main",
+]

--- a/tests/evals/sweep.py
+++ b/tests/evals/sweep.py
@@ -1,0 +1,551 @@
+"""``python -m tests.evals.sweep --confirm-spend`` — the effort sweep (plan §5, §8).
+
+#24 asks a measurement question: ``effort: "medium"`` was a starting point, so what do
+``low``, ``medium`` and ``high`` actually cost, and does accuracy hold when you go
+cheaper? This module answers it by running :func:`tests.evals.run_eval.main` once per
+level and comparing the result files it wrote.
+
+**There is no second evaluation loop here, on purpose.** #23 left an ``assessor_factory``
+seam precisely so a sweep could vary the assessor without re-implementing the harness, and
+this module is what that seam was for: it passes the same factory to the same ``main``
+three times with a different ``--effort`` and a different ``--out``. Everything after that
+is arithmetic over saved JSON, which means the sweep can only ever report something a
+later ``diff_results`` of the same files would also report, and that a level's numbers are
+reproducible from an artifact rather than from this process's memory.
+
+**A sweep is three runs, so it costs three times as much.** ``--estimate`` prints the
+whole bill per level and in total, needs no key, and calls nothing. Without
+``--confirm-spend`` *and* an ``ANTHROPIC_API_KEY`` the command refuses before it builds a
+single assessor, and the number in the refusal is the sweep's price, not one run's.
+
+**The comparison is honest about what it cannot say.** Fifteen synthetic cases resolve
+differences no finer than one case — 6.7 points — so a level that scores one case better
+has not been shown to be better at all. See :mod:`tests.evals.compare` for the noise
+floor, and ``docs/rubric-tuning.md`` for what to do with the output. The one thing this
+tool will not do is name a cheapest-that-holds-accuracy winner off a synthetic set: that
+is the decision #24 exists to inform, and it needs real labeled leads under it first.
+"""
+
+from __future__ import annotations
+
+import argparse
+import contextlib
+import io
+import json
+import sys
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from decimal import Decimal
+from pathlib import Path
+from typing import Final
+
+import pytest
+
+from leadquali.adapters.tenant_config_json import (
+    DEFAULT_TENANT_ID,
+    JsonFileTenantConfigLoader,
+    default_tenants_dir,
+)
+from leadquali.app.assessment_result import DEFAULT_EFFORT, EFFORT_LEVELS, Effort
+from leadquali.config import get_settings
+from leadquali.domain.tenant_config import TenantConfig, TenantConfigError
+from tests.evals.compare import (
+    ComparisonError,
+    SweepComparison,
+    load_result,
+    render_sweep,
+)
+from tests.evals.golden_set import GOLDEN_LEADS_PATH, GoldenSet, load_golden_set
+from tests.evals.run_eval import (
+    DEFAULT_ASSUMED_OUTPUT_TOKENS,
+    DEFAULT_CONCURRENCY,
+    EXIT_INPUT_ERROR,
+    EXIT_OK,
+    EXIT_REFUSED,
+    EXIT_SECURITY_FINDING,
+    AssessorFactory,
+    CostEstimate,
+    estimate_cost,
+)
+from tests.evals.run_eval import main as run_eval_main
+
+#: Billable, exactly like #23's harness. Nothing here is collected today, and this is the
+#: guard for the day somebody renames the file: ``tests/conftest.py`` keeps ``live_api``
+#: out of the default suite.
+pytestmark = pytest.mark.live_api
+
+#: The three levels #24 names. ``xhigh`` and ``max`` exist and can be swept with repeated
+#: ``--effort`` flags, but they are not in the default sweep: the question on the table is
+#: whether the *cheapest* level holds, and paying for two levels above the incumbent to
+#: answer it is money spent in the wrong direction.
+DEFAULT_SWEEP_EFFORTS: Final[tuple[Effort, ...]] = ("low", "medium", "high")
+
+#: The level everything is compared against: the incumbent default, so the deltas answer
+#: "may I move off medium?" rather than "how do these three rank among themselves?".
+DEFAULT_BASELINE: Final[Effort] = DEFAULT_EFFORT
+
+#: Where the sweep writes, when ``--out`` is not given. Git-ignored like #23's results.
+DEFAULT_SWEEP_DIR: Final[Path] = Path(__file__).resolve().parent / "results" / "sweeps"
+
+
+# --------------------------------------------------------------------------- estimating
+
+
+@dataclass(frozen=True, slots=True)
+class SweepEstimate:
+    """What the whole sweep will cost, per level and in total, before spending anything."""
+
+    per_level: Mapping[str, CostEstimate]
+    repeat: int
+
+    @property
+    def total_cost_usd(self) -> Decimal:
+        """Every level, multiplied by ``--repeat``."""
+        return sum((level.cost_usd for level in self.per_level.values()), Decimal(0)) * self.repeat
+
+    @property
+    def levels(self) -> int:
+        """How many effort levels this sweep would run."""
+        return len(self.per_level)
+
+    def render(self) -> str:
+        """The text printed by ``--estimate``."""
+        first = next(iter(self.per_level.values()), None)
+        cases = 0 if first is None else first.cases
+        lines = [
+            f"Estimated cost of a sweep over {self.levels} effort level(s) x {cases} cases "
+            f"x {self.repeat} repeat(s):",
+        ]
+        for effort, estimate in self.per_level.items():
+            lines.append(
+                f"  {effort:<8} ${estimate.cost_usd * self.repeat:.4f} "
+                f"(${estimate.cost_usd:.4f} per repeat, "
+                f"~${estimate.cost_usd / max(estimate.cases, 1):.4f} per lead)"
+            )
+        lines.append(f"  {'TOTAL':<8} ${self.total_cost_usd:.4f}")
+        shown_for = next(iter(self.per_level), "-")
+        lines.append(
+            f"This is an estimate, not a quote. It assumes (shown for {shown_for}; the "
+            f"input side is identical at every level, since the prompts are):"
+        )
+        assumptions = list(first.assumptions) if first is not None else []
+        assumptions.append(
+            "the same assumed output-token count at every effort level, which overstates "
+            "low and understates high - thinking tokens are billed as output and are "
+            "exactly what effort buys. Re-estimate with --assumed-output-tokens once one "
+            "real run has told you the true figure for a level."
+        )
+        lines.extend(f"  - {assumption}" for assumption in assumptions)
+        return "\n".join(lines)
+
+
+def load_inputs(
+    golden_set: Path | None, tenant: str, tenants_dir: Path | None
+) -> tuple[GoldenSet, TenantConfig]:
+    """Load the golden set and the tenant config a sweep will run against.
+
+    Raises:
+        OSError, ValueError, TenantConfigError: the same failures ``run_eval`` reports, and
+            reported here first so a sweep fails before its first billable call rather
+            than a third of the way through.
+    """
+    golden = load_golden_set(golden_set)
+    config = JsonFileTenantConfigLoader(tenants_dir or default_tenants_dir()).get(tenant)
+    return golden, config
+
+
+def estimate_sweep(
+    golden: GoldenSet,
+    config: TenantConfig,
+    *,
+    efforts: Sequence[Effort],
+    concurrency: int = DEFAULT_CONCURRENCY,
+    repeat: int = 1,
+    output_tokens_per_case: int = DEFAULT_ASSUMED_OUTPUT_TOKENS,
+) -> SweepEstimate:
+    """Price the sweep by pricing each level with #23's own estimator."""
+    return SweepEstimate(
+        per_level={
+            effort: estimate_cost(
+                golden,
+                config,
+                effort=effort,
+                concurrency=concurrency,
+                output_tokens_per_case=output_tokens_per_case,
+            )
+            for effort in efforts
+        },
+        repeat=repeat,
+    )
+
+
+# ------------------------------------------------------------------------ running levels
+
+
+@dataclass(frozen=True, slots=True)
+class LevelRun:
+    """One effort level's run: where its result landed and what the harness printed."""
+
+    effort: Effort
+    exit_code: int
+    result_path: Path
+    report: str
+
+
+def run_level(
+    effort: Effort,
+    *,
+    arguments: Sequence[str],
+    out_dir: Path,
+    assessor_factory: AssessorFactory | None,
+    now: Callable[[], datetime] | None,
+) -> LevelRun:
+    """Run #23's harness once at ``effort`` and return where it wrote its result.
+
+    Each level gets its own ``--out`` directory. Result files are named for the instant the
+    run started, and three levels started in the same second would otherwise collide on one
+    filename — losing two thirds of a sweep that has already been paid for.
+
+    Raises:
+        ComparisonError: the harness reported success but left no result file behind.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    captured = io.StringIO()
+    with contextlib.redirect_stdout(captured):
+        code = run_eval_main(
+            [*arguments, "--effort", effort, "--out", str(out_dir)],
+            assessor_factory=assessor_factory,
+            now=now,
+        )
+    written = sorted(out_dir.glob("eval-*.json"))
+    if not written and code in {EXIT_OK, EXIT_SECURITY_FINDING}:
+        raise ComparisonError(
+            f"the {effort} run reported success but wrote no result file into {out_dir}"
+        )
+    return LevelRun(
+        effort=effort,
+        exit_code=code,
+        # Latest by name is latest by start time: the filename leads with the timestamp.
+        result_path=written[-1] if written else out_dir,
+        report=captured.getvalue(),
+    )
+
+
+# ------------------------------------------------------------------------------- the CLI
+
+
+def build_parser() -> argparse.ArgumentParser:
+    """The command line. ``--confirm-spend`` is required for any run that calls the API."""
+    parser = argparse.ArgumentParser(
+        prog="python -m tests.evals.sweep",
+        description=(
+            "Run the golden set at each effort level and compare accuracy, cost and p95 "
+            "latency side by side. Makes one billable model call per case per level."
+        ),
+        epilog=(
+            "The seed golden set is entirely synthetic, and fifteen cases cannot resolve "
+            "a difference finer than one case. Read docs/rubric-tuning.md before acting "
+            "on anything this prints."
+        ),
+    )
+    parser.add_argument(
+        "--confirm-spend",
+        action="store_true",
+        help=(
+            "Required. Acknowledges one billable model call per golden case per effort "
+            "level. Without it nothing is called. Use --estimate to see the price first."
+        ),
+    )
+    parser.add_argument(
+        "--estimate",
+        action="store_true",
+        help="Print the estimated cost of the whole sweep and exit. Calls nothing.",
+    )
+    parser.add_argument(
+        "--effort",
+        action="append",
+        dest="efforts",
+        default=None,
+        help=(
+            f"An effort level to sweep; repeat the flag for more. Default: "
+            f"{', '.join(DEFAULT_SWEEP_EFFORTS)}. Known levels: {', '.join(EFFORT_LEVELS)}."
+        ),
+    )
+    parser.add_argument(
+        "--baseline",
+        default=DEFAULT_BASELINE,
+        help=f"The level every other level is compared against (default: {DEFAULT_BASELINE}).",
+    )
+    parser.add_argument(
+        "--tenant",
+        default=DEFAULT_TENANT_ID,
+        help=f"Tenant whose rubric to apply (default: {DEFAULT_TENANT_ID}).",
+    )
+    parser.add_argument(
+        "--tenants-dir", type=Path, default=None, help="Directory of tenant config files."
+    )
+    parser.add_argument(
+        "--golden-set",
+        type=Path,
+        default=None,
+        help=f"Golden set to run (default: {GOLDEN_LEADS_PATH}).",
+    )
+    parser.add_argument(
+        "--concurrency",
+        type=int,
+        default=DEFAULT_CONCURRENCY,
+        help=f"In-flight model calls per level (default: {DEFAULT_CONCURRENCY}).",
+    )
+    parser.add_argument(
+        "--repeat",
+        type=int,
+        default=1,
+        help=(
+            "Repeats per level. Two or more measures the run-to-run spread, which is what "
+            "turns the noise floor from a stated convention into a measured number. "
+            "Multiplies the cost by the same factor."
+        ),
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=None,
+        help=f"Directory for the per-level results and the comparison (default: "
+        f"{DEFAULT_SWEEP_DIR}).",
+    )
+    parser.add_argument(
+        "--per-level-report",
+        action="store_true",
+        help="Also print each level's full eval report, not only the comparison.",
+    )
+    parser.add_argument(
+        "--assumed-output-tokens",
+        type=int,
+        default=DEFAULT_ASSUMED_OUTPUT_TOKENS,
+        help=f"Output tokens per call assumed by --estimate (default: "
+        f"{DEFAULT_ASSUMED_OUTPUT_TOKENS}).",
+    )
+    return parser
+
+
+def main(
+    argv: Sequence[str] | None = None,
+    *,
+    assessor_factory: AssessorFactory | None = None,
+    now: Callable[[], datetime] | None = None,
+) -> int:
+    """Run the sweep. Returns the process exit code.
+
+    ``assessor_factory`` and ``now`` are handed straight to #23's ``main`` for each level,
+    which is what makes the whole sweep testable offline with assessors scripted per
+    effort level.
+    """
+    parser = build_parser()
+    args = parser.parse_args(list(sys.argv[1:] if argv is None else argv))
+
+    try:
+        efforts = _checked_efforts(args.efforts)
+        baseline = _checked_baseline(args.baseline, efforts)
+        golden, config = load_inputs(args.golden_set, args.tenant, args.tenants_dir)
+        _check_bounds(args.concurrency, args.repeat)
+    except (OSError, ValueError, TenantConfigError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    estimate = estimate_sweep(
+        golden,
+        config,
+        efforts=efforts,
+        concurrency=args.concurrency,
+        repeat=args.repeat,
+        output_tokens_per_case=args.assumed_output_tokens,
+    )
+    if args.estimate:
+        print(estimate.render())
+        return EXIT_OK
+
+    refusal = _refuse_unless_authorised(args.confirm_spend, estimate)
+    if refusal is not None:
+        print(refusal, file=sys.stderr)
+        return EXIT_REFUSED
+
+    out_dir = args.out or DEFAULT_SWEEP_DIR
+    shared = _harness_arguments(args)
+    runs: list[LevelRun] = []
+    try:
+        for effort in efforts:
+            run = run_level(
+                effort,
+                arguments=shared,
+                out_dir=out_dir / effort,
+                assessor_factory=assessor_factory,
+                now=now,
+            )
+            if run.exit_code not in {EXIT_OK, EXIT_SECURITY_FINDING}:
+                print(run.report, file=sys.stderr)
+                print(f"error: the {effort} run failed; abandoning the sweep", file=sys.stderr)
+                return run.exit_code
+            runs.append(run)
+    except ComparisonError as error:
+        print(f"error: {error}", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    if args.per_level_report:
+        for run in runs:
+            print(run.report, end="")
+
+    try:
+        snapshots = [load_result(run.result_path, label=run.effort) for run in runs]
+        sweep = SweepComparison.of(snapshots, baseline=baseline)
+    except (OSError, ComparisonError) as error:
+        print(f"error: {error}", file=sys.stderr)
+        return EXIT_INPUT_ERROR
+
+    print(render_sweep(sweep), end="")
+    destination = write_sweep(sweep, runs, out_dir, (now or _utc_now)())
+    print(f"Sweep comparison written to {destination}")
+    return (
+        EXIT_SECURITY_FINDING
+        if any(run.exit_code == EXIT_SECURITY_FINDING for run in runs)
+        else EXIT_OK
+    )
+
+
+def write_sweep(
+    sweep: SweepComparison, runs: Sequence[LevelRun], directory: Path, at: datetime
+) -> Path:
+    """Write the comparison document, with a pointer to each level's own result file."""
+    directory.mkdir(parents=True, exist_ok=True)
+    payload = {
+        **sweep.as_json(),
+        "result_files": {run.effort: str(run.result_path) for run in runs},
+    }
+    destination = directory / f"sweep-{at.strftime('%Y%m%dT%H%M%SZ')}.json"
+    destination.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+    return destination
+
+
+def _harness_arguments(args: argparse.Namespace) -> list[str]:
+    """The flags every level's run shares. ``--effort`` and ``--out`` are added per level."""
+    arguments = [
+        "--confirm-spend",
+        "--tenant",
+        args.tenant,
+        "--concurrency",
+        str(args.concurrency),
+        "--repeat",
+        str(args.repeat),
+        "--assumed-output-tokens",
+        str(args.assumed_output_tokens),
+    ]
+    if args.tenants_dir is not None:
+        arguments += ["--tenants-dir", str(args.tenants_dir)]
+    if args.golden_set is not None:
+        arguments += ["--golden-set", str(args.golden_set)]
+    return arguments
+
+
+def _refuse_unless_authorised(confirmed: bool, estimate: SweepEstimate) -> str | None:
+    """The message to print, or ``None`` when the sweep may proceed.
+
+    The headline number is the sweep's, not one run's: somebody who has seen "$0.30" for a
+    single run and types the sweep command is about to spend three times that, and the
+    figure they are asked to confirm has to be the one they will pay.
+    """
+    missing: list[str] = []
+    if not confirmed:
+        missing.append(
+            "--confirm-spend was not given: this makes one billable model call per golden "
+            "case per effort level"
+        )
+    if not _api_key_present():
+        missing.append(
+            "ANTHROPIC_API_KEY is not set: the sweep calls the real API, and there is no "
+            "offline mode that would produce a meaningful number"
+        )
+    if not missing:
+        return None
+    return (
+        f"refusing to run a {estimate.levels} effort level sweep "
+        f"(about ${estimate.total_cost_usd:.2f} in total):\n"
+        + "\n".join(f"  - {reason}" for reason in missing)
+        + "\n\nRun with --estimate to see the full breakdown without calling anything."
+    )
+
+
+def _api_key_present() -> bool:
+    try:
+        get_settings().require_anthropic_api_key()
+    except RuntimeError:
+        return False
+    return True
+
+
+def _checked_efforts(raw: Sequence[str] | None) -> tuple[Effort, ...]:
+    """Validate the requested levels and order them by spend.
+
+    Raises:
+        ValueError: an unknown level, or the same level twice — a sweep that ran ``low``
+            twice would report a difference between a level and itself as if it were a
+            comparison.
+    """
+    requested: list[str] = [str(item) for item in (raw if raw else DEFAULT_SWEEP_EFFORTS)]
+    unknown = [effort for effort in requested if effort not in EFFORT_LEVELS]
+    if unknown:
+        raise ValueError(
+            f"unknown effort level(s) {', '.join(repr(item) for item in unknown)}; "
+            f"expected one of {', '.join(EFFORT_LEVELS)}"
+        )
+    duplicates = sorted({item for item in requested if requested.count(item) > 1})
+    if duplicates:
+        raise ValueError(
+            f"effort level(s) {', '.join(repr(item) for item in duplicates)} requested more "
+            f"than once; each level is run exactly once"
+        )
+    levels: list[Effort] = [effort for effort in EFFORT_LEVELS if effort in requested]
+    return tuple(levels)
+
+
+def _checked_baseline(baseline: str, efforts: Sequence[Effort]) -> Effort:
+    """The baseline must be a level the sweep actually runs."""
+    if baseline not in efforts:
+        raise ValueError(
+            f"baseline effort {baseline!r} is not among the levels being swept "
+            f"({', '.join(efforts)}); add it with --effort {baseline} or pick another baseline"
+        )
+    return baseline  # type: ignore[return-value]  # membership in efforts proves the Literal
+
+
+def _check_bounds(concurrency: int, repeat: int) -> None:
+    if concurrency < 1:
+        raise ValueError(f"--concurrency must be at least 1, got {concurrency}")
+    if repeat < 1:
+        raise ValueError(f"--repeat must be at least 1, got {repeat}")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+if __name__ == "__main__":  # pragma: no cover - exercised via `python -m tests.evals.sweep`
+    raise SystemExit(main())
+
+
+__all__ = [
+    "DEFAULT_BASELINE",
+    "DEFAULT_SWEEP_DIR",
+    "DEFAULT_SWEEP_EFFORTS",
+    "EXIT_INPUT_ERROR",
+    "EXIT_OK",
+    "EXIT_REFUSED",
+    "EXIT_SECURITY_FINDING",
+    "LevelRun",
+    "SweepEstimate",
+    "build_parser",
+    "estimate_sweep",
+    "load_inputs",
+    "main",
+    "run_level",
+    "write_sweep",
+]

--- a/tests/unit/test_eval_compare.py
+++ b/tests/unit/test_eval_compare.py
@@ -1,0 +1,734 @@
+"""Comparing two saved eval results: the maths, the noise floor, and the diff CLI.
+
+Everything here is offline and free. The diff tool exists precisely so that "did last
+Tuesday's prompt change make things worse?" is answerable from artifacts already paid for,
+so a test that needed a key would defeat the point of the module it tests.
+
+The tests are grouped by the mistake they prevent:
+
+1. **Reading two incomparable files as one experiment.** A schema-version mismatch is
+   refused outright; a case present in one run and not the other is reported rather than
+   quietly dropped out of a denominator.
+2. **Calling noise a finding.** The noise floor is asserted from both sides — a difference
+   below it must be reported as indistinguishable, and one above it must not be explained
+   away. This is the substance of #24: at fifteen cases a one-case difference is a coin
+   flip, and a report that presents it as a result gets somebody to pick ``low`` on the
+   strength of one.
+3. **Fabricating a recommendation.** With zero real cases in the golden set the tool must
+   refuse to name a winner, whatever the numbers happen to say.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.evals import compare, diff_results
+from tests.evals.report import RESULT_SCHEMA_VERSION
+
+# --------------------------------------------------------------------- result documents
+
+
+def _ratio(numerator: int, denominator: int, reason: str = "") -> dict[str, Any]:
+    payload: dict[str, Any] = {
+        "numerator": numerator,
+        "denominator": denominator,
+        "value": None if denominator == 0 else numerator / denominator,
+    }
+    if denominator == 0:
+        payload["undefined_reason"] = reason or "nothing to measure"
+    return payload
+
+
+def _case(
+    case_id: str,
+    expected: str,
+    predicted: str,
+    *,
+    status: str = "ok",
+    latency_ms: int = 4000,
+    cost: str = "0.0200",
+    escalated: bool = False,
+) -> dict[str, Any]:
+    return {
+        "case_id": case_id,
+        "provenance": "synthetic",
+        "hard_case": False,
+        "injection_case_id": None,
+        "tags": [],
+        "expected_tier": expected,
+        "expected_band": {"lower": expected, "upper": expected},
+        "predicted_tier": predicted,
+        "status": status,
+        "exact_match": expected == predicted,
+        "adjacent_match": True,
+        "within_band": expected == predicted,
+        "expected_contactable": expected in {"hot", "warm"},
+        "predicted_contactable": predicted in {"hot", "warm"},
+        "false_disqualification": expected in {"hot", "warm"} and predicted not in {"hot", "warm"},
+        "assessed": True,
+        "escalated": escalated,
+        "escalation_reason": None,
+        "expect_escalation": False,
+        "missing_expected_escalation": False,
+        "dimension_range_violations": [],
+        "extracted_mismatches": [],
+        "cost_usd": cost,
+        "latency_ms": latency_ms,
+        "labelers": ["seed_author"],
+        "label_notes": "",
+        "model_reasoning": "",
+        "record": {},
+    }
+
+
+#: Fifteen cases, the size of the shipped seed set, so the arithmetic in these tests is
+#: the arithmetic the owner will actually be reading.
+def _fifteen(exact_hits: int) -> list[dict[str, Any]]:
+    """Fifteen hot-labeled cases, ``exact_hits`` of which the pipeline got right."""
+    return [
+        _case(
+            f"case_{index:02d}",
+            "hot",
+            "hot" if index < exact_hits else "cold",
+            status="ok" if index < exact_hits else "LOST",
+        )
+        for index in range(15)
+    ]
+
+
+def _payload(
+    *,
+    effort: str = "medium",
+    cases: Sequence[Mapping[str, Any]] | None = None,
+    metrics: Mapping[str, tuple[int, int]] | None = None,
+    schema_version: int = RESULT_SCHEMA_VERSION,
+    prompt_version: str = "rubric_v1",
+    model_id: str = "claude-opus-5",
+    git_sha: str = "abc1234def",
+    git_dirty: bool = False,
+    real_cases: int = 0,
+    cost_per_lead: str = "0.020000",
+    p95_ms: int = 5000,
+    stability: Mapping[str, Any] | None = None,
+    golden_set_path: str = "tests/evals/golden_leads.jsonl",
+) -> dict[str, Any]:
+    """A complete result document in ``tests.evals.report.as_json`` shape."""
+    case_list = list(cases if cases is not None else _fifteen(13))
+    total = len(case_list)
+    counts = metrics or {}
+    default = (sum(1 for case in case_list if case["exact_match"]), total)
+    resolved = {
+        name: counts.get(name, default)
+        for name in (
+            "recall_on_contactable",
+            "precision_on_hot",
+            "exact_tier_accuracy",
+            "adjacent_tier_accuracy",
+            "within_band_accuracy",
+        )
+    }
+    return {
+        "schema_version": schema_version,
+        "caveat": "Synthetic set; these numbers measure self-consistency, not correctness.",
+        "run": {
+            "started_at": "2026-09-03T12:00:00+00:00",
+            "finished_at": "2026-09-03T12:02:00+00:00",
+            "duration_seconds": 120.0,
+            "git_sha": git_sha,
+            "git_dirty": git_dirty,
+            "model_id": model_id,
+            "prompt_version": prompt_version,
+            "effort": effort,
+            "tenant_id": "default",
+            "concurrency": 4,
+            "repeats": 1 if stability is None else int(stability["repeats"]),
+            "golden_set_path": golden_set_path,
+        },
+        "golden_set": {
+            "path": golden_set_path,
+            "counts": {"total": total, "real": real_cases, "synthetic": total - real_cases},
+            "inter_labeler_agreement": None,
+            "meets_acceptance_criteria": False,
+            "acceptance_gaps": ["needs 50 real cases"],
+            "summary": "15 synthetic cases, 0 real.",
+        },
+        "metrics": {
+            "name": "all",
+            "cases": total,
+            "synthetic_cases": total - real_cases,
+            "real_cases": real_cases,
+            "assessed": total,
+            "failures": 0,
+            **{name: _ratio(*value) for name, value in resolved.items()},
+            "false_disqualified_case_ids": [],
+            "escalations": 0,
+            "escalations_by_reason": {},
+            "missing_expected_escalations": [],
+            "total_cost_usd": "0.300000",
+            "cost_usd_per_lead": cost_per_lead,
+            "latency": {"p50_ms": 4000, "p95_ms": p95_ms, "max_ms": p95_ms},
+            "caveat": "Every one of these cases is synthetic.",
+        },
+        "segments": {},
+        "confusion_matrix": {},
+        "stability": stability,
+        "security_findings": [],
+        "cases": case_list,
+    }
+
+
+def _stability(repeats: int, spreads: Mapping[str, float | None]) -> dict[str, Any]:
+    return {
+        "repeats": repeats,
+        "tier_stability": _ratio(14, 15),
+        "unstable_case_ids": ["case_14"],
+        "metric_spreads": {
+            name: {"minimum": None, "maximum": None, "spread": spread, "values": []}
+            for name, spread in spreads.items()
+        },
+    }
+
+
+def _write(tmp_path: Path, name: str, payload: Mapping[str, Any]) -> Path:
+    path = tmp_path / name
+    path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    return path
+
+
+# ------------------------------------------------------------------------- loading
+
+
+def test_a_result_document_round_trips_into_a_snapshot() -> None:
+    snapshot = compare.parse_result(_payload(effort="low"), label="low")
+    assert snapshot.effort == "low"
+    assert snapshot.cases_total == 15
+    assert snapshot.real_cases == 0
+    assert snapshot.metrics["exact_tier_accuracy"].numerator == 13
+    assert snapshot.metrics["exact_tier_accuracy"].denominator == 15
+    assert set(snapshot.cases) == {f"case_{index:02d}" for index in range(15)}
+
+
+def test_a_newer_schema_version_is_refused_rather_than_guessed_at() -> None:
+    """The keys may have moved. Reading them anyway would produce a confident wrong diff."""
+    with pytest.raises(compare.ComparisonError) as caught:
+        compare.parse_result(_payload(schema_version=RESULT_SCHEMA_VERSION + 1), label="new")
+    message = str(caught.value)
+    assert str(RESULT_SCHEMA_VERSION + 1) in message
+    assert str(RESULT_SCHEMA_VERSION) in message
+
+
+def test_an_older_schema_version_is_refused_too() -> None:
+    with pytest.raises(compare.ComparisonError):
+        compare.parse_result(_payload(schema_version=RESULT_SCHEMA_VERSION - 1), label="old")
+
+
+def test_a_document_that_is_not_a_result_file_is_rejected_with_the_key_it_wanted() -> None:
+    with pytest.raises(compare.ComparisonError) as caught:
+        compare.parse_result({"hello": "world"}, label="junk")
+    assert "schema_version" in str(caught.value)
+
+
+# ---------------------------------------------------------------------- noise floor
+
+
+def test_the_resolution_floor_is_one_case() -> None:
+    """Arithmetic, not statistics: a proportion over n cases moves in steps of 1/n."""
+    floor = compare.NoiseFloor(cases=15, observed_spread_pp=None, repeats=1)
+    assert floor.resolution_pp == pytest.approx(100 / 15)
+    assert floor.floor_pp == pytest.approx(compare.MIN_MEANINGFUL_CASES * 100 / 15)
+    assert not floor.measured
+
+
+def test_a_one_case_difference_at_fifteen_cases_is_within_noise() -> None:
+    floor = compare.NoiseFloor(cases=15, observed_spread_pp=None, repeats=1)
+    assert not floor.is_meaningful(100 / 15)
+    assert floor.verdict_for(100 / 15) == compare.VERDICT_WITHIN_NOISE
+
+
+def test_a_measured_spread_can_raise_the_floor_above_the_resolution_limit() -> None:
+    """Repeats of an unchanged prompt that move 40pp make a 20pp difference meaningless."""
+    floor = compare.NoiseFloor(cases=15, observed_spread_pp=40.0, repeats=3)
+    assert floor.measured
+    assert floor.floor_pp == pytest.approx(40.0)
+    assert not floor.is_meaningful(20.0)
+    assert floor.is_meaningful(45.0)
+
+
+def test_a_large_difference_is_reported_as_meaningful() -> None:
+    floor = compare.NoiseFloor(cases=100, observed_spread_pp=1.0, repeats=2)
+    assert floor.is_meaningful(20.0)
+    assert floor.verdict_for(20.0) == compare.VERDICT_MEANINGFUL
+
+
+def test_the_floor_describes_itself_including_whether_it_was_measured() -> None:
+    unmeasured = compare.NoiseFloor(cases=15, observed_spread_pp=None, repeats=1).describe()
+    assert "--repeat" in unmeasured
+    assert "not measured" in unmeasured
+    measured = compare.NoiseFloor(cases=15, observed_spread_pp=6.0, repeats=2).describe()
+    assert "not measured" not in measured
+
+
+def test_cases_needed_for_a_target_resolution_is_the_reciprocal() -> None:
+    assert compare.cases_needed_for(6.67) == 15
+    assert compare.cases_needed_for(5.0) == 20
+    assert compare.cases_needed_for(2.0) == 50
+
+
+def test_p95_over_a_small_set_is_the_slowest_case_not_a_tail_estimate() -> None:
+    """Nearest-rank p95 at n<=20 selects the maximum. Worth saying out loud in a report."""
+    assert compare.p95_is_max(15)
+    assert compare.p95_is_max(19)
+    assert not compare.p95_is_max(20)
+
+
+def test_an_empty_set_has_no_resolution_at_all() -> None:
+    floor = compare.NoiseFloor(cases=0, observed_spread_pp=None, repeats=1)
+    assert floor.resolution_pp is None
+    assert not floor.is_meaningful(100.0)
+
+
+def test_the_floor_is_taken_from_the_widest_spread_across_the_runs_compared() -> None:
+    quiet = compare.parse_result(
+        _payload(effort="low", stability=_stability(2, {"exact_tier_accuracy": 0.02})),
+        label="low",
+    )
+    noisy = compare.parse_result(
+        _payload(effort="high", stability=_stability(2, {"exact_tier_accuracy": 0.25})),
+        label="high",
+    )
+    floor = compare.noise_floor([quiet, noisy], "exact_tier_accuracy")
+    assert floor.observed_spread_pp == pytest.approx(25.0)
+    assert floor.floor_pp == pytest.approx(25.0)
+
+
+# ----------------------------------------------------------------------- comparison
+
+
+def test_a_metric_delta_reports_both_percentage_points_and_whole_cases() -> None:
+    baseline = compare.parse_result(
+        _payload(effort="medium", metrics={"exact_tier_accuracy": (13, 15)}), label="medium"
+    )
+    candidate = compare.parse_result(
+        _payload(effort="low", metrics={"exact_tier_accuracy": (10, 15)}), label="low"
+    )
+    comparison = compare.Comparison.of(baseline, candidate)
+    delta = comparison.metric("exact_tier_accuracy")
+    assert delta.delta_cases == -3
+    assert delta.delta_pp == pytest.approx(-20.0)
+
+
+def test_a_one_case_difference_is_reported_as_indistinguishable_not_as_a_regression() -> None:
+    """The whole issue in one assertion."""
+    baseline = compare.parse_result(
+        _payload(effort="medium", metrics={"exact_tier_accuracy": (13, 15)}), label="medium"
+    )
+    candidate = compare.parse_result(
+        _payload(effort="low", metrics={"exact_tier_accuracy": (12, 15)}), label="low"
+    )
+    comparison = compare.Comparison.of(baseline, candidate)
+    delta = comparison.metric("exact_tier_accuracy")
+    assert delta.delta_cases == -1
+    assert not delta.meaningful
+    assert delta.verdict == compare.VERDICT_WITHIN_NOISE
+    assert not comparison.any_meaningful
+
+
+def test_a_difference_above_the_floor_is_not_explained_away() -> None:
+    baseline = compare.parse_result(
+        _payload(effort="medium", metrics={"recall_on_contactable": (15, 15)}), label="medium"
+    )
+    candidate = compare.parse_result(
+        _payload(effort="low", metrics={"recall_on_contactable": (8, 15)}), label="low"
+    )
+    comparison = compare.Comparison.of(baseline, candidate)
+    delta = comparison.metric("recall_on_contactable")
+    assert delta.meaningful
+    assert delta.verdict == compare.VERDICT_MEANINGFUL
+    assert comparison.any_meaningful
+    assert comparison.regressions == ("recall_on_contactable",)
+
+
+def test_an_undefined_metric_on_either_side_is_not_comparable() -> None:
+    """Precision on hot with nothing predicted hot is not zero, and not a delta either."""
+    baseline = compare.parse_result(
+        _payload(effort="medium", metrics={"precision_on_hot": (0, 0)}), label="medium"
+    )
+    candidate = compare.parse_result(
+        _payload(effort="low", metrics={"precision_on_hot": (4, 5)}), label="low"
+    )
+    delta = compare.Comparison.of(baseline, candidate).metric("precision_on_hot")
+    assert delta.delta_pp is None
+    assert delta.verdict == compare.VERDICT_NOT_COMPARABLE
+
+
+def test_different_denominators_report_points_but_refuse_to_count_cases() -> None:
+    """12/15 to 12/16 is the golden set growing, not the model regressing."""
+    baseline = compare.parse_result(
+        _payload(effort="medium", metrics={"exact_tier_accuracy": (12, 15)}), label="medium"
+    )
+    candidate = compare.parse_result(
+        _payload(effort="medium", metrics={"exact_tier_accuracy": (12, 16)}), label="candidate"
+    )
+    delta = compare.Comparison.of(baseline, candidate).metric("exact_tier_accuracy")
+    assert delta.delta_cases is None
+    assert delta.delta_pp is not None
+
+
+def test_cost_and_latency_deltas_are_reported_beside_the_accuracy() -> None:
+    baseline = compare.parse_result(
+        _payload(effort="medium", cost_per_lead="0.020000", p95_ms=5000), label="medium"
+    )
+    candidate = compare.parse_result(
+        _payload(effort="low", cost_per_lead="0.005000", p95_ms=2000), label="low"
+    )
+    comparison = compare.Comparison.of(baseline, candidate)
+    assert comparison.cost_per_lead_delta is not None
+    assert float(comparison.cost_per_lead_delta) == pytest.approx(-0.015)
+    assert comparison.p95_latency_delta_ms == -3000
+
+
+# ------------------------------------------------------------- case-set differences
+
+
+def test_a_case_present_in_one_run_and_not_the_other_is_named_not_dropped() -> None:
+    baseline = compare.parse_result(
+        _payload(cases=[_case("kept", "hot", "hot"), _case("only_in_baseline", "warm", "warm")]),
+        label="baseline",
+    )
+    candidate = compare.parse_result(
+        _payload(cases=[_case("kept", "hot", "hot"), _case("only_in_candidate", "cold", "cold")]),
+        label="candidate",
+    )
+    comparison = compare.Comparison.of(baseline, candidate)
+    assert comparison.cases.only_in_baseline == ("only_in_baseline",)
+    assert comparison.cases.only_in_candidate == ("only_in_candidate",)
+    assert comparison.cases.shared == ("kept",)
+    assert not comparison.cases.comparable
+    assert any("case set" in warning for warning in comparison.warnings)
+
+
+def test_a_tier_that_moved_between_two_runs_is_listed_with_both_verdicts() -> None:
+    baseline = compare.parse_result(
+        _payload(cases=[_case("moved", "hot", "hot"), _case("stayed", "cold", "cold")]),
+        label="baseline",
+    )
+    candidate = compare.parse_result(
+        _payload(
+            cases=[_case("moved", "hot", "cold", status="LOST"), _case("stayed", "cold", "cold")]
+        ),
+        label="candidate",
+    )
+    comparison = compare.Comparison.of(baseline, candidate)
+    changed = comparison.cases.changes
+    assert [change.case_id for change in changed] == ["moved"]
+    assert changed[0].baseline_tier == "hot"
+    assert changed[0].candidate_tier == "cold"
+    assert changed[0].regressed
+
+
+def test_two_identical_runs_report_no_case_movement() -> None:
+    payload = _payload()
+    comparison = compare.Comparison.of(
+        compare.parse_result(payload, label="a"), compare.parse_result(payload, label="b")
+    )
+    assert comparison.cases.changes == ()
+    assert not comparison.any_meaningful
+
+
+# -------------------------------------------------------------------- attribution
+
+
+def test_a_prompt_version_change_is_attributed_rather_than_read_as_a_regression() -> None:
+    """The diff tool's job is exactly this comparison, so it explains rather than refuses."""
+    baseline = compare.parse_result(_payload(prompt_version="rubric_v1"), label="before")
+    candidate = compare.parse_result(_payload(prompt_version="rubric_v2"), label="after")
+    comparison = compare.Comparison.of(baseline, candidate)
+    joined = " ".join(comparison.warnings)
+    assert "prompt_version" in joined
+    assert "rubric_v1" in joined and "rubric_v2" in joined
+
+
+def test_a_different_golden_set_or_model_is_also_attributed() -> None:
+    baseline = compare.parse_result(_payload(model_id="claude-opus-5"), label="before")
+    candidate = compare.parse_result(
+        _payload(model_id="claude-haiku-9", golden_set_path="other.jsonl"), label="after"
+    )
+    joined = " ".join(compare.Comparison.of(baseline, candidate).warnings)
+    assert "model_id" in joined
+    assert "golden_set" in joined
+
+
+def test_a_dirty_working_tree_is_called_out_as_unreproducible() -> None:
+    baseline = compare.parse_result(_payload(), label="before")
+    candidate = compare.parse_result(_payload(git_dirty=True), label="after")
+    assert any(
+        "dirty" in warning for warning in compare.Comparison.of(baseline, candidate).warnings
+    )
+
+
+# ------------------------------------------------------------------ the diff CLI
+
+
+def test_the_diff_cli_compares_two_files_and_prints_the_deltas(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    before = _write(tmp_path, "before.json", _payload(metrics={"exact_tier_accuracy": (13, 15)}))
+    after = _write(tmp_path, "after.json", _payload(metrics={"exact_tier_accuracy": (12, 15)}))
+    code = diff_results.main([str(before), str(after)])
+    assert code == diff_results.EXIT_OK
+    out = capsys.readouterr().out
+    assert "exact_tier_accuracy" in out
+    assert compare.VERDICT_WITHIN_NOISE.lower() in out.lower()
+
+
+def test_the_diff_cli_needs_no_key_and_spends_nothing(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    before = _write(tmp_path, "before.json", _payload())
+    after = _write(tmp_path, "after.json", _payload())
+    assert diff_results.main([str(before), str(after)]) == diff_results.EXIT_OK
+    assert "confirm-spend" not in capsys.readouterr().out
+
+
+def test_the_diff_cli_exits_nonzero_on_a_meaningful_regression(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    before = _write(tmp_path, "before.json", _payload(metrics={"recall_on_contactable": (15, 15)}))
+    after = _write(tmp_path, "after.json", _payload(metrics={"recall_on_contactable": (7, 15)}))
+    code = diff_results.main([str(before), str(after)])
+    assert code == diff_results.EXIT_MEANINGFUL_REGRESSION
+    assert "recall_on_contactable" in capsys.readouterr().out
+
+
+def test_the_diff_cli_refuses_a_schema_mismatch_with_both_versions_named(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    before = _write(tmp_path, "before.json", _payload())
+    after = _write(tmp_path, "after.json", _payload(schema_version=RESULT_SCHEMA_VERSION + 1))
+    code = diff_results.main([str(before), str(after)])
+    assert code == diff_results.EXIT_INPUT_ERROR
+    assert "schema" in capsys.readouterr().err.lower()
+
+
+def test_the_diff_cli_reports_a_missing_case_rather_than_a_smaller_denominator(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    before = _write(
+        tmp_path,
+        "before.json",
+        _payload(cases=[_case("kept", "hot", "hot"), _case("dropped", "warm", "warm")]),
+    )
+    after = _write(tmp_path, "after.json", _payload(cases=[_case("kept", "hot", "hot")]))
+    assert diff_results.main([str(before), str(after)]) == diff_results.EXIT_OK
+    out = capsys.readouterr().out
+    assert "dropped" in out
+    assert "only in" in out.lower()
+
+
+def test_the_diff_cli_reports_an_unreadable_file_by_name(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    missing = tmp_path / "nope.json"
+    existing = _write(tmp_path, "before.json", _payload())
+    code = diff_results.main([str(existing), str(missing)])
+    assert code == diff_results.EXIT_INPUT_ERROR
+    assert "nope.json" in capsys.readouterr().err
+
+
+def test_the_diff_cli_can_emit_the_comparison_as_json(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    before = _write(tmp_path, "before.json", _payload(metrics={"exact_tier_accuracy": (13, 15)}))
+    after = _write(tmp_path, "after.json", _payload(metrics={"exact_tier_accuracy": (12, 15)}))
+    assert diff_results.main([str(before), str(after), "--json"]) == diff_results.EXIT_OK
+    payload: object = json.loads(capsys.readouterr().out)
+    assert isinstance(payload, dict)
+    assert payload["baseline"]["effort"] == "medium"
+    assert payload["noise_floor"]["cases"] == 15
+    metrics = payload["metrics"]
+    assert isinstance(metrics, list)
+    assert {entry["name"] for entry in metrics} >= {"exact_tier_accuracy"}
+
+
+def test_the_rendered_diff_always_carries_the_synthetic_caveat(tmp_path: Path) -> None:
+    """A number lifted out of this report must not lose the sentence that qualifies it."""
+    comparison = compare.Comparison.of(
+        compare.parse_result(_payload(), label="a"), compare.parse_result(_payload(), label="b")
+    )
+    rendered = compare.render_comparison(comparison)
+    assert "self-consistency" in rendered
+
+
+# ------------------------------------------------------------- the effort comparison
+
+
+def _levels(**by_effort: tuple[int, int]) -> list[compare.ResultSnapshot]:
+    """One snapshot per effort level, differing only in exact-tier accuracy."""
+    return [
+        compare.parse_result(
+            _payload(effort=effort, metrics={"exact_tier_accuracy": counts}), label=effort
+        )
+        for effort, counts in by_effort.items()
+    ]
+
+
+def test_a_sweep_orders_its_levels_by_spend_not_by_argument_order() -> None:
+    sweep = compare.SweepComparison.of(
+        _levels(high=(13, 15), low=(12, 15), medium=(13, 15)), baseline="medium"
+    )
+    assert [snapshot.effort for snapshot in sweep.snapshots] == ["low", "medium", "high"]
+    assert sweep.baseline.effort == "medium"
+
+
+def test_a_sweep_compares_every_level_against_the_baseline() -> None:
+    sweep = compare.SweepComparison.of(
+        _levels(low=(12, 15), medium=(13, 15), high=(14, 15)), baseline="medium"
+    )
+    assert [comparison.candidate.effort for comparison in sweep.comparisons] == ["low", "high"]
+
+
+def test_a_sweep_whose_levels_differ_by_one_case_says_so_in_exactly_those_words() -> None:
+    """If the honest answer is that the set cannot tell these apart, the tool says it."""
+    sweep = compare.SweepComparison.of(
+        _levels(low=(12, 15), medium=(13, 15), high=(13, 15)), baseline="medium"
+    )
+    assert not sweep.distinguishable
+    assert sweep.verdict == compare.VERDICT_INDISTINGUISHABLE
+    assert compare.VERDICT_INDISTINGUISHABLE in compare.render_sweep(sweep)
+
+
+def test_a_sweep_with_a_real_gap_reports_the_level_that_is_meaningfully_worse() -> None:
+    sweep = compare.SweepComparison.of(
+        _levels(low=(6, 15), medium=(14, 15), high=(14, 15)), baseline="medium"
+    )
+    assert sweep.distinguishable
+    assert sweep.verdict != compare.VERDICT_INDISTINGUISHABLE
+    assert "low" in sweep.verdict
+
+
+def test_a_sweep_never_names_a_winner_while_the_golden_set_has_no_real_cases() -> None:
+    """Indistinguishable is not the same as equivalent, and synthetic is not evidence."""
+    sweep = compare.SweepComparison.of(
+        _levels(low=(13, 15), medium=(13, 15), high=(13, 15)), baseline="medium"
+    )
+    recommendation = sweep.recommendation()
+    assert recommendation.level is None
+    assert "real" in recommendation.rationale
+
+
+def test_a_sweep_declines_to_pick_a_level_purely_because_it_is_cheaper() -> None:
+    """The failure mode this whole issue exists to prevent."""
+    sweep = compare.SweepComparison.of(_levels(low=(13, 15), medium=(13, 15)), baseline="medium")
+    rendered = compare.render_sweep(sweep)
+    assert "cheapest" not in rendered.lower() or compare.VERDICT_INDISTINGUISHABLE in rendered
+    assert sweep.recommendation().level is None
+
+
+def test_the_sweep_report_states_the_minimum_detectable_difference() -> None:
+    sweep = compare.SweepComparison.of(_levels(low=(12, 15), medium=(13, 15)), baseline="medium")
+    rendered = compare.render_sweep(sweep)
+    assert "6.7" in rendered
+    assert "13.3" in rendered
+    assert "self-consistency" in rendered
+
+
+def test_the_sweep_report_warns_that_p95_over_a_small_set_is_the_slowest_case() -> None:
+    sweep = compare.SweepComparison.of(_levels(low=(12, 15), medium=(13, 15)), baseline="medium")
+    assert "slowest" in compare.render_sweep(sweep).lower()
+
+
+def test_the_sweep_json_carries_every_level_and_its_deltas() -> None:
+    sweep = compare.SweepComparison.of(
+        _levels(low=(12, 15), medium=(13, 15), high=(14, 15)), baseline="medium"
+    )
+    payload = sweep.as_json()
+    assert [level["effort"] for level in payload["levels"]] == ["low", "medium", "high"]
+    assert payload["verdict"] == compare.VERDICT_INDISTINGUISHABLE
+    assert payload["recommendation"]["level"] is None
+    assert payload["caveat"]
+
+
+def test_a_sweep_needs_a_baseline_that_was_actually_run() -> None:
+    with pytest.raises(compare.ComparisonError):
+        compare.SweepComparison.of(_levels(low=(12, 15), high=(13, 15)), baseline="medium")
+
+
+def test_a_sweep_of_one_level_cannot_compare_anything_and_says_so() -> None:
+    sweep = compare.SweepComparison.of(_levels(medium=(13, 15)), baseline="medium")
+    assert sweep.comparisons == ()
+    assert compare.VERDICT_INDISTINGUISHABLE in compare.render_sweep(sweep)
+
+
+def _real_levels(**by_effort: tuple[int, int]) -> list[compare.ResultSnapshot]:
+    """Levels whose golden set is fully real, so the recommendation gate can open."""
+    return [
+        compare.parse_result(
+            _payload(effort=effort, real_cases=15, metrics={"recall_on_contactable": counts}),
+            label=effort,
+        )
+        for effort, counts in by_effort.items()
+    ]
+
+
+def test_a_real_set_with_a_real_gap_names_the_cheapest_level_that_holds() -> None:
+    """The issue's actual outcome, reachable only once the evidence supports it."""
+    sweep = compare.SweepComparison.of(
+        _real_levels(low=(15, 15), medium=(15, 15), high=(5, 15)), baseline="medium"
+    )
+    recommendation = sweep.recommendation()
+    assert recommendation.level == "low"
+    assert "cheapest" in recommendation.rationale
+
+
+def test_a_level_that_regresses_meaningfully_is_passed_over_for_the_baseline() -> None:
+    sweep = compare.SweepComparison.of(
+        _real_levels(low=(5, 15), medium=(15, 15), high=(15, 15)), baseline="medium"
+    )
+    assert sweep.recommendation().level == "medium"
+
+
+def test_a_real_set_that_still_cannot_separate_the_levels_recommends_nothing() -> None:
+    """Real cases are necessary, not sufficient: the set must also be able to see."""
+    sweep = compare.SweepComparison.of(
+        _real_levels(low=(14, 15), medium=(15, 15), high=(15, 15)), baseline="medium"
+    )
+    recommendation = sweep.recommendation()
+    assert recommendation.level is None
+    assert compare.VERDICT_INDISTINGUISHABLE in recommendation.rationale
+    assert "untested" in recommendation.rationale
+
+
+def test_a_case_that_got_worse_is_surfaced_even_when_the_rate_is_noise() -> None:
+    """A lost lead is a fact about that lead, whatever the denominator can resolve."""
+    baseline = compare.parse_result(
+        _payload(cases=[_case("kept", "warm", "warm"), _case("other", "cold", "cold")]),
+        label="before",
+    )
+    candidate = compare.parse_result(
+        _payload(
+            cases=[
+                _case("kept", "warm", "disqualified", status="LOST"),
+                _case("other", "cold", "cold"),
+            ]
+        ),
+        label="after",
+    )
+    comparison = compare.Comparison.of(baseline, candidate)
+    assert not comparison.any_meaningful
+    assert "kept" in comparison.verdict
+    assert "evidence about that case" in comparison.verdict
+    assert "kept" in compare.render_comparison(comparison)
+
+
+def test_a_clean_comparison_does_not_invent_a_case_to_worry_about() -> None:
+    payload = _payload()
+    comparison = compare.Comparison.of(
+        compare.parse_result(payload, label="a"), compare.parse_result(payload, label="b")
+    )
+    assert "Read the cases anyway" not in comparison.verdict

--- a/tests/unit/test_eval_sweep.py
+++ b/tests/unit/test_eval_sweep.py
@@ -1,0 +1,376 @@
+"""The effort sweep, driven end to end offline with assessors scripted per effort level.
+
+The sweep is #23's harness run three times and the three result files compared. That is
+the design, and these tests hold it to it: the assessor is built once per level through
+the ``assessor_factory`` seam, each level writes its own result file, and the comparison
+is computed from those files rather than from anything held in memory — so the sweep can
+only ever report what a diff of the saved artifacts would also report.
+
+The expensive mistakes, in order:
+
+1. **Spending by accident, three times over.** A sweep is three runs. Both of #23's guards
+   are asserted again at sweep scale, and the estimate is asserted to be the multiple.
+2. **Manufacturing a winner.** Three cases (or fifteen) cannot separate three effort
+   levels, and the sweep must say so rather than ranking noise.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator, Mapping
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from leadquali.app.assessment_result import (
+    AssessmentOutcome,
+    AssessmentSucceeded,
+    CallMetering,
+    Effort,
+)
+from leadquali.app.ports import LeadAssessorPort
+from leadquali.config import get_settings
+from leadquali.domain.models import Tier
+from tests.evals import compare, sweep
+
+# The fixture golden set and the scripted-assessor machinery are #23's, and are imported
+# rather than copied: a sweep that ran against a different fixture set from the harness
+# tests would be testing a pipeline nobody has.
+from tests.unit.test_run_eval import (
+    _CASES,
+    _HEADER,
+    LABEL_TIERS,
+    MARKERS,
+    MappedAssessor,
+    _assessment,
+)
+
+API_KEY = "sk-ant-not-a-real-key"
+
+#: What each level costs and how long it takes in the fixtures. Spread wide on purpose:
+#: cost and latency are the only columns a fifteen-case sweep can separate, and the tests
+#: assert that they survive into the comparison while accuracy does not.
+COST_BY_EFFORT: Mapping[Effort, str] = {"low": "0.0050", "medium": "0.0200", "high": "0.0600"}
+LATENCY_BY_EFFORT: Mapping[Effort, int] = {"low": 2000, "medium": 4500, "high": 9000}
+
+
+def _outcome(tier: Tier, *, effort: Effort) -> AssessmentOutcome:
+    return AssessmentSucceeded(
+        assessment=_assessment(tier),
+        metering=CallMetering(
+            model_id="claude-opus-5",
+            prompt_version="rubric_v1",
+            effort=effort,
+            input_tokens=2000,
+            output_tokens=900,
+            cache_read_tokens=1500,
+            cache_creation_tokens=0,
+            cost_usd=Decimal(COST_BY_EFFORT[effort]),
+            latency_ms=LATENCY_BY_EFFORT[effort],
+        ),
+    )
+
+
+class ScriptedFactory:
+    """Builds one assessor per effort level, and records which levels were asked for."""
+
+    def __init__(self, script: Mapping[str, Mapping[str, Tier]] | None = None) -> None:
+        self._script = script or {}
+        self.efforts: list[str] = []
+
+    def __call__(self, effort: Effort) -> LeadAssessorPort:
+        self.efforts.append(effort)
+        per_case = {**LABEL_TIERS, **self._script.get(effort, {})}
+        return MappedAssessor(
+            {
+                MARKERS[case_id]: [_outcome(tier, effort=effort)]
+                for case_id, tier in per_case.items()
+            }
+        )
+
+
+def _exploding_factory(effort: Effort) -> LeadAssessorPort:
+    raise AssertionError("no assessor may be built for a sweep that was never authorised")
+
+
+@pytest.fixture
+def golden_file(tmp_path: Path) -> Path:
+    path = tmp_path / "fixture_leads.jsonl"
+    path.write_text(
+        "\n".join(json.dumps(record) for record in [_HEADER, *_CASES]) + "\n", encoding="utf-8"
+    )
+    return path
+
+
+@pytest.fixture(autouse=True)
+def _clean_settings(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    get_settings.cache_clear()
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    yield
+    get_settings.cache_clear()
+
+
+@pytest.fixture
+def with_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ANTHROPIC_API_KEY", API_KEY)
+    get_settings.cache_clear()
+
+
+def _run(
+    golden_file: Path,
+    tmp_path: Path,
+    *,
+    factory: Any,
+    extra: tuple[str, ...] = (),
+) -> int:
+    return sweep.main(
+        [
+            "--confirm-spend",
+            "--golden-set",
+            str(golden_file),
+            "--out",
+            str(tmp_path / "sweep"),
+            *extra,
+        ],
+        assessor_factory=factory,
+    )
+
+
+# --------------------------------------------------------------------- the refusals
+
+
+def test_the_sweep_refuses_without_the_confirmation_flag(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = sweep.main(
+        ["--golden-set", str(golden_file), "--out", str(tmp_path / "sweep")],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == sweep.EXIT_REFUSED
+    assert "--confirm-spend" in capsys.readouterr().err
+
+
+def test_the_sweep_refuses_without_an_api_key(
+    golden_file: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = sweep.main(
+        ["--confirm-spend", "--golden-set", str(golden_file), "--out", str(tmp_path / "sweep")],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == sweep.EXIT_REFUSED
+    assert "ANTHROPIC_API_KEY" in capsys.readouterr().err
+
+
+def test_the_refusal_quotes_the_whole_sweep_price_not_one_run(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """A sweep is three runs, and the number the person sees must be the one they pay."""
+    code = sweep.main(
+        ["--golden-set", str(golden_file), "--out", str(tmp_path / "sweep")],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == sweep.EXIT_REFUSED
+    stderr = capsys.readouterr().err
+    assert "3 effort level" in stderr
+
+
+# --------------------------------------------------------------------- the estimate
+
+
+def test_the_estimate_prints_a_line_per_level_and_a_total(
+    golden_file: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = sweep.main(
+        ["--estimate", "--golden-set", str(golden_file), "--out", str(tmp_path / "sweep")],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == sweep.EXIT_OK
+    out = capsys.readouterr().out
+    for level in ("low", "medium", "high"):
+        assert level in out
+    assert "total" in out.lower()
+
+
+def test_the_estimate_is_the_single_run_estimate_times_the_levels(
+    golden_file: Path, tmp_path: Path
+) -> None:
+    estimate = sweep.estimate_sweep(
+        *sweep.load_inputs(golden_file, "default", None),
+        efforts=("low", "medium", "high"),
+        concurrency=4,
+        repeat=1,
+        output_tokens_per_case=1200,
+    )
+    assert len(estimate.per_level) == 3
+    assert estimate.total_cost_usd == sum(
+        (level.cost_usd for level in estimate.per_level.values()), Decimal(0)
+    )
+
+
+def test_the_estimate_multiplies_by_repeat(golden_file: Path) -> None:
+    inputs = sweep.load_inputs(golden_file, "default", None)
+    once = sweep.estimate_sweep(
+        *inputs, efforts=("low", "medium"), concurrency=4, repeat=1, output_tokens_per_case=1200
+    )
+    twice = sweep.estimate_sweep(
+        *inputs, efforts=("low", "medium"), concurrency=4, repeat=2, output_tokens_per_case=1200
+    )
+    assert twice.total_cost_usd == once.total_cost_usd * 2
+
+
+def test_the_estimate_spends_nothing_and_needs_no_key(
+    golden_file: Path, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = sweep.main(
+        ["--estimate", "--golden-set", str(golden_file), "--out", str(tmp_path / "sweep")],
+        assessor_factory=_exploding_factory,
+    )
+    assert code == sweep.EXIT_OK
+    assert "ANTHROPIC_API_KEY" not in capsys.readouterr().err
+
+
+# ----------------------------------------------------------------- input validation
+
+
+def test_an_unknown_effort_level_is_an_input_error(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = _run(golden_file, tmp_path, factory=_exploding_factory, extra=("--effort", "turbo"))
+    assert code == sweep.EXIT_INPUT_ERROR
+    assert "turbo" in capsys.readouterr().err
+
+
+def test_a_baseline_outside_the_swept_levels_is_an_input_error(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = _run(
+        golden_file,
+        tmp_path,
+        factory=_exploding_factory,
+        extra=("--effort", "low", "--effort", "high", "--baseline", "medium"),
+    )
+    assert code == sweep.EXIT_INPUT_ERROR
+    assert "medium" in capsys.readouterr().err
+
+
+def test_a_repeated_effort_level_is_an_input_error(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    code = _run(
+        golden_file,
+        tmp_path,
+        factory=_exploding_factory,
+        extra=("--effort", "low", "--effort", "low"),
+    )
+    assert code == sweep.EXIT_INPUT_ERROR
+    assert "low" in capsys.readouterr().err
+
+
+# ------------------------------------------------------------------------ the sweep
+
+
+def test_the_sweep_builds_one_assessor_per_level_through_the_injected_factory(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    factory = ScriptedFactory()
+    assert _run(golden_file, tmp_path, factory=factory) == sweep.EXIT_OK
+    assert factory.efforts == ["low", "medium", "high"]
+
+
+def test_each_level_writes_its_own_result_file(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    """One artifact per level, so the sweep and a later diff read the same evidence."""
+    assert _run(golden_file, tmp_path, factory=ScriptedFactory()) == sweep.EXIT_OK
+    for level in ("low", "medium", "high"):
+        files = list((tmp_path / "sweep" / level).glob("eval-*.json"))
+        assert len(files) == 1, f"expected one result file for {level}, found {files}"
+
+
+def test_the_sweep_writes_one_comparison_document(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    assert _run(golden_file, tmp_path, factory=ScriptedFactory()) == sweep.EXIT_OK
+    files = list((tmp_path / "sweep").glob("sweep-*.json"))
+    assert len(files) == 1
+    payload: object = json.loads(files[0].read_text(encoding="utf-8"))
+    assert isinstance(payload, dict)
+    assert [level["effort"] for level in payload["levels"]] == ["low", "medium", "high"]
+    assert payload["result_files"]["low"].endswith(".json")
+
+
+def test_the_comparison_carries_cost_and_latency_side_by_side(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert _run(golden_file, tmp_path, factory=ScriptedFactory()) == sweep.EXIT_OK
+    out = capsys.readouterr().out
+    assert "cost per lead" in out.lower()
+    assert "p95" in out.lower()
+    assert "0.0050" in out.replace("$", "")
+
+
+def test_a_sweep_over_a_tiny_set_reports_that_it_cannot_distinguish_the_levels(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Three cases and a one-case difference is a coin flip, and the report says so."""
+    factory = ScriptedFactory({"low": {"a_hot_buyer": Tier.WARM}})
+    assert _run(golden_file, tmp_path, factory=factory) == sweep.EXIT_OK
+    assert compare.VERDICT_INDISTINGUISHABLE in capsys.readouterr().out
+
+
+def test_the_sweep_never_recommends_a_level_off_a_synthetic_set(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert _run(golden_file, tmp_path, factory=ScriptedFactory()) == sweep.EXIT_OK
+    out = capsys.readouterr().out
+    assert compare.NO_RECOMMENDATION in out
+
+
+def test_repeat_is_passed_through_and_turns_the_noise_floor_into_a_measured_one(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    assert _run(golden_file, tmp_path, factory=ScriptedFactory(), extra=("--repeat", "2")) == (
+        sweep.EXIT_OK
+    )
+    # Collapse the report's line wrapping before matching: the sentence is the assertion,
+    # not where the renderer happened to break it.
+    normalised = " ".join(capsys.readouterr().out.split())
+    assert "measured over 2 repeats" in normalised
+    assert "spread not measured" not in normalised
+
+
+def test_a_security_finding_at_any_level_makes_the_whole_sweep_non_green(
+    golden_file: Path, tmp_path: Path, with_key: None
+) -> None:
+    """An injection case tiered hot is a defect at any effort level."""
+    factory = ScriptedFactory({"low": {"b_injection": Tier.HOT}})
+    assert _run(golden_file, tmp_path, factory=factory) == sweep.EXIT_SECURITY_FINDING
+
+
+def test_a_single_level_sweep_still_produces_a_report(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    factory = ScriptedFactory()
+    code = _run(golden_file, tmp_path, factory=factory, extra=("--effort", "medium"))
+    assert code == sweep.EXIT_OK
+    assert factory.efforts == ["medium"]
+    assert compare.VERDICT_INDISTINGUISHABLE in capsys.readouterr().out
+
+
+def test_the_per_level_reports_are_suppressed_unless_asked_for(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The sweep's output is the comparison; three full reports would bury it."""
+    _run(golden_file, tmp_path, factory=ScriptedFactory())
+    assert "CONFUSION MATRIX" not in capsys.readouterr().out
+    _run(golden_file, tmp_path, factory=ScriptedFactory(), extra=("--per-level-report",))
+    assert "CONFUSION MATRIX" in capsys.readouterr().out
+
+
+def test_the_sweep_report_names_the_golden_set_it_ran_against(
+    golden_file: Path, tmp_path: Path, with_key: None, capsys: pytest.CaptureFixture[str]
+) -> None:
+    _run(golden_file, tmp_path, factory=ScriptedFactory())
+    assert golden_file.name in capsys.readouterr().out


### PR DESCRIPTION
Closes #24. **This completes Phase 3.** On top of #63 (eval harness) → #62 → #61.

```bash
python -m tests.evals.sweep --estimate                 # free
python -m tests.evals.sweep --confirm-spend            # + ANTHROPIC_API_KEY
python -m tests.evals.diff_results BEFORE.json AFTER.json   # free, offline, no key
```

The sweep drives #63's runner through its `assessor_factory` seam rather than reimplementing the evaluation loop.

## The substance: what 15 cases can and cannot tell you

Real output of the estimator, run just now — note what it volunteers about itself:

```
  low      $0.5627   medium   $0.5627   high     $0.5627   TOTAL  $1.6882
  - the same assumed output-token count at every effort level, which overstates low
    and understates high - thinking tokens are billed as output and are exactly what
    effort buys. Re-estimate with --assumed-output-tokens once one real run has told
    you the true figure for a level.
```

**The cost comparison between levels is uninformative until one real run measures output tokens per level** — and the tool says so rather than presenting three identical numbers as a finding.

The accuracy side is qualified the same way:

- **Resolution: 6.7pp** — one case. Nothing finer exists at this set size.
- **Stated minimum detectable difference: 13.3pp** (two cases), raised to the observed spread when `--repeat` measures one.
- **20 cases to resolve 5pp; 50 to resolve 2pp.**
- **p95 under 20 cases *is* the slowest single call** — nearest-rank on a small set makes "p95" a synonym for "max", so it moves on any one slow response.

Every comparison is labelled `meaningful`, `within_noise`, `not_comparable` or `indistinguishable`. **The tool will not name a winner off a synthetic set whatever the numbers say, and it will not treat "indistinguishable" as "equivalent".** Without that, someone picks `low` on the strength of a coin flip and books the saving.

**No significance test** — deliberately. A stated minimum detectable difference plus an observed spread is defensible; a p-value invented over 15 self-labeled cases is not.

## The diff tool

Answers "did last Tuesday's prompt change make things worse?" from **stored artifacts**, without re-running or re-spending. Exit 1 only on a regression **above the noise floor**; exit 2 on unreadable or schema-mismatched input. Handles a case present in one run but not the other.

## What is deliberately not done

**No live sweep was run** — no API key here, and the sweep has no offline mode on purpose. `docs/rubric-tuning.md` carries the three-level table **present but marked "not measured"**, and states that picking the cheapest effort that holds accuracy is yours to execute *after* the golden set has real cases (#62).

**Nothing in `tenants/default.json` changed**: `effort` and `min_confidence` stay documented guesses until a real measurement moves them. The tuning doc also carries the warning that tuning against a synthetic self-labeled set optimises for agreement with its author, not for revenue.

## Verification

70 new tests (1368 passing), all offline, reusing #63's fixture golden set and scripted-assessor machinery rather than forking it. Both CLIs were run for real: the estimator against the actual 15-case set, and the diff over two result files genuinely produced by `run_eval`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_