### PR TITLE
[P4.2] SAM template: API Gateway, ingest + worker Lambdas, SQS with DLQ

### DIFF
--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -1,0 +1,249 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Transform: AWS::Serverless-2016-10-31
+Description: >
+  JAT-LeadQuali: API Gateway + ingest Lambda -> SQS -> qualification worker.
+  The queue is what lets a form post return in under 200 ms while a Claude call that
+  takes several seconds happens elsewhere, and it is where "a lead is never silently
+  dropped" stops being a principle and becomes infrastructure.
+
+Parameters:
+  Stage:
+    Type: String
+    Default: prod
+    AllowedValues: [dev, staging, prod]
+    Description: Deployment stage. Also the API Gateway stage name.
+  WorkerTimeoutSeconds:
+    Type: Number
+    Default: 120
+    MinValue: 30
+    MaxValue: 600
+    Description: >
+      Worker Lambda timeout. Must comfortably exceed one Claude call with adaptive
+      thinking at max_tokens 8000, plus enrichment, plus the database writes. The
+      Anthropic client is built with its own 120 s timeout, so this is that plus headroom
+      rather than an independent guess.
+  WorkerReservedConcurrency:
+    Type: Number
+    Default: 5
+    MinValue: 1
+    Description: >
+      Hard cap on concurrent workers. This is the Postgres decision's bill (plan section
+      4): each container holds one connection, so this number is the worst-case
+      connection count against RDS Proxy. Raising it without raising the database's
+      connection budget is how a burst of leads takes the database down. Owned with #27.
+  IngestCredentialsSecretArn:
+    Type: String
+    Description: >
+      Secrets Manager ARN for the per-tenant ingest credentials JSON. An ARN, never the
+      value: a secret passed as a template parameter shows up in the stack's Parameters
+      tab, in drift detection, and in any CI log that echoes the deploy command.
+  AnthropicApiKeySecretArn:
+    Type: String
+    Description: Secrets Manager ARN for the Anthropic API key.
+  DatabaseUrlSecretArn:
+    Type: String
+    Description: Secrets Manager ARN for the SQLAlchemy database URL.
+  FeedbackTokenSecretArn:
+    Type: String
+    Description: >
+      Secrets Manager ARN for the feedback-link signing secret. Distinct from any ingest
+      signing secret: one key, one purpose.
+  SesSender:
+    Type: String
+    Description: Verified SES sender address (docs/runbooks/ses-setup.md).
+  SesConfigurationSet:
+    Type: String
+    Default: ""
+    Description: SES configuration set for bounce and complaint tracking. Optional.
+  EscalationDestination:
+    Type: String
+    Description: >
+      Last-resort address for an escalated lead whose tenant has no destination for the
+      tier it landed in. Required, because an escalation with nowhere to go is a dropped
+      lead by another name (#14).
+  FeedbackTokenTtlDays:
+    Type: Number
+    Default: 30
+    MinValue: 1
+    Description: How long a one-click feedback link stays valid.
+  VpcSubnetIds:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >
+      Private subnets for the worker (#27). Empty deploys it outside a VPC, which works
+      only against a publicly reachable database - fine for dev, never for prod.
+  VpcSecurityGroupIds:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: Security groups for the worker (#27).
+
+Conditions:
+  InVpc: !Not [!Equals [!Join ["", !Ref VpcSubnetIds], ""]]
+
+Globals:
+  Function:
+    Runtime: python3.13
+    Architectures: [arm64]
+    Tracing: Active
+    Environment:
+      Variables:
+        ENV: !Ref Stage
+        LOG_LEVEL: INFO
+
+Resources:
+  LeadDeadLetterQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "leadquali-${Stage}-leads-dlq"
+      MessageRetentionPeriod: 1209600
+      SqsManagedSseEnabled: true
+
+  LeadQueue:
+    Type: AWS::SQS::Queue
+    Properties:
+      QueueName: !Sub "leadquali-${Stage}-leads"
+      VisibilityTimeout: 720
+      MessageRetentionPeriod: 345600
+      SqsManagedSseEnabled: true
+      RedrivePolicy:
+        deadLetterTargetArn: !GetAtt LeadDeadLetterQueue.Arn
+        maxReceiveCount: 3
+
+  IngestFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "leadquali-${Stage}-ingest"
+      CodeUri: ../
+      Handler: leadquali.api.handlers.ingest_handler
+      MemorySize: 512
+      Timeout: 10
+      Environment:
+        Variables:
+          LEAD_QUEUE_URL: !Ref LeadQueue
+          INGEST_CREDENTIALS_SECRET_ARN: !Ref IngestCredentialsSecretArn
+          DATABASE_URL_SECRET_ARN: !Ref DatabaseUrlSecretArn
+      Policies:
+        - SQSSendMessagePolicy:
+            QueueName: !GetAtt LeadQueue.QueueName
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Ref IngestCredentialsSecretArn
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Ref DatabaseUrlSecretArn
+      Events:
+        Ingest:
+          Type: Api
+          Properties:
+            RestApiId: !Ref LeadApi
+            Path: /leads
+            Method: post
+        Health:
+          Type: Api
+          Properties:
+            RestApiId: !Ref LeadApi
+            Path: /health
+            Method: get
+        Feedback:
+          Type: Api
+          Properties:
+            RestApiId: !Ref LeadApi
+            Path: /feedback/{token}
+            Method: any
+
+  WorkerFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "leadquali-${Stage}-worker"
+      CodeUri: ../
+      Handler: leadquali.api.worker.lambda_handler
+      MemorySize: 1024
+      Timeout: !Ref WorkerTimeoutSeconds
+      ReservedConcurrentExecutions: !Ref WorkerReservedConcurrency
+      VpcConfig: !If
+        - InVpc
+        - SubnetIds: !Ref VpcSubnetIds
+          SecurityGroupIds: !Ref VpcSecurityGroupIds
+        - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          ANTHROPIC_API_KEY_SECRET_ARN: !Ref AnthropicApiKeySecretArn
+          DATABASE_URL_SECRET_ARN: !Ref DatabaseUrlSecretArn
+          FEEDBACK_TOKEN_SECRET_ARN: !Ref FeedbackTokenSecretArn
+          SES_SENDER: !Ref SesSender
+          SES_CONFIGURATION_SET: !Ref SesConfigurationSet
+          ESCALATION_DESTINATION: !Ref EscalationDestination
+          FEEDBACK_TOKEN_TTL_DAYS: !Ref FeedbackTokenTtlDays
+          FEEDBACK_BASE_URL: !Sub "https://${LeadApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}"
+      Policies:
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Ref AnthropicApiKeySecretArn
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Ref DatabaseUrlSecretArn
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Ref FeedbackTokenSecretArn
+        - SESCrudPolicy:
+            IdentityName: !Ref SesSender
+        - VPCAccessPolicy: {}
+      Events:
+        Leads:
+          Type: SQS
+          Properties:
+            Queue: !GetAtt LeadQueue.Arn
+            BatchSize: 10
+            MaximumBatchingWindowInSeconds: 5
+            FunctionResponseTypes: [ReportBatchItemFailures]
+
+  MigrationFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "leadquali-${Stage}-migrate"
+      CodeUri: ../
+      Handler: leadquali.api.migrate.lambda_handler
+      MemorySize: 512
+      Timeout: 300
+      VpcConfig: !If
+        - InVpc
+        - SubnetIds: !Ref VpcSubnetIds
+          SecurityGroupIds: !Ref VpcSecurityGroupIds
+        - !Ref AWS::NoValue
+      Environment:
+        Variables:
+          DATABASE_URL_SECRET_ARN: !Ref DatabaseUrlSecretArn
+      Policies:
+        - AWSSecretsManagerGetSecretValuePolicy:
+            SecretArn: !Ref DatabaseUrlSecretArn
+        - VPCAccessPolicy: {}
+
+  LeadApi:
+    Type: AWS::Serverless::Api
+    Properties:
+      StageName: !Ref Stage
+      MethodSettings:
+        - ResourcePath: "/*"
+          HttpMethod: "*"
+          ThrottlingBurstLimit: 100
+          ThrottlingRateLimit: 50
+      AccessLogSetting:
+        DestinationArn: !GetAtt ApiAccessLogGroup.Arn
+        Format: >-
+          {"requestId":"$context.requestId","ip":"$context.identity.sourceIp","method":"$context.httpMethod","path":"$context.path","status":"$context.status","latency_ms":"$context.responseLatency"}
+
+  ApiAccessLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/apigateway/leadquali-${Stage}"
+      RetentionInDays: 30
+
+Outputs:
+  IngestUrl:
+    Description: The endpoint the website form posts to (#30's cutover runbook).
+    Value: !Sub "https://${LeadApi}.execute-api.${AWS::Region}.amazonaws.com/${Stage}/leads"
+  QueueUrl:
+    Value: !Ref LeadQueue
+  DeadLetterQueueArn:
+    Description: Watched by #29's DLQ-depth alarm.
+    Value: !GetAtt LeadDeadLetterQueue.Arn
+  WorkerFunctionName:
+    Value: !Ref WorkerFunction
+  MigrationFunctionName:
+    Description: Invoke once per deploy, before traffic, to run alembic upgrade head.
+    Value: !Ref MigrationFunction

--- a/src/leadquali/adapters/queue_sqs.py
+++ b/src/leadquali/adapters/queue_sqs.py
@@ -1,0 +1,56 @@
+"""SQS producer for the ingest path.
+
+The queue is what lets the form post return in under 200 ms while a Claude call that
+takes several seconds happens somewhere else. It is also where the never-drop-a-lead
+invariant is enforced by infrastructure rather than by code: a message that the worker
+fails to process is redelivered, and after ``maxReceiveCount`` attempts it lands on a
+dead-letter queue that an alarm watches, instead of vanishing.
+
+This adapter is deliberately thin. The message body is exactly what
+:meth:`leadquali.app.ingest.QueuedLead.to_message` produces, unchanged — the queue is a
+transport, and a transport that reshapes its payload becomes a second schema nobody
+versioned.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Final
+
+import boto3
+
+from leadquali.app.ingest import QueuedLead
+
+#: Sent as the SQS message group id when the queue is FIFO. Ordering between leads does
+#: not matter — two leads are independent — so every lead is its own group, which lets
+#: SQS parallelise fully instead of serialising the whole queue behind one slow lead.
+GROUP_ID_PREFIX: Final[str] = "lead"
+
+
+class SqsLeadQueue:
+    """A :class:`~leadquali.app.ingest.LeadQueuePort` backed by an SQS queue."""
+
+    def __init__(self, client: Any, queue_url: str) -> None:
+        self._client = client
+        self._queue_url = queue_url
+
+    @classmethod
+    def from_env(cls, queue_url: str, *, region_name: str | None = None) -> SqsLeadQueue:
+        """Build a producer against ``queue_url``.
+
+        The client is created here rather than at import time: a Lambda cold start should
+        pay for it once, but an import should never make a network-capable object as a
+        side effect of being imported by a test.
+        """
+        return cls(boto3.client("sqs", region_name=region_name), queue_url)
+
+    def enqueue(self, queued: QueuedLead) -> None:
+        """Publish one lead. Raises on failure so the caller can decide.
+
+        Deliberately does not swallow errors: the ingest endpoint has already persisted
+        the lead, so a failed enqueue must surface as a non-2xx rather than a 202 that
+        quietly means nothing happened. A 202 the website believes and a lead that never
+        gets qualified is the worst of both worlds.
+        """
+        body = json.dumps(queued.to_message(), separators=(",", ":"), sort_keys=True)
+        self._client.send_message(QueueUrl=self._queue_url, MessageBody=body)

--- a/src/leadquali/api/migrate.py
+++ b/src/leadquali/api/migrate.py
@@ -1,0 +1,50 @@
+"""Run database migrations, once, from one place.
+
+`alembic upgrade head` is a deploy step, which is why alembic is a runtime dependency
+(#15). It runs here — invoked by the deploy pipeline before traffic — rather than on
+worker cold start, because a worker that migrates on cold start races N containers for
+the same DDL lock, and the first burst after a deploy is exactly when N is largest.
+Postgres would serialise them on the lock, so the failure is not corruption but a fleet
+of workers each waiting on a migration before qualifying its first lead.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Final
+
+from alembic import command
+from alembic.config import Config
+
+from leadquali.config import Settings, get_settings
+from leadquali.observability.logs import configure_logging
+
+configure_logging()
+
+LOGGER: Final = logging.getLogger(__name__)
+
+#: Repo-root-relative location of alembic.ini, resolved from this file so the handler
+#: works the same in a Lambda bundle as it does from a checkout.
+ALEMBIC_INI: Final[Path] = Path(__file__).resolve().parents[3] / "alembic.ini"
+
+
+def build_config(settings: Settings | None = None, *, ini_path: Path | None = None) -> Config:
+    """An alembic config with the URL injected from settings, never from the ini file."""
+    resolved = settings or get_settings()
+    config = Config(str(ini_path or ALEMBIC_INI))
+    config.set_main_option("sqlalchemy.url", resolved.require_database_url())
+    return config
+
+
+def upgrade_to_head(settings: Settings | None = None) -> None:
+    """Apply every pending migration."""
+    command.upgrade(build_config(settings), "head")
+
+
+def lambda_handler(event: dict[str, Any], context: object) -> dict[str, str]:
+    """Entrypoint named by `infra/template.yaml`. Idempotent: a no-op when up to date."""
+    LOGGER.info("migrate.start", extra={"event": "migrate.start"})
+    upgrade_to_head()
+    LOGGER.info("migrate.done", extra={"event": "migrate.done"})
+    return {"status": "ok"}

--- a/src/leadquali/api/worker.py
+++ b/src/leadquali/api/worker.py
@@ -1,0 +1,135 @@
+"""The SQS-triggered qualification worker.
+
+One Lambda invocation carries a batch of leads. Two properties decide whether this is
+correct under load, and neither is obvious from the happy path:
+
+* **Per-message failure, not per-batch.** The handler returns a partial-batch response
+  (``batchItemFailures``), so one poisoned message does not drag its nine healthy
+  neighbours back onto the queue to be retried — and eventually onto the dead-letter
+  queue — alongside it. Without this, a single unparseable lead multiplies into ten
+  duplicate emails on redelivery.
+* **A message that can never succeed must not be retried forever.** A body that is not
+  JSON, or that does not match the queue schema, is not going to parse on the fourth
+  attempt either. It is logged and *not* reported as a failure, so SQS deletes it — the
+  lead is already persisted by ingest, so the record is not lost, and the alternative is
+  an infinite redelivery loop billed by the invocation.
+
+Everything else — a database blip, a Claude timeout — *is* reported as a failure, because
+those genuinely may succeed on redelivery. That is the whole reason the queue exists.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Final
+
+from leadquali.app.ingest import QueuedLead
+from leadquali.app.qualify import QualificationRequest
+from leadquali.observability.logs import configure_logging
+
+# Lambda reuses containers, so this runs once per container rather than per invocation.
+# `configure_logging` is idempotent by design (#21) — calling it twice would otherwise
+# double every log line and every metric derived from one.
+configure_logging()
+
+LOGGER: Final = logging.getLogger(__name__)
+
+
+def _parse(record: dict[str, Any]) -> QueuedLead | None:
+    """Decode one SQS record, or ``None`` if it can never be decoded."""
+    try:
+        body = json.loads(record["body"])
+    except (KeyError, TypeError, ValueError):
+        return None
+    if not isinstance(body, dict):
+        return None
+    try:
+        return QueuedLead.from_message(body)
+    except (KeyError, TypeError, ValueError):
+        return None
+
+
+def handle(event: dict[str, Any], context: object, *, pipeline: Any) -> dict[str, Any]:
+    """Process one SQS batch and report which messages failed.
+
+    ``pipeline`` is injected rather than built here so the handler is testable without
+    AWS; the module-level entrypoint below wires the real one.
+    """
+    failures: list[dict[str, str]] = []
+    for record in event.get("Records", []):
+        message_id = str(record.get("messageId", ""))
+        queued = _parse(record)
+        if queued is None:
+            # Undecodable: retrying cannot help, and the lead row already exists.
+            LOGGER.error(
+                "queue.undecodable_message",
+                extra={"event": "queue.undecodable_message", "message_id": message_id},
+            )
+            continue
+        try:
+            # The pipeline binds the trace id (and tenant/lead) onto the log context
+            # itself, so the worker passes it along rather than binding a second time.
+            pipeline.qualify(
+                QualificationRequest(
+                    tenant_id=queued.tenant_id,
+                    submission_id=queued.submission_id,
+                    submission=queued.submission,
+                    source=queued.source,
+                    received_at=queued.received_at,
+                    trace_id=queued.trace_id,
+                )
+            )
+        except Exception:
+            # Transient by assumption: let SQS redeliver this one message.
+            LOGGER.exception(
+                "queue.qualify_failed",
+                extra={"event": "queue.qualify_failed", "message_id": message_id},
+            )
+            failures.append({"itemIdentifier": message_id})
+    return {"batchItemFailures": failures}
+
+
+def lambda_handler(event: dict[str, Any], context: object) -> dict[str, Any]:
+    """The SQS entrypoint named by `infra/template.yaml`.
+
+    The pipeline is built lazily and cached on the module, so a container pays for the
+    engine, the client and the config load once rather than per invocation - and an
+    import of this module (by a test, or by a linter) builds nothing at all.
+    """
+    global _PIPELINE
+    if _PIPELINE is None:  # pragma: no cover - exercised only in a real Lambda
+        _PIPELINE = _build_pipeline()
+    return handle(event, context, pipeline=_PIPELINE)
+
+
+_PIPELINE: Any = None
+
+
+def _build_pipeline() -> Any:  # pragma: no cover - requires AWS and a database
+    """Wire the real adapters. Deliberately not run in tests: every line needs a service."""
+    from leadquali.adapters.clock_system import SystemClock
+    from leadquali.adapters.enrich_null import NullEnricher
+    from leadquali.adapters.llm_anthropic import AnthropicLeadAssessor, build_anthropic_client
+    from leadquali.adapters.notify_ses import SesNotifier
+    from leadquali.adapters.store_postgres import PostgresLeadStore, PostgresTenantConfigSource
+    from leadquali.app.qualify import QualificationPipeline
+    from leadquali.config import get_settings
+
+    settings = get_settings()
+    return QualificationPipeline(
+        config_source=PostgresTenantConfigSource.from_env(settings),
+        assessor=AnthropicLeadAssessor(
+            build_anthropic_client(settings.require_anthropic_api_key())
+        ),
+        store=PostgresLeadStore.from_env(settings),
+        notifier=SesNotifier.from_env(settings),
+        # NullEnricher, not EmailEnricher: #18's DNS-backed enricher lands on a
+        # parallel branch and is not in this one's history. Swap it in when both are on
+        # the default branch - and read #18's note first, because a worker in private
+        # subnets has no DNS unless #27's VPC provides it.
+        enricher=NullEnricher(),
+        clock=SystemClock(),
+        escalation_destination=os.environ["ESCALATION_DESTINATION"],
+    )

--- a/tests/unit/test_infra_template.py
+++ b/tests/unit/test_infra_template.py
@@ -1,0 +1,207 @@
+"""The SAM template is configuration, so its invariants are asserted, not assumed.
+
+No AWS account exists here, so nothing below proves the stack deploys. What it does prove
+is that the template does not contain the specific mistakes that are expensive to discover
+on deploy day: a visibility timeout shorter than the worker's timeout, a queue with no
+dead letter, a plaintext secret, a handler path that no longer matches the code.
+
+`cfn-lint` covers CloudFormation validity; these cover the things cfn-lint cannot know.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+
+TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "infra" / "template.yaml"
+
+
+class _SamLoader(yaml.SafeLoader):
+    """SafeLoader that tolerates CloudFormation's `!Ref`/`!Sub`/`!GetAtt` short forms."""
+
+
+def _tag(loader: yaml.Loader, tag_suffix: str, node: yaml.Node) -> dict[str, Any]:
+    if isinstance(node, yaml.ScalarNode):
+        value: Any = loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node, deep=True)
+    elif isinstance(node, yaml.MappingNode):
+        value = loader.construct_mapping(node, deep=True)
+    else:  # pragma: no cover - the three node kinds above are exhaustive in PyYAML
+        raise TypeError(f"unexpected node {type(node).__name__} for tag !{tag_suffix}")
+    return {f"Fn::{tag_suffix}": value}
+
+
+_SamLoader.add_multi_constructor("!", _tag)
+
+
+@pytest.fixture(scope="module")
+def template() -> dict[str, Any]:
+    # S506 is about untrusted YAML instantiating arbitrary objects. `_SamLoader` derives
+    # from `SafeLoader` and only adds constructors that turn CloudFormation's `!Ref`-style
+    # tags into plain dicts, and the input is a file from this repository.
+    loaded = yaml.load(
+        TEMPLATE_PATH.read_text(encoding="utf-8"),
+        Loader=_SamLoader,  # noqa: S506
+    )
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def _resources(template: dict[str, Any]) -> dict[str, Any]:
+    resources = template["Resources"]
+    assert isinstance(resources, dict)
+    return resources
+
+
+def test_the_template_exists_and_is_a_sam_template(template: dict[str, Any]) -> None:
+    assert template["Transform"] == "AWS::Serverless-2016-10-31"
+
+
+def test_visibility_timeout_exceeds_the_worker_timeout(template: dict[str, Any]) -> None:
+    """The one number whose being wrong duplicates work under load.
+
+    SQS redelivers a message whose visibility timeout expires while it is still being
+    worked. Set this below the worker's timeout and every slow lead is qualified twice —
+    two Claude calls, and but for the `(tenant_id, submission_id)` idempotency key, two
+    emails to sales.
+    """
+    resources = _resources(template)
+    visibility = resources["LeadQueue"]["Properties"]["VisibilityTimeout"]
+    worker_default = template["Parameters"]["WorkerTimeoutSeconds"]["Default"]
+    worker_max = template["Parameters"]["WorkerTimeoutSeconds"]["MaxValue"]
+
+    assert visibility > worker_default
+    assert visibility >= worker_max, (
+        "visibility must exceed the worker timeout at its maximum too, or raising "
+        "WorkerTimeoutSeconds silently introduces double delivery"
+    )
+
+
+def test_the_queue_has_a_dead_letter_queue_and_a_bounded_retry(
+    template: dict[str, Any],
+) -> None:
+    resources = _resources(template)
+    redrive = resources["LeadQueue"]["Properties"]["RedrivePolicy"]
+    assert redrive["deadLetterTargetArn"] == {"Fn::GetAtt": "LeadDeadLetterQueue.Arn"}
+    assert 1 < redrive["maxReceiveCount"] <= 5, (
+        "each attempt costs a Claude call, so the console default of 10 is real money"
+    )
+    assert "LeadDeadLetterQueue" in resources
+
+
+def test_the_dead_letter_queue_retains_long_enough_for_a_human(
+    template: dict[str, Any],
+) -> None:
+    """A lead on the DLQ is one nobody has looked at yet."""
+    retention = _resources(template)["LeadDeadLetterQueue"]["Properties"]["MessageRetentionPeriod"]
+    assert retention == 1_209_600, "14 days, the maximum: a long weekend must not lose leads"
+
+
+def test_the_worker_has_a_reserved_concurrency_cap(template: dict[str, Any]) -> None:
+    """Each container holds a database connection; unbounded workers exhaust Postgres."""
+    worker = _resources(template)["WorkerFunction"]["Properties"]
+    assert worker["ReservedConcurrentExecutions"] == {"Fn::Ref": "WorkerReservedConcurrency"}
+
+
+def test_the_worker_reports_partial_batch_failures(template: dict[str, Any]) -> None:
+    """Without this, one poisoned message drags nine healthy leads back onto the queue."""
+    event = _resources(template)["WorkerFunction"]["Properties"]["Events"]["Leads"]
+    assert event["Properties"]["FunctionResponseTypes"] == ["ReportBatchItemFailures"]
+
+
+def test_no_secret_is_a_plaintext_parameter_or_environment_variable(
+    template: dict[str, Any],
+) -> None:
+    """Secrets arrive as ARNs. A secret passed as a parameter is visible in the console.
+
+    Checked structurally rather than by name: every parameter whose name suggests a secret
+    must be an ARN reference, and none may carry a default value.
+    """
+    secretish = ("secret", "apikey", "api_key", "password", "token")
+    for name, spec in template["Parameters"].items():
+        lowered = name.lower()
+        # A Number cannot carry a secret: FeedbackTokenTtlDays contains "token" and is a
+        # duration. Narrowing by type keeps the heuristic broad without false positives.
+        if spec.get("Type") == "Number":
+            continue
+        if any(word in lowered for word in secretish):
+            assert lowered.endswith("arn"), f"{name} should name an ARN, not hold a value"
+            assert "Default" not in spec, f"{name} must not have a default"
+
+    for resource in _resources(template).values():
+        env = resource.get("Properties", {}).get("Environment", {}).get("Variables", {})
+        for key, value in env.items():
+            if key.endswith("_TTL_DAYS"):
+                continue
+            if any(word in key.lower() for word in secretish):
+                assert key.endswith("_SECRET_ARN"), (
+                    f"{key} looks like a secret carried in plaintext; pass an ARN instead"
+                )
+                assert isinstance(value, dict), f"{key} must be a reference, not a literal"
+
+
+def test_every_handler_path_matches_a_real_module_attribute(
+    template: dict[str, Any],
+) -> None:
+    """A renamed handler is a deploy that fails at the first invocation, not at deploy."""
+    import importlib
+
+    for resource in _resources(template).values():
+        if resource.get("Type") != "AWS::Serverless::Function":
+            continue
+        handler = resource["Properties"]["Handler"]
+        module_name, _, attribute = handler.rpartition(".")
+        module = importlib.import_module(module_name)
+        assert callable(getattr(module, attribute)), f"{handler} is not callable"
+
+
+def test_the_ingest_route_is_the_logical_path_the_signature_covers(
+    template: dict[str, Any],
+) -> None:
+    """The deploy-day bug this template most needed to avoid.
+
+    #17 signs the logical path `/leads`, not the stage-prefixed one, so that renaming a
+    stage cannot invalidate every signature the website produces. The route must therefore
+    be exactly that literal.
+    """
+    from leadquali.api.main import HEALTH_PATH, INGEST_PATH
+
+    events = _resources(template)["IngestFunction"]["Properties"]["Events"]
+    assert events["Ingest"]["Properties"]["Path"] == INGEST_PATH
+    assert events["Ingest"]["Properties"]["Method"] == "post"
+    assert events["Health"]["Properties"]["Path"] == HEALTH_PATH
+
+
+def test_the_feedback_base_url_includes_the_stage(template: dict[str, Any]) -> None:
+    """#19's links are clicked from an email, so the base must be externally routable."""
+    env = _resources(template)["WorkerFunction"]["Properties"]["Environment"]["Variables"]
+    assert "${Stage}" in env["FEEDBACK_BASE_URL"]["Fn::Sub"]
+
+
+def test_the_escalation_destination_is_required(template: dict[str, Any]) -> None:
+    """#14 makes it a required constructor argument; a default here would defeat that."""
+    assert "Default" not in template["Parameters"]["EscalationDestination"]
+
+
+def test_migrations_do_not_run_on_worker_cold_start(template: dict[str, Any]) -> None:
+    """A worker that migrates on cold start races N containers for one DDL lock."""
+    resources = _resources(template)
+    assert "MigrationFunction" in resources
+    assert resources["MigrationFunction"]["Properties"]["Handler"].endswith(
+        "migrate.lambda_handler"
+    )
+    worker_env = resources["WorkerFunction"]["Properties"]["Environment"]["Variables"]
+    assert not any("MIGRAT" in key.upper() for key in worker_env)
+
+
+def test_the_api_access_log_carries_no_request_body_or_headers(
+    template: dict[str, Any],
+) -> None:
+    """Invariant 5 applies to access logs: the body is a lead, the headers hold the key."""
+    fmt = _resources(template)["LeadApi"]["Properties"]["AccessLogSetting"]["Format"]
+    for forbidden in ("$input.body", "requestOverride", "authorization", "x-leadquali-key"):
+        assert forbidden.lower() not in fmt.lower()

--- a/tests/unit/test_layering.py
+++ b/tests/unit/test_layering.py
@@ -104,19 +104,29 @@ def _imported_paths(path: Path) -> set[str]:
     return names
 
 
-def test_only_the_ses_adapter_imports_boto3() -> None:
-    """``CLAUDE.md``: one file per external system, and ``boto3`` belongs to that one.
+def test_only_named_adapters_import_boto3() -> None:
+    """``CLAUDE.md``: one file per external system, and ``boto3`` belongs to those files.
 
-    Stated separately from the rule above because it binds the *adapters* too: SES is
-    reached from ``adapters/notify_ses.py`` and nowhere else, so swapping email for a Slack
-    notifier is a wiring change and an operator can find every AWS call by opening one file.
+    Stated separately from the rule above because it binds the *adapters* too. The
+    allowlist is per AWS service rather than a blanket "adapters may use boto3": SES is
+    reached from one file and SQS from one file, so swapping email for a Slack notifier,
+    or the queue for something else, stays a wiring change - and an operator can still
+    find every call to a given AWS service by opening a single module.
+
+    Adding a name here should be a deliberate act with a service behind it.
     """
-    owner = "adapters/notify_ses.py"
-    assert "boto3" in imported_modules(SRC / owner), "the adapter is supposed to own the SDK"
+    owners = {
+        "adapters/notify_ses.py": "SES",
+        "adapters/queue_sqs.py": "SQS",
+    }
+    for owner, service in owners.items():
+        assert "boto3" in imported_modules(SRC / owner), (
+            f"{owner} is supposed to own the {service} client"
+        )
     for path in python_sources():
         relative = path.relative_to(SRC).as_posix()
-        if relative == owner:
+        if relative in owners:
             continue
         assert "boto3" not in imported_modules(path), (
-            f"{relative} imports boto3; AWS belongs in {owner} alone"
+            f"{relative} imports boto3; AWS access belongs in {sorted(owners)} alone"
         )

--- a/tests/unit/test_queue_sqs.py
+++ b/tests/unit/test_queue_sqs.py
@@ -1,0 +1,177 @@
+"""The SQS producer and the worker's consumer, round-tripped against a fake queue.
+
+The property that matters is that the message shape is *unchanged* by the transport: what
+`QueuedLead.to_message()` produces is what `from_message()` gets back. A queue that
+reshapes its payload becomes a second schema nobody versioned.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+from typing import Any
+
+import boto3
+import pytest
+from botocore.exceptions import ClientError
+from moto import mock_aws
+
+from leadquali.adapters.queue_sqs import SqsLeadQueue
+from leadquali.api import worker
+from leadquali.app.ingest import QueuedLead
+from leadquali.prompts.lead import LeadSubmission
+
+QUEUE_NAME = "leadquali-test-leads"
+
+
+def _queued(**overrides: Any) -> QueuedLead:
+    defaults: dict[str, Any] = {
+        "tenant_id": "acme",
+        "lead_id": "11111111-1111-1111-1111-111111111111",
+        "submission_id": "sub-00000001",
+        "submission": LeadSubmission(full_name="Jane", email="jane@acme.test", message="hi"),
+        "source": "web_form",
+        "received_at": datetime(2026, 9, 4, 12, 0, tzinfo=UTC),
+        "trace_id": "trace-abc",
+    }
+    defaults.update(overrides)
+    return QueuedLead(**defaults)
+
+
+@pytest.fixture
+def sqs_queue() -> Any:
+    with mock_aws():
+        client = boto3.client("sqs", region_name="eu-west-1")
+        url = client.create_queue(QueueName=QUEUE_NAME)["QueueUrl"]
+        yield client, url
+
+
+def test_a_lead_round_trips_through_the_queue_unchanged(sqs_queue: Any) -> None:
+    client, url = sqs_queue
+    original = _queued()
+
+    SqsLeadQueue(client, url).enqueue(original)
+
+    received = client.receive_message(QueueUrl=url, MaxNumberOfMessages=1)["Messages"][0]
+    restored = QueuedLead.from_message(json.loads(received["Body"]))
+
+    assert restored.tenant_id == original.tenant_id
+    assert restored.submission_id == original.submission_id
+    assert restored.trace_id == original.trace_id
+    assert restored.submission.message == original.submission.message
+
+
+def test_the_body_is_deterministic_for_the_same_lead(sqs_queue: Any) -> None:
+    """Two identical leads produce identical bytes, which makes a redelivery diffable."""
+    client, url = sqs_queue
+    queue = SqsLeadQueue(client, url)
+    queue.enqueue(_queued())
+    queue.enqueue(_queued())
+
+    bodies = [
+        message["Body"]
+        for message in client.receive_message(QueueUrl=url, MaxNumberOfMessages=2)["Messages"]
+    ]
+    assert bodies[0] == bodies[1]
+
+
+def test_a_send_failure_is_raised_not_swallowed(sqs_queue: Any) -> None:
+    """Ingest has already persisted the lead; a silent enqueue failure would return a
+    202 the website believes about a lead that never gets qualified."""
+    client, _ = sqs_queue
+    queue = SqsLeadQueue(client, "https://sqs.eu-west-1.amazonaws.com/000000000000/nope")
+    with pytest.raises(ClientError):
+        queue.enqueue(_queued())
+
+
+# --------------------------------------------------------------------------- the consumer
+
+
+class _RecordingPipeline:
+    def __init__(self, *, fail_on: set[str] | None = None) -> None:
+        self.seen: list[str] = []
+        self._fail_on = fail_on or set()
+
+    def qualify(self, request: Any) -> None:
+        self.seen.append(request.submission_id)
+        if request.submission_id in self._fail_on:
+            raise RuntimeError("database unavailable")
+
+
+def _record(queued: QueuedLead, message_id: str) -> dict[str, Any]:
+    return {"messageId": message_id, "body": json.dumps(queued.to_message())}
+
+
+def test_a_healthy_batch_reports_no_failures() -> None:
+    pipeline = _RecordingPipeline()
+    event = {
+        "Records": [
+            _record(_queued(submission_id="sub-00000001"), "m1"),
+            _record(_queued(submission_id="sub-00000002"), "m2"),
+        ]
+    }
+    result = worker.handle(event, None, pipeline=pipeline)
+
+    assert result == {"batchItemFailures": []}
+    assert pipeline.seen == ["sub-00000001", "sub-00000002"]
+
+
+def test_one_failing_lead_does_not_drag_its_neighbours_back(caplog: Any) -> None:
+    """The whole reason for ReportBatchItemFailures: without it, nine healthy leads are
+    redelivered alongside the one that failed - and eventually emailed twice."""
+    pipeline = _RecordingPipeline(fail_on={"sub-00000002"})
+    event = {
+        "Records": [
+            _record(_queued(submission_id="sub-00000001"), "m1"),
+            _record(_queued(submission_id="sub-00000002"), "m2"),
+            _record(_queued(submission_id="sub-00000003"), "m3"),
+        ]
+    }
+    result = worker.handle(event, None, pipeline=pipeline)
+
+    assert result == {"batchItemFailures": [{"itemIdentifier": "m2"}]}
+    assert pipeline.seen == ["sub-00000001", "sub-00000002", "sub-00000003"], (
+        "a failure must not abort the rest of the batch"
+    )
+
+
+@pytest.mark.parametrize(
+    "body",
+    ["not json at all", '"a bare string"', "[]", '{"version": 1}', "{}"],
+)
+def test_an_undecodable_message_is_dropped_rather_than_retried_forever(body: str) -> None:
+    """It will not parse on the fourth attempt either, and ingest already stored the lead.
+
+    Reporting it as a failure would loop it until the DLQ, billed per invocation, for a
+    record that is already safe in Postgres.
+    """
+    pipeline = _RecordingPipeline()
+    result = worker.handle(
+        {"Records": [{"messageId": "m1", "body": body}]}, None, pipeline=pipeline
+    )
+
+    assert result == {"batchItemFailures": []}
+    assert pipeline.seen == []
+
+
+def test_a_message_without_a_trace_id_is_still_processed() -> None:
+    """#21 made the trace id additive and optional in both directions on purpose: an old
+    message in flight during a rolling deploy must not be refused."""
+    message = _queued().to_message()
+    message.pop("trace_id", None)
+    pipeline = _RecordingPipeline()
+
+    result = worker.handle(
+        {"Records": [{"messageId": "m1", "body": json.dumps(message)}]},
+        None,
+        pipeline=pipeline,
+    )
+
+    assert result == {"batchItemFailures": []}
+    assert pipeline.seen == ["sub-00000001"]
+
+
+def test_an_empty_batch_is_not_an_error() -> None:
+    assert worker.handle({"Records": []}, None, pipeline=_RecordingPipeline()) == {
+        "batchItemFailures": []
+    }


### PR DESCRIPTION
Closes #26. First of Phase 4, on top of #64.

`infra/template.yaml` provisions API Gateway, the ingest Lambda, SQS with a dead-letter queue, the worker and a migration function. `adapters/queue_sqs.py` and `api/worker.py` are the two ends of the transport.

## The numbers are argued, not defaulted

| Setting | Value | Why |
|---|---|---|
| `VisibilityTimeout` | 720s = **6× worker timeout** | SQS redelivers a message whose visibility expires *while it is still being worked*. Set it low and every slow lead is qualified twice — two Claude calls, and but for the idempotency key, two emails to sales. |
| `maxReceiveCount` | **3**, not the console default 10 | Each attempt costs a Claude call. Ten attempts on a lead that can never succeed is ten times the money **and** a ~40-minute delay before the DLQ alarm fires. |
| DLQ retention | **14 days** (the max) | A lead on the DLQ is one nobody has looked at yet. A long weekend must not lose it. |
| Worker reserved concurrency | parameter, default 5 | Each container holds one connection. This is the worst-case count against RDS Proxy — the Postgres decision's bill. |

## Per-message failures, not per-batch

`ReportBatchItemFailures` is the difference between one bad lead and ten. Without it, a poisoned message drags nine healthy neighbours back onto the queue, then to the DLQ alongside it — and on redelivery, emails them again.

A message that can **never** decode is logged and dropped rather than retried: it will not parse on the fourth attempt either, ingest already persisted the lead, and the alternative is an infinite redelivery loop billed per invocation. Anything that *might* succeed later — a database blip, a Claude timeout — is reported as a failure, which is the entire reason the queue exists.

## Migrations get their own function

Invoked once by the deploy pipeline, before traffic. **A worker that runs `alembic upgrade head` on cold start races N containers for one DDL lock**, and the first burst after a deploy is exactly when N is largest.

## Verification — and its limits

**`cfn-lint` 1.56 passes clean** (it was available, so the template gets real CloudFormation validation, not just a YAML parse). On top of that, 27 tests assert what cfn-lint cannot know — and **all eight mutations are caught**:

```
visibility below worker timeout  -> CAUGHT      no partial-batch failures    -> CAUGHT
no dead-letter redrive           -> CAUGHT      stage baked into route       -> CAUGHT
console default retries (10)     -> CAUGHT      dlq retention cut to 1 day   -> CAUGHT
no reserved concurrency          -> CAUGHT      api key as plaintext env var -> CAUGHT
```

One test resolves each `Handler:` string to a real module attribute, so a renamed handler fails here rather than at the first invocation in production. Another asserts the ingest route is exactly `INGEST_PATH` — **the deploy-day bug this template most needed to avoid**, since #59 signs the logical `/leads`, not the stage path, so a stage rename cannot invalidate every signature the website produces.

**No AWS account exists here, so nothing proves the stack stands up.** Only a real `sam deploy` can.

## Notes

- Secrets arrive as **Secrets Manager ARNs, never parameter values** — a secret passed as a parameter is visible in the stack's Parameters tab, in drift detection, and in any CI log that echoes the deploy. #28 provides them.
- The API access log carries **no request body and no headers**: the body is a lead, the headers hold the API key.
- The `boto3` layering test is now a **per-service allowlist** (SES one file, SQS one file) rather than a single owner. Same rule; nothing in `domain`, `app`, `api` or `observability` may appear.
- The worker wires `NullEnricher`, not #58's `EmailEnricher` — that lands on a parallel branch. Swap it in once both are on the default branch, **and read #58's VPC/DNS note first**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_