### PR TITLE
[P4.3] VPC, RDS Postgres, RDS Proxy and the connection arithmetic

### DIFF
--- a/docs/infrastructure-cost.md
+++ b/docs/infrastructure-cost.md
@@ -1,0 +1,87 @@
+# What the Postgres decision costs per month
+
+Plan §4 chose Postgres over DynamoDB and called the VPC an **accepted cost**. Plan §8
+prices the model at roughly **$25/month at 1,000 leads/month**. This page is the other
+number, so the two are visible next to each other rather than one being in the plan and
+the other being on an invoice.
+
+All figures are us-east-1 list price, 730 hours, the default parameters in
+`infra/network.yaml`. They are estimates from published rates, not measurements — no AWS
+account exists in this repository, so nothing here has been observed on a bill.
+
+## The bill, with the defaults as written
+
+| Line | Rate | Monthly |
+|---|---|---|
+| NAT gateway | $0.045/h | $32.85 |
+| NAT data processing | $0.045/GB × ~0.05 GB | $0.01 |
+| Public IPv4 address (the NAT's EIP) | $0.005/h | $3.65 |
+| RDS `db.t4g.micro`, single-AZ | $0.016/h | $11.68 |
+| RDS gp3 storage, 20 GiB | $0.115/GB | $2.30 |
+| RDS automated backups, 7 days | free up to allocated storage | $0.00 |
+| KMS customer-managed key | $1/key | $1.00 |
+| KMS requests | $0.03/10k | ~$0.01 |
+| CloudWatch Logs (`postgresql` export) | $0.50/GB ingest | ~$0.50 |
+| **RDS Proxy** | $0.015/vCPU-h, **8 vCPU floor for T-family** | **$87.60** |
+| | | **≈ $139.60** |
+
+At 1,000 leads/month that is **$0.140 per lead of infrastructure** against **$0.025 per
+lead of tokens**. The networking is not a rounding error next to the model; it is the
+larger half of the bill by a factor of five.
+
+## The line worth arguing about
+
+**RDS Proxy is $87.60/month in front of a database that costs $11.68/month.** The price is
+not set by our volume: RDS Proxy bills per vCPU-hour of the underlying instance with a
+floor of eight vCPUs for T-family instances, and `db.t4g.micro` has two. We pay for eight.
+
+What it buys at today's volume, stated honestly, is **not** connection headroom. With
+`pool_size=1` and a reserved concurrency of 5, the worker holds 5 of 112 connections; the
+database would survive without a proxy for a long time. What it buys is connection
+establishment taken off the Lambda cold-start path, transparent failover, and the ability
+to raise reserved concurrency later without reopening the connection question.
+
+#27 mandates the proxy, so `EnableRdsProxy` defaults to `true`. It is a parameter rather
+than a hardcoded resource so that the owner can see this number and decide. Turning it off
+drops the stack to **≈ $52.00/month** and points the application at the instance endpoint;
+the connection arithmetic holds either way, because it is bounded by reserved concurrency
+rather than by the proxy.
+
+## The egress decision, priced
+
+The worker must reach api.anthropic.com, SES, Secrets Manager, CloudWatch Logs and X-Ray.
+#27 states a preference for interface VPC endpoints over a NAT gateway. That preference
+does not survive the first item on the list: Anthropic is a third-party public API with no
+PrivateLink endpoint and no fixed prefix list, so *some* route to the public internet is
+required regardless. Endpoints are therefore an addition to the NAT, not a substitute.
+
+| Option | Monthly |
+|---|---|
+| **A — one NAT gateway, no endpoints (chosen)** | **$36.51** |
+| B — interface endpoints for the four AWS services (4 × 2 AZs × $0.01/h = $58.40) plus the NAT that Anthropic still requires | $94.91 |
+
+Option B costs 2.6× Option A and buys a few milliseconds off the Secrets Manager call on a
+cold start. It would win if AWS-service traffic were large enough for endpoint data rates
+($0.01/GB) to beat NAT processing ($0.045/GB); the crossover is near 1.7 TB/month and this
+workload moves about 50 MB.
+
+**One NAT, not one per AZ.** A second costs another $36.51/month and removes exactly one
+failure: an outage of the NAT's own AZ. What that failure does here is stop egress for both
+private subnets, so Claude calls fail, SQS redelivers, and leads are qualified when egress
+returns. Nothing is dropped — invariant 3 is held by the queue, not by the NAT. Converting
+a delay into no delay is not worth $438/year at this volume.
+
+## When to revisit
+
+- **Volume crosses plan §12's thresholds.** Under ~50 leads/day, RDS Proxy and possibly
+  SQS are deferrable. Over ~5,000/day the proxy's fixed price stops being the headline and
+  the instance class becomes the question.
+- **`db.t4g.micro` stops being enough.** Moving to `db.t4g.small` doubles the instance to
+  $23.36 and, because the proxy's floor is already above the instance, does not change the
+  proxy line at all. It also raises `max_connections` to 225, which the concurrency
+  arithmetic in `infra/network.yaml` reads from a mapping rather than a memory.
+- **Multi-AZ.** `DbMultiAz` defaults to `false`; setting it doubles the instance line.
+- **Aurora Serverless v2**, allowed by plan §4, was priced and rejected: at $0.12/ACU-hour
+  even a 0.5-ACU floor is $43.80/month before storage and I/O, and a worker that runs
+  every few minutes keeps the cluster from reaching the 0-ACU auto-pause that would make
+  it cheap. It costs roughly 4× the instance it would replace.

--- a/infra/network.yaml
+++ b/infra/network.yaml
@@ -1,0 +1,835 @@
+AWSTemplateFormatVersion: "2010-09-09"
+Description: >
+  JAT-LeadQuali network and data tier (#27): VPC, private subnets, egress, RDS Postgres,
+  RDS Proxy. This is the bill for the Postgres decision (plan section 4) — an accepted
+  cost, priced in the comments below rather than discovered on an invoice.
+
+  Deployed as its own stack, separately from infra/template.yaml, for three reasons.
+  (1) #26 already made the subnets and security groups *parameters* of the application
+  template; honouring that seam is what this stack is for. (2) Lifecycle: the application
+  stack is deployed on every merge, and a stack that is deployed twenty times a week must
+  not be able to replace a database. Everything stateful lives here, behind Snapshot
+  deletion policies, and is touched deliberately. (3) Time: a NAT gateway and an RDS
+  Proxy take fifteen to twenty-five minutes to create. Coupling that to a two-minute
+  Lambda deploy makes every deploy slow and every rollback frightening.
+
+  Its Outputs are the application stack's Parameters. Deploy this first, once.
+
+Parameters:
+  Stage:
+    Type: String
+    Default: prod
+    AllowedValues: [dev, staging, prod]
+    Description: Deployment stage. Must match the application stack's Stage.
+  VpcCidr:
+    Type: String
+    Default: 10.42.0.0/16
+    AllowedPattern: "^(\\d{1,3}\\.){3}\\d{1,3}/\\d{1,2}$"
+    Description: >
+      VPC address range. /16 is deliberate slack, not need: the workload is three Lambda
+      functions and a database, but resizing a VPC means rebuilding it.
+  DbInstanceClass:
+    Type: String
+    Default: db.t4g.micro
+    AllowedValues: [db.t4g.micro, db.t4g.small, db.t4g.medium]
+    Description: >
+      Plan section 4 names db.t4g.micro. The allowed set is exactly the set of classes
+      whose max_connections is recorded in the InstanceCapacity mapping below, because the
+      connection arithmetic in this stack is only valid for a class it has a number for.
+  DbEngineVersion:
+    Type: String
+    Default: "16.4"
+    Description: >
+      Postgres major.minor. Its major version must match DbParameterGroupFamily; a
+      mismatch is rejected by RDS at create time and by tests/unit/test_infra_network.py
+      before that.
+  DbParameterGroupFamily:
+    Type: String
+    Default: postgres16
+    Description: Parameter group family. Tied to DbEngineVersion's major version.
+  DbAllocatedStorage:
+    Type: Number
+    Default: 20
+    MinValue: 20
+    MaxValue: 1000
+    Description: Initial gp3 storage in GiB. 20 is the RDS minimum.
+  DbMaxAllocatedStorage:
+    Type: Number
+    Default: 100
+    MinValue: 20
+    MaxValue: 4000
+    Description: >
+      Storage autoscaling ceiling. Leads are small rows; the ceiling exists so a runaway
+      write cannot fill the volume and take the database read-only at 3am.
+  DbBackupRetentionDays:
+    Type: Number
+    Default: 7
+    MinValue: 1
+    MaxValue: 35
+    Description: >
+      Automated backup retention. MinValue is 1, not 0: zero disables automated backups
+      entirely, and this template must not be able to express that.
+  DbMultiAz:
+    Type: String
+    Default: "false"
+    AllowedValues: ["true", "false"]
+    Description: >
+      Multi-AZ doubles the instance cost (see the cost note below) to remove an AZ failure
+      from the failure list. At hundreds of leads a day behind SQS, an AZ failure delays
+      qualification and drops nothing, so the default is off. Turn it on when a customer's
+      contract says so, not before.
+  EnableRdsProxy:
+    Type: String
+    Default: "true"
+    AllowedValues: ["true", "false"]
+    Description: >
+      RDS Proxy in front of the database. The default is "true" because #27 mandates it.
+      It is a parameter, and not a hardcoded resource, because it is the single most
+      expensive line in this stack (~$87.60/month — see the cost note) and its price is
+      set by a vCPU floor that has nothing to do with our volume. Turning it off points
+      the application at the instance endpoint instead; the connection arithmetic below
+      holds either way, because it is bounded by reserved concurrency, not by the proxy.
+  ProxyMaxConnectionsPercent:
+    Type: Number
+    Default: 75
+    MinValue: 10
+    MaxValue: 100
+    Description: >
+      Share of the database's max_connections that RDS Proxy may hold as backend
+      connections. Deliberately below 100: the migration Lambda connects directly (it must
+      not go through the proxy — see MigrationSecurityGroup), Postgres reserves
+      superuser_reserved_connections, and an operator with psql during an incident needs a
+      slot that a saturated proxy has not already taken.
+  ProxyMaxIdleConnectionsPercent:
+    Type: Number
+    Default: 50
+    MinValue: 0
+    MaxValue: 100
+    Description: >
+      Share of max_connections the proxy may keep idle for reuse. Idle backend
+      connections are what make a Lambda cold start cheap; keeping half the budget warm
+      is the trade this proxy exists to make.
+
+Mappings:
+  # max_connections per instance class, from the RDS Postgres default
+  # `LEAST({DBInstanceClassMemory/9531392}, 5000)`. These numbers are not left to that
+  # formula at runtime: DbParameterGroup below pins max_connections to exactly this value,
+  # so the number the arithmetic depends on is a number this template sets, not one a
+  # memory calculation happens to produce on the day. Pinning at or below the
+  # memory-derived default is safe; above it trades OOM for connections.
+  InstanceCapacity:
+    db.t4g.micro:   # 1 GiB
+      MaxConnections: "112"
+    db.t4g.small:   # 2 GiB
+      MaxConnections: "225"
+    db.t4g.medium:  # 4 GiB
+      MaxConnections: "450"
+
+Conditions:
+  ProxyEnabled: !Equals [!Ref EnableRdsProxy, "true"]
+  ProxyDisabled: !Equals [!Ref EnableRdsProxy, "false"]
+
+Resources:
+  # ---------------------------------------------------------------------------------
+  # Network
+  #
+  # EnableDnsSupport and EnableDnsHostnames are both required, and the first one is not
+  # optional in the way it looks. A Lambda in a private subnet resolves names through the
+  # Amazon-provided resolver at the VPC's base address plus two (and the link-local
+  # 169.254.169.253). That resolver only exists when EnableDnsSupport is true. Turn it
+  # off and every outbound lookup — Anthropic, SES, Secrets Manager — times out rather
+  # than failing fast; #18's enrichment circuit breaker opens, every lead is enriched with
+  # nothing, every lead is still delivered, and no alarm fires because nothing errored.
+  # That is the specific silent failure this VPC is built to not have.
+  #
+  # Note that DNS *resolution* does not traverse the NAT gateway: the resolver is inside
+  # the VPC and reaches public DNS on its own. The NAT is for the HTTPS connection that
+  # follows the lookup. No Route 53 Resolver outbound endpoint is needed — that is for
+  # resolving on-premises names, which this workload has none of.
+  # ---------------------------------------------------------------------------------
+  Vpc:
+    Type: AWS::EC2::VPC
+    Properties:
+      CidrBlock: !Ref VpcCidr
+      EnableDnsSupport: true
+      EnableDnsHostnames: true
+      InstanceTenancy: default
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}"
+
+  InternetGateway:
+    Type: AWS::EC2::InternetGateway
+    Properties:
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-igw"
+
+  InternetGatewayAttachment:
+    Type: AWS::EC2::VPCGatewayAttachment
+    Properties:
+      VpcId: !Ref Vpc
+      InternetGatewayId: !Ref InternetGateway
+
+  # The only public subnet, and the only thing in it is the NAT gateway.
+  # MapPublicIpOnLaunch is false so that anything else accidentally launched here is not
+  # reachable from the internet by default.
+  NatSubnet:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: !Select [0, !Cidr [!Ref VpcCidr, 4, 8]]
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-nat"
+
+  PrivateSubnetA:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: !Select [1, !Cidr [!Ref VpcCidr, 4, 8]]
+      AvailabilityZone: !Select [0, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-private-a"
+
+  PrivateSubnetB:
+    Type: AWS::EC2::Subnet
+    Properties:
+      VpcId: !Ref Vpc
+      CidrBlock: !Select [2, !Cidr [!Ref VpcCidr, 4, 8]]
+      AvailabilityZone: !Select [1, !GetAZs ""]
+      MapPublicIpOnLaunch: false
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-private-b"
+
+  NatEip:
+    Type: AWS::EC2::EIP
+    Properties:
+      Domain: vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-nat"
+
+  # ---------------------------------------------------------------------------------
+  # Egress: one NAT gateway. The decision, and the arithmetic behind it.
+  #
+  # #27 states a preference for interface VPC endpoints over a NAT gateway. That
+  # preference was written before the worker's full egress list was traced through, and
+  # the arithmetic reverses it. The list is: Anthropic (api.anthropic.com), SES, Secrets
+  # Manager, CloudWatch Logs, X-Ray. Four of those five have interface endpoints. The
+  # first does not and never will — it is a third-party public API, so *some* route to the
+  # public internet is required no matter what. Endpoints are therefore not a substitute
+  # for the NAT here; they are an addition to it.
+  #
+  # us-east-1 list prices, 730 hours:
+  #
+  #   Option A — NAT only (chosen)
+  #     NAT gateway            730 h x $0.045/h            = $32.85
+  #     NAT data processing    ~0.05 GB x $0.045/GB        =  $0.01
+  #     Public IPv4 (EIP)      730 h x $0.005/h            =  $3.65
+  #                                                   total  ~$36.51/month
+  #
+  #   Option B — interface endpoints for the AWS services, plus NAT for Anthropic
+  #     4 endpoints x 2 AZs    8 x 730 h x $0.01/h         = $58.40
+  #     endpoint data          ~0.05 GB x $0.01/GB         =  $0.00
+  #     NAT gateway (still required for Anthropic)         = $36.51
+  #                                                   total  ~$94.91/month
+  #
+  # Option B costs 2.6x Option A and buys, at this volume, a few milliseconds off the
+  # Secrets Manager call on a cold start. It would win if the AWS-service traffic were
+  # large enough for endpoint data rates ($0.01/GB) to beat NAT processing ($0.045/GB) —
+  # the crossover is around 1.7 TB/month, and this workload moves about 50 MB. Option A.
+  #
+  # One NAT, not one per AZ. A second NAT in the other AZ costs another $36.51/month and
+  # removes one failure: an outage of the NAT's own AZ. What that failure actually does
+  # here is stop egress for the workers in both private subnets, which means Claude calls
+  # fail, which means SQS redelivers, which means leads queue up and are qualified when
+  # egress returns. Nothing is dropped — invariant 3 is held by the queue, not by the NAT.
+  # Paying $438/year to convert a delay into no delay is not the best available use of
+  # that money at this volume. Revisit if leads/day crosses the threshold in plan §12.
+  #
+  # Cross-AZ cost: traffic from PrivateSubnetB to the NAT in AZ A is billed at $0.01/GB
+  # each way. At ~50 MB/month that is under a cent.
+  # ---------------------------------------------------------------------------------
+  NatGateway:
+    Type: AWS::EC2::NatGateway
+    Properties:
+      AllocationId: !GetAtt NatEip.AllocationId
+      SubnetId: !Ref NatSubnet
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-nat"
+
+  PublicRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-public"
+
+  PublicDefaultRoute:
+    Type: AWS::EC2::Route
+    DependsOn: InternetGatewayAttachment
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      GatewayId: !Ref InternetGateway
+
+  NatSubnetRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PublicRouteTable
+      SubnetId: !Ref NatSubnet
+
+  # One private route table shared by both private subnets, because there is one NAT.
+  # If a second NAT is ever added, this splits into one table per AZ — that is the change,
+  # and it is why the association resources are named per subnet already.
+  PrivateRouteTable:
+    Type: AWS::EC2::RouteTable
+    Properties:
+      VpcId: !Ref Vpc
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-private"
+
+  PrivateDefaultRoute:
+    Type: AWS::EC2::Route
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      DestinationCidrBlock: 0.0.0.0/0
+      NatGatewayId: !Ref NatGateway
+
+  PrivateSubnetARouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnetA
+
+  PrivateSubnetBRouteTableAssociation:
+    Type: AWS::EC2::SubnetRouteTableAssociation
+    Properties:
+      RouteTableId: !Ref PrivateRouteTable
+      SubnetId: !Ref PrivateSubnetB
+
+  # ---------------------------------------------------------------------------------
+  # Security groups.
+  #
+  # Written as identities rather than addresses. Every rule that can name a security
+  # group names one, because "port 5432 from sg-lambda" keeps meaning the right thing
+  # after someone renumbers a subnet, and "port 5432 from 10.42.1.0/24" only happens to
+  # be right today. The two exceptions are the rules that genuinely are about addresses:
+  # HTTPS to the public internet, and DNS to the VPC resolver.
+  #
+  # The shape is a chain, and each link is one direction only:
+  #
+  #   LambdaSecurityGroup    --5432-->  ProxySecurityGroup  --5432-->  DatabaseSecurityGroup
+  #   MigrationSecurityGroup ------------------5432------------------>
+  #
+  # The worker and the ingest function share LambdaSecurityGroup and can reach the proxy
+  # and nothing else on 5432. They cannot reach the database directly. That is not
+  # decoration: the connection budget in this stack is enforced by the proxy's
+  # MaxConnectionsPercent, and a function that could open a direct connection could walk
+  # straight past it.
+  #
+  # The migration function gets its own group and is the only thing allowed to bypass the
+  # proxy, because a migration is exactly the workload RDS Proxy is bad at — one long
+  # session holding DDL locks and an advisory lock, which pins a backend connection for
+  # the duration and defeats multiplexing for everyone else. It runs once per deploy at a
+  # reserved concurrency of one, so it costs exactly one connection.
+  #
+  # DatabaseSecurityGroup has no CIDR ingress rule of any kind. There is no rule to get
+  # wrong, and PubliclyAccessible: false below means there is no public address to point
+  # one at either.
+  # ---------------------------------------------------------------------------------
+  DatabaseSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: >-
+        Postgres. Ingress only from the proxy and the migration function, both by group id.
+      VpcId: !Ref Vpc
+      # CloudFormation adds an allow-all egress rule to any security group that does not
+      # declare one, so this declares one. A database initiates nothing; the loopback
+      # destination is the conventional way to say "no egress" in CloudFormation, which
+      # has no way to express an empty egress list.
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          CidrIp: 127.0.0.1/32
+          Description: No egress. Postgres never initiates a connection.
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-db"
+
+  LambdaSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: >-
+        Worker and ingest Lambda functions. Egress only: HTTPS out, DNS to the VPC
+        resolver, Postgres to the proxy.
+      VpcId: !Ref Vpc
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+          Description: >-
+            HTTPS via the NAT gateway: api.anthropic.com, SES, Secrets Manager, CloudWatch
+            Logs, X-Ray. Anthropic is a third-party public endpoint with no fixed address
+            range, so this cannot be narrowed to a prefix list.
+        # The two DNS rules are the finding from #18 written as configuration. Egress
+        # rules apply to DNS queries as much as to anything else, so a security group
+        # locked to 443 resolves no names at all: every lookup times out, the enrichment
+        # circuit breaker opens, leads are enriched with nothing, and nothing errors
+        # loudly enough to page anyone. Both destinations are needed — the Amazon-provided
+        # resolver sits at the VPC base address plus two, and the link-local address is
+        # the alias for it.
+        - IpProtocol: udp
+          FromPort: 53
+          ToPort: 53
+          CidrIp: !Ref VpcCidr
+          Description: DNS to the Amazon-provided resolver (VPC base + 2).
+        - IpProtocol: tcp
+          FromPort: 53
+          ToPort: 53
+          CidrIp: !Ref VpcCidr
+          Description: DNS over TCP, for responses that do not fit in a UDP datagram.
+        - IpProtocol: udp
+          FromPort: 53
+          ToPort: 53
+          CidrIp: 169.254.169.253/32
+          Description: DNS to the link-local resolver alias.
+        - IpProtocol: tcp
+          FromPort: 53
+          ToPort: 53
+          CidrIp: 169.254.169.253/32
+          Description: DNS over TCP to the link-local resolver alias.
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-lambda"
+
+  MigrationSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: >-
+        Migration Lambda. The only group permitted to reach Postgres directly, bypassing
+        the proxy, because alembic holds one long transaction and would pin a backend.
+      VpcId: !Ref Vpc
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          DestinationSecurityGroupId: !Ref DatabaseSecurityGroup
+          Description: Postgres, direct. One connection, reserved concurrency of one.
+        - IpProtocol: tcp
+          FromPort: 443
+          ToPort: 443
+          CidrIp: 0.0.0.0/0
+          Description: Secrets Manager and CloudWatch Logs via the NAT gateway.
+        - IpProtocol: udp
+          FromPort: 53
+          ToPort: 53
+          CidrIp: !Ref VpcCidr
+          Description: DNS to the Amazon-provided resolver.
+        - IpProtocol: tcp
+          FromPort: 53
+          ToPort: 53
+          CidrIp: !Ref VpcCidr
+          Description: DNS over TCP.
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-migrate"
+
+  ProxySecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: RDS Proxy. In from the Lambda group, out to the database group.
+      VpcId: !Ref Vpc
+      SecurityGroupIngress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          SourceSecurityGroupId: !Ref LambdaSecurityGroup
+          Description: Worker and ingest, by group id.
+      SecurityGroupEgress:
+        - IpProtocol: tcp
+          FromPort: 5432
+          ToPort: 5432
+          DestinationSecurityGroupId: !Ref DatabaseSecurityGroup
+          Description: The pooled backend connections.
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-proxy"
+
+  # Declared as standalone rules rather than inline, because inline rules in both
+  # directions between two groups are a circular dependency CloudFormation refuses.
+  LambdaToProxyEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Properties:
+      GroupId: !Ref LambdaSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      DestinationSecurityGroupId: !Ref ProxySecurityGroup
+      Description: Postgres via RDS Proxy. The only database path the worker has.
+
+  DatabaseIngressFromProxy:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref DatabaseSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      SourceSecurityGroupId: !Ref ProxySecurityGroup
+      Description: Pooled connections from RDS Proxy.
+
+  DatabaseIngressFromMigration:
+    Type: AWS::EC2::SecurityGroupIngress
+    Properties:
+      GroupId: !Ref DatabaseSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      SourceSecurityGroupId: !Ref MigrationSecurityGroup
+      Description: alembic upgrade head, once per deploy.
+
+  # Only when the proxy is switched off: the worker then needs the direct path the proxy
+  # would otherwise have provided. Both halves are conditional, so turning the proxy back
+  # on removes the bypass rather than leaving it behind.
+  LambdaDirectToDatabaseEgress:
+    Type: AWS::EC2::SecurityGroupEgress
+    Condition: ProxyDisabled
+    Properties:
+      GroupId: !Ref LambdaSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      DestinationSecurityGroupId: !Ref DatabaseSecurityGroup
+      Description: Direct Postgres, only while EnableRdsProxy is false.
+
+  DatabaseIngressFromLambda:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: ProxyDisabled
+    Properties:
+      GroupId: !Ref DatabaseSecurityGroup
+      IpProtocol: tcp
+      FromPort: 5432
+      ToPort: 5432
+      SourceSecurityGroupId: !Ref LambdaSecurityGroup
+      Description: Direct Postgres, only while EnableRdsProxy is false.
+
+  # ---------------------------------------------------------------------------------
+  # Data tier
+  # ---------------------------------------------------------------------------------
+  DatabaseKmsKey:
+    Type: AWS::KMS::Key
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Description: !Sub "leadquali-${Stage} RDS encryption at rest"
+      EnableKeyRotation: true
+      PendingWindowInDays: 30
+      KeyPolicy:
+        Version: "2012-10-17"
+        Id: !Sub "leadquali-${Stage}-db-key"
+        Statement:
+          # A customer-managed key rather than the account's aws/rds key, because plan
+          # section 8 treats leads as personal data: a CMK is what makes "revoke access to
+          # the data" and "prove the key is rotated" answerable. It costs $1/month.
+          # DeletionPolicy Retain is deliberate — deleting the key destroys every snapshot
+          # taken with it, which would make the Snapshot policy on the instance a lie.
+          - Sid: AllowAccountAdministration
+            Effect: Allow
+            Principal:
+              AWS: !Sub "arn:${AWS::Partition}:iam::${AWS::AccountId}:root"
+            Action: "kms:*"
+            Resource: "*"
+
+  DatabaseKmsAlias:
+    Type: AWS::KMS::Alias
+    Properties:
+      AliasName: !Sub "alias/leadquali-${Stage}-db"
+      TargetKeyId: !Ref DatabaseKmsKey
+
+  DatabaseSubnetGroup:
+    Type: AWS::RDS::DBSubnetGroup
+    Properties:
+      DBSubnetGroupDescription: >-
+        Private subnets, two availability zones. RDS requires two AZs even for a
+        single-AZ instance, so that a failover or a class change has somewhere to land.
+      SubnetIds:
+        - !Ref PrivateSubnetA
+        - !Ref PrivateSubnetB
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}-db"
+
+  # ---------------------------------------------------------------------------------
+  # THE CONNECTION ARITHMETIC. This is the relationship a future person will break.
+  #
+  # It is written here as parameters and pinned settings rather than as a remembered
+  # number, and tests/unit/test_infra_network.py recomputes it from both templates on
+  # every test run.
+  #
+  #   Given (this stack):
+  #     max_connections                    112   pinned below, from InstanceCapacity
+  #     superuser_reserved_connections       3   pinned below
+  #     ProxyMaxConnectionsPercent          75%
+  #
+  #   Derived:
+  #     proxy backend budget = floor(112 x 75 / 100)                        =  84
+  #     migration function, direct, ReservedConcurrentExecutions = 1        =   1
+  #     Postgres superuser reserve                                          =   3
+  #     ------------------------------------------------------------------------
+  #     committed                                                              88
+  #     operator headroom (psql during an incident, monitoring)              =  24
+  #                                                                     total  112
+  #
+  #   Required of the application stack (infra/template.yaml):
+  #     each Lambda container holds exactly one connection, because
+  #     store_postgres.engine_for uses pool_size=1 and max_overflow=0, so
+  #
+  #       WorkerReservedConcurrency + IngestReservedConcurrency <= 84
+  #
+  #     CloudFormation cannot express a constraint across two parameters, so it is split
+  #     into per-parameter MaxValues that sum below the budget — 50 + 30 = 80 <= 84 —
+  #     which means a deploy that violates it is rejected by CloudFormation itself, not
+  #     merely by a test. The test asserts the sum, which is the half CloudFormation
+  #     cannot see. Defaults are 5 and 20, so the everyday peak is 25 of 84.
+  #
+  #   Raising DbInstanceClass raises max_connections (see InstanceCapacity) and therefore
+  #   the budget; the MaxValues in the application stack must then be raised deliberately,
+  #   and the test will say so if they are not.
+  # ---------------------------------------------------------------------------------
+  DatabaseParameterGroup:
+    Type: AWS::RDS::DBParameterGroup
+    Properties:
+      Description: !Sub "leadquali-${Stage}: pinned connection budget and session hygiene"
+      Family: !Ref DbParameterGroupFamily
+      Parameters:
+        # Pinned, not left to the default formula LEAST({DBInstanceClassMemory/9531392},
+        # 5000). The whole budget above depends on this number, and a number that is
+        # computed from instance memory at boot is a number nobody can read off a
+        # template. Pinning it at the class's memory-derived default changes nothing about
+        # capacity and makes the arithmetic auditable.
+        max_connections: !FindInMap [InstanceCapacity, !Ref DbInstanceClass, MaxConnections]
+        superuser_reserved_connections: "3"
+        # Five minutes. A session that has held a transaction open that long has leaked
+        # one: it holds locks the redelivered SQS message will wait on, and it is the
+        # state that makes RDS Proxy pin a client to a backend. The store commits every
+        # unit of work before returning, so nothing legitimate here comes close; the
+        # migration Lambda's own timeout is 300 s, so it cannot be caught by this either.
+        idle_in_transaction_session_timeout: "300000"
+        rds.force_ssl: "1"
+        log_min_duration_statement: "1000"
+
+  Database:
+    Type: AWS::RDS::DBInstance
+    # Snapshot, not Delete: the feedback loop in this database is the product's moat
+    # (plan section 4), and a stack deletion must not be able to take it.
+    DeletionPolicy: Snapshot
+    UpdateReplacePolicy: Snapshot
+    Properties:
+      DBInstanceIdentifier: !Sub "leadquali-${Stage}"
+      DBName: leadquali
+      Engine: postgres
+      EngineVersion: !Ref DbEngineVersion
+      DBInstanceClass: !Ref DbInstanceClass
+      DBParameterGroupName: !Ref DatabaseParameterGroup
+      DBSubnetGroupName: !Ref DatabaseSubnetGroup
+      VPCSecurityGroups:
+        - !Ref DatabaseSecurityGroup
+      # No public address exists. This is the acceptance criterion, and it is also what
+      # makes the migration story in #26 honest: migrations run from a Lambda inside the
+      # VPC because there is no other way in, not because someone remembered not to.
+      PubliclyAccessible: false
+      MultiAZ: !Ref DbMultiAz
+      AllocatedStorage: !Ref DbAllocatedStorage
+      MaxAllocatedStorage: !Ref DbMaxAllocatedStorage
+      StorageType: gp3
+      StorageEncrypted: true
+      KmsKeyId: !GetAtt DatabaseKmsKey.Arn
+      # The master password is never in this template, never a stack parameter and never
+      # in a CI log: RDS generates it into Secrets Manager and rotates it there. #28
+      # composes the application's DATABASE_URL from this secret and DatabaseEndpoint.
+      ManageMasterUserPassword: true
+      MasterUsername: leadquali
+      BackupRetentionPeriod: !Ref DbBackupRetentionDays
+      PreferredBackupWindow: "03:10-03:40"
+      PreferredMaintenanceWindow: "sun:04:00-sun:05:00"
+      CopyTagsToSnapshot: true
+      DeletionProtection: true
+      AutoMinorVersionUpgrade: true
+      EnableCloudwatchLogsExports:
+        - postgresql
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}"
+
+  DatabaseProxyRole:
+    Type: AWS::IAM::Role
+    Condition: ProxyEnabled
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: "2012-10-17"
+        Statement:
+          - Effect: Allow
+            Principal:
+              Service: rds.amazonaws.com
+            Action: sts:AssumeRole
+      Policies:
+        - PolicyName: read-master-user-secret
+          PolicyDocument:
+            Version: "2012-10-17"
+            Statement:
+              - Effect: Allow
+                Action:
+                  - secretsmanager:GetSecretValue
+                  - secretsmanager:DescribeSecret
+                Resource: !GetAtt Database.MasterUserSecret.SecretArn
+              - Effect: Allow
+                Action: kms:Decrypt
+                # The RDS-managed master user secret is encrypted with the account's
+                # aws/secretsmanager key, whose ARN this template cannot name. The
+                # ViaService condition is what keeps this from being a general decrypt
+                # grant: the role can only use KMS through Secrets Manager.
+                Resource: "*"
+                Condition:
+                  StringEquals:
+                    kms:ViaService: !Sub "secretsmanager.${AWS::Region}.amazonaws.com"
+
+  # RDS Proxy. Its price is the surprise in this stack and is stated here rather than
+  # left for the first invoice: RDS Proxy bills $0.015 per vCPU-hour of the underlying
+  # instance, with a floor of 8 vCPUs for T-family instances. That is
+  # 8 x 730 x $0.015 = $87.60/month in front of a database that costs $11.68/month —
+  # seven times the instance, and more than three times the entire per-lead token budget
+  # in plan section 8. The floor is fixed, so this does not get cheaper with volume; it
+  # gets *relatively* cheaper, and only when volume grows.
+  #
+  # What it buys at today's volume, honestly: not connection headroom. With pool_size=1
+  # and a reserved concurrency of 5, the worker holds 5 of 112 connections, and the
+  # database would survive without a proxy. What it buys is (a) connection establishment
+  # taken off the cold-start path, which matters because Lambda churns containers, (b)
+  # failover transparency, and (c) the ability to raise reserved concurrency later without
+  # a second conversation about connections. #27 mandates it, so it is on by default; the
+  # EnableRdsProxy parameter exists so the owner can see the price and decide, and so the
+  # decision is a parameter change rather than a template rewrite.
+  DatabaseProxy:
+    Type: AWS::RDS::DBProxy
+    Condition: ProxyEnabled
+    Properties:
+      DBProxyName: !Sub "leadquali-${Stage}"
+      EngineFamily: POSTGRESQL
+      RoleArn: !GetAtt DatabaseProxyRole.Arn
+      VpcSubnetIds:
+        - !Ref PrivateSubnetA
+        - !Ref PrivateSubnetB
+      VpcSecurityGroupIds:
+        - !Ref ProxySecurityGroup
+      RequireTLS: true
+      # 1800 s, comfortably above the adapter's pool_recycle of 300 s. The ordering is the
+      # point: the client must give up a connection before the proxy does, or a warm
+      # container wakes onto a socket the proxy has already closed. pool_pre_ping turns
+      # that into a reconnect rather than a failure, but a reconnect on the request path
+      # is latency nobody asked for.
+      IdleClientTimeout: 1800
+      DebugLogging: false
+      Auth:
+        - AuthScheme: SECRETS
+          SecretArn: !GetAtt Database.MasterUserSecret.SecretArn
+          IAMAuth: DISABLED
+          ClientPasswordAuthType: POSTGRES_SCRAM_SHA_256
+      Tags:
+        - Key: Name
+          Value: !Sub "leadquali-${Stage}"
+
+  DatabaseProxyTargetGroup:
+    Type: AWS::RDS::DBProxyTargetGroup
+    Condition: ProxyEnabled
+    Properties:
+      DBProxyName: !Ref DatabaseProxy
+      # "default" is the only name RDS accepts for a proxy target group.
+      TargetGroupName: default
+      DBInstanceIdentifiers:
+        - !Ref Database
+      ConnectionPoolConfigurationInfo:
+        MaxConnectionsPercent: !Ref ProxyMaxConnectionsPercent
+        MaxIdleConnectionsPercent: !Ref ProxyMaxIdleConnectionsPercent
+        # Seconds a client waits for a backend connection before the proxy gives up. Kept
+        # short on purpose: the worker is behind SQS, so failing fast and letting the
+        # message be redelivered is strictly better than holding a Lambda invocation open
+        # and paying for it. It is also the signal that the concurrency cap is set wrong.
+        ConnectionBorrowTimeout: 30
+        # Prepared statements are the classic pinning trigger. store_postgres already
+        # disables them at the client with prepare_threshold=None; this is the same
+        # statement made on the proxy side, so a future client that forgets degrades to
+        # pinning-with-a-warning rather than to silent serialisation.
+        SessionPinningFilters:
+          - EXCLUDE_VARIABLE_SETS
+
+Outputs:
+  VpcId:
+    Description: For anything later that needs to attach to this network.
+    Value: !Ref Vpc
+    Export:
+      Name: !Sub "leadquali-${Stage}-vpc-id"
+  PrivateSubnetIds:
+    Description: >-
+      The application stack's VpcSubnetIds parameter. Two AZs, no route to an internet
+      gateway.
+    Value: !Join [",", [!Ref PrivateSubnetA, !Ref PrivateSubnetB]]
+    Export:
+      Name: !Sub "leadquali-${Stage}-private-subnet-ids"
+  LambdaSecurityGroupId:
+    Description: The application stack's VpcSecurityGroupIds parameter (worker + ingest).
+    Value: !Ref LambdaSecurityGroup
+    Export:
+      Name: !Sub "leadquali-${Stage}-lambda-sg-id"
+  MigrationSecurityGroupId:
+    Description: >-
+      The application stack's MigrationSecurityGroupIds parameter. Separate because this
+      is the only group that may reach Postgres without going through the proxy.
+    Value: !Ref MigrationSecurityGroup
+    Export:
+      Name: !Sub "leadquali-${Stage}-migration-sg-id"
+  DatabaseEndpoint:
+    Description: >-
+      What #28 puts in DATABASE_URL. The proxy endpoint when the proxy is enabled, the
+      instance endpoint when it is not, so that the switch is invisible to the application.
+      Append sslmode=require — the instance sets rds.force_ssl and the proxy sets
+      RequireTLS, so a URL that negotiates plaintext will simply be refused.
+    Value: !If
+      - ProxyEnabled
+      - !GetAtt DatabaseProxy.Endpoint
+      - !GetAtt Database.Endpoint.Address
+    Export:
+      Name: !Sub "leadquali-${Stage}-db-endpoint"
+  DatabasePort:
+    Value: !GetAtt Database.Endpoint.Port
+  DatabaseName:
+    Value: leadquali
+  DatabaseMasterUserSecretArn:
+    Description: >-
+      RDS-managed, rotated by RDS. #28 reads username and password from here and composes
+      the DATABASE_URL secret; nothing else should hand this ARN to application code.
+    Value: !GetAtt Database.MasterUserSecret.SecretArn
+    Export:
+      Name: !Sub "leadquali-${Stage}-db-secret-arn"
+  DatabaseIdentifier:
+    Description: >-
+      For #29's DatabaseConnections alarm. The threshold is the arithmetic in this
+      template: alarm when connections approach the proxy backend budget, which for
+      db.t4g.micro at 75% is 84 of a pinned max_connections of 112.
+    Value: !Ref Database
+  DatabaseProxyName:
+    Condition: ProxyEnabled
+    Description: For #29's proxy-side connection and borrow-timeout alarms.
+    Value: !Ref DatabaseProxy
+  DatabaseKmsKeyArn:
+    Value: !GetAtt DatabaseKmsKey.Arn

--- a/infra/template.yaml
+++ b/infra/template.yaml
@@ -26,11 +26,41 @@ Parameters:
     Type: Number
     Default: 5
     MinValue: 1
+    MaxValue: 50
     Description: >
       Hard cap on concurrent workers. This is the Postgres decision's bill (plan section
       4): each container holds one connection, so this number is the worst-case
       connection count against RDS Proxy. Raising it without raising the database's
       connection budget is how a burst of leads takes the database down. Owned with #27.
+
+      MaxValue is the half of #27's connection arithmetic that CloudFormation can enforce
+      by itself. The whole relationship is:
+
+        (WorkerReservedConcurrency + IngestReservedConcurrency) x connections-per-container
+          <= floor(max_connections x ProxyMaxConnectionsPercent / 100)
+        (50                       + 30)                         x 1
+          <= floor(112            x 75                          / 100) = 84
+
+      connections-per-container is 1 because store_postgres.engine_for builds its engine
+      with pool_size=1 and max_overflow=0; max_connections is 112 because
+      infra/network.yaml pins it there for a db.t4g.micro rather than leaving it to the
+      instance-memory formula. CloudFormation has no way to constrain two parameters
+      against each other, so the ceiling is split into two MaxValues that sum below the
+      budget, and tests/unit/test_infra_network.py asserts the sum. Raise either one only
+      together with DbInstanceClass in the network stack.
+  IngestReservedConcurrency:
+    Type: Number
+    Default: 20
+    MinValue: 1
+    MaxValue: 30
+    Description: >
+      Hard cap on concurrent ingest containers, for the same reason the worker has one:
+      api/main.py builds a PostgresLeadStore for the idempotency check and api/feedback.py
+      a PostgresFeedbackStore for the one-click links, so every warm ingest container also
+      holds a database connection. Without this the API side of the connection budget is
+      unbounded, and the cap on the worker only bounds half the problem. The default of 20
+      is sized to the API's own throttle above (50 rps steady, 100 burst) at roughly
+      200 ms per request; MaxValue is set by the arithmetic on WorkerReservedConcurrency.
   IngestCredentialsSecretArn:
     Type: String
     Description: >
@@ -75,10 +105,25 @@ Parameters:
   VpcSecurityGroupIds:
     Type: CommaDelimitedList
     Default: ""
-    Description: Security groups for the worker (#27).
+    Description: >
+      Security groups for the worker and ingest functions (#27). In the network stack this
+      is LambdaSecurityGroupId, which reaches RDS Proxy on 5432 and cannot reach Postgres
+      directly - the proxy's connection cap is only a cap if it cannot be walked around.
+  MigrationSecurityGroupIds:
+    Type: CommaDelimitedList
+    Default: ""
+    Description: >
+      Security groups for the migration function (#27's MigrationSecurityGroupId). It is
+      separate because migrations are the one workload allowed to bypass RDS Proxy: alembic
+      holds a single long transaction with DDL and advisory locks, which pins a backend
+      connection and defeats the multiplexing the proxy exists for. Left empty, the
+      migration function falls back to VpcSecurityGroupIds and goes through the proxy,
+      which works and is merely worse.
 
 Conditions:
   InVpc: !Not [!Equals [!Join ["", !Ref VpcSubnetIds], ""]]
+  MigrationHasDedicatedSg:
+    !Not [!Equals [!Join ["", !Ref MigrationSecurityGroupIds], ""]]
 
 Globals:
   Function:
@@ -117,6 +162,25 @@ Resources:
       Handler: leadquali.api.handlers.ingest_handler
       MemorySize: 512
       Timeout: 10
+      ReservedConcurrentExecutions: !Ref IngestReservedConcurrency
+      # Ingest is in the VPC for the same reason the worker is, and it is easy to miss:
+      # this function talks to Postgres. api/main.py builds a PostgresLeadStore so that a
+      # duplicate submission_id is rejected at the door, and api/feedback.py builds a
+      # PostgresFeedbackStore for the one-click links in #19's emails. With the database
+      # not publicly accessible - which is the whole point of #27 - a function outside the
+      # VPC cannot reach it at all, so leaving ingest outside would not be a performance
+      # choice, it would be a stack that returns 500 on the first lead.
+      #
+      # The cost is a cold start behind a synchronous HTTP request. Since Lambda moved to
+      # shared Hyperplane ENIs this is tens of milliseconds rather than the ten seconds it
+      # used to be, and the p99 target in plan section 8 has room for it - but it is the
+      # one latency number in this stack that only a real deploy can settle, so measure it
+      # before promising anything about it.
+      VpcConfig: !If
+        - InVpc
+        - SubnetIds: !Ref VpcSubnetIds
+          SecurityGroupIds: !Ref VpcSecurityGroupIds
+        - !Ref AWS::NoValue
       Environment:
         Variables:
           LEAD_QUEUE_URL: !Ref LeadQueue
@@ -129,6 +193,7 @@ Resources:
             SecretArn: !Ref IngestCredentialsSecretArn
         - AWSSecretsManagerGetSecretValuePolicy:
             SecretArn: !Ref DatabaseUrlSecretArn
+        - VPCAccessPolicy: {}
       Events:
         Ingest:
           Type: Api
@@ -200,10 +265,18 @@ Resources:
       Handler: leadquali.api.migrate.lambda_handler
       MemorySize: 512
       Timeout: 300
+      # Exactly one. Not a parameter, because there is no value other than one that is
+      # correct: two concurrent alembic runs contend for the same DDL and advisory locks,
+      # and the loser spends the Lambda's whole 300 s waiting to do nothing. It is also
+      # the single direct connection reserved for migrations in #27's budget.
+      ReservedConcurrentExecutions: 1
       VpcConfig: !If
         - InVpc
         - SubnetIds: !Ref VpcSubnetIds
-          SecurityGroupIds: !Ref VpcSecurityGroupIds
+          SecurityGroupIds: !If
+            - MigrationHasDedicatedSg
+            - !Ref MigrationSecurityGroupIds
+            - !Ref VpcSecurityGroupIds
         - !Ref AWS::NoValue
       Environment:
         Variables:

--- a/tests/unit/cfn.py
+++ b/tests/unit/cfn.py
@@ -1,0 +1,91 @@
+"""One CloudFormation loader, shared by the infrastructure tests.
+
+#26 introduced the loader that tolerates CloudFormation's `!Ref`/`!GetAtt` short forms;
+#27 added a second template to assert against. It lives here rather than in either test
+module so that there is exactly one of it: two loaders that drift is how a test starts
+passing against a shape the real template no longer has.
+
+Nothing here resolves intrinsic functions. A `!Ref` comes back as `{"Fn::Ref": "Name"}`,
+which is what the tests want — asserting that a property *references* a parameter is a
+stronger statement than asserting on whatever that parameter happens to default to.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+INFRA_DIR = Path(__file__).resolve().parents[2] / "infra"
+
+#: The application stack: API Gateway, ingest, queue, worker, migrations (#26, #27).
+APPLICATION_TEMPLATE_PATH = INFRA_DIR / "template.yaml"
+
+#: The network and data stack: VPC, egress, RDS Postgres, RDS Proxy (#27).
+NETWORK_TEMPLATE_PATH = INFRA_DIR / "network.yaml"
+
+
+class CloudFormationLoader(yaml.SafeLoader):
+    """SafeLoader that tolerates CloudFormation's `!Ref`/`!Sub`/`!GetAtt` short forms."""
+
+
+def _tag(loader: yaml.Loader, tag_suffix: str, node: yaml.Node) -> dict[str, Any]:
+    if isinstance(node, yaml.ScalarNode):
+        value: Any = loader.construct_scalar(node)
+    elif isinstance(node, yaml.SequenceNode):
+        value = loader.construct_sequence(node, deep=True)
+    elif isinstance(node, yaml.MappingNode):
+        value = loader.construct_mapping(node, deep=True)
+    else:  # pragma: no cover - the three node kinds above are exhaustive in PyYAML
+        raise TypeError(f"unexpected node {type(node).__name__} for tag !{tag_suffix}")
+    return {f"Fn::{tag_suffix}": value}
+
+
+CloudFormationLoader.add_multi_constructor("!", _tag)
+
+
+def load_template(path: Path) -> dict[str, Any]:
+    """Parse a CloudFormation template into plain dicts.
+
+    Args:
+        path: The template to read.
+
+    Returns:
+        The template as nested built-in types, with intrinsic function tags turned into
+        single-key dicts such as ``{"Fn::Ref": "Stage"}``.
+    """
+    # S506 is about untrusted YAML instantiating arbitrary objects. `CloudFormationLoader`
+    # derives from `SafeLoader` and only adds constructors that turn CloudFormation's
+    # `!Ref`-style tags into plain dicts, and the input is a file from this repository.
+    loaded = yaml.load(path.read_text(encoding="utf-8"), Loader=CloudFormationLoader)  # noqa: S506
+    assert isinstance(loaded, dict)
+    return loaded
+
+
+def resources(template: dict[str, Any]) -> dict[str, Any]:
+    """Return a template's ``Resources`` block.
+
+    Args:
+        template: A template loaded by :func:`load_template`.
+
+    Returns:
+        The resource logical-id to definition mapping.
+    """
+    block = template["Resources"]
+    assert isinstance(block, dict)
+    return block
+
+
+def parameters(template: dict[str, Any]) -> dict[str, Any]:
+    """Return a template's ``Parameters`` block.
+
+    Args:
+        template: A template loaded by :func:`load_template`.
+
+    Returns:
+        The parameter name to specification mapping.
+    """
+    block = template["Parameters"]
+    assert isinstance(block, dict)
+    return block

--- a/tests/unit/test_infra_network.py
+++ b/tests/unit/test_infra_network.py
@@ -1,0 +1,447 @@
+"""Invariants of the network and data stack (#27).
+
+No AWS account exists here, so none of this proves the stack deploys, that RDS accepts the
+engine version, or that a Lambda in these subnets can actually resolve `api.anthropic.com`.
+What it does prove is that the template still says the things the design depends on, and
+those are exactly the things that are cheap to change by accident and expensive to
+discover: a database that became publicly accessible, storage that stopped being
+encrypted, a security group that grew a CIDR rule, a VPC whose DNS was turned off, and —
+the one with no visible symptom — a worker concurrency cap raised past the number of
+connections the database can serve.
+
+The last one is the reason this file exists at all. The relationship
+
+    (worker + ingest concurrency) x connections-per-container <= proxy backend budget
+
+spans two templates and a Python module's engine settings. Nothing enforces it end to end
+except the test below, so it is written as arithmetic over the parameters rather than as a
+comparison against a remembered number.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from tests.unit.cfn import (
+    APPLICATION_TEMPLATE_PATH,
+    NETWORK_TEMPLATE_PATH,
+    load_template,
+    parameters,
+    resources,
+)
+
+#: Connections a warm Lambda container holds open. One, and not a guess:
+#: `store_postgres.engine_for` builds its engine with `pool_size=1` and `max_overflow=0`
+#: precisely so that this factor is 1 and reserved concurrency *is* the connection budget.
+#: `test_the_adapter_still_holds_one_connection_per_container` keeps that true.
+CONNECTIONS_PER_CONTAINER = 1
+
+DATABASE_PORT = 5432
+
+
+@pytest.fixture(scope="module")
+def network() -> dict[str, Any]:
+    return load_template(NETWORK_TEMPLATE_PATH)
+
+
+@pytest.fixture(scope="module")
+def application() -> dict[str, Any]:
+    return load_template(APPLICATION_TEMPLATE_PATH)
+
+
+def _security_group_rules(
+    template: dict[str, Any], group: str, direction: str
+) -> list[dict[str, Any]]:
+    """Every rule in one direction for one security group, inline and standalone.
+
+    Collecting both forms matters: a rule declared inline on the group and a rule declared
+    as its own `AWS::EC2::SecurityGroupIngress` resource have identical effect, so a check
+    that only reads one of them can be defeated by moving a rule.
+
+    Args:
+        template: The loaded network template.
+        group: The security group's logical id.
+        direction: ``"Ingress"`` or ``"Egress"``.
+
+    Returns:
+        The matching rules, each annotated with the CloudFormation ``Condition`` guarding
+        it (``None`` when unconditional).
+    """
+    inline_key = f"SecurityGroup{direction}"
+    standalone_type = f"AWS::EC2::SecurityGroup{direction}"
+    found: list[dict[str, Any]] = []
+
+    for logical_id, resource in resources(template).items():
+        properties = resource.get("Properties", {})
+        if logical_id == group and resource.get("Type") == "AWS::EC2::SecurityGroup":
+            for rule in properties.get(inline_key, []):
+                found.append({**rule, "Condition": resource.get("Condition")})
+        elif resource.get("Type") == standalone_type and properties.get("GroupId") == {
+            "Fn::Ref": group
+        }:
+            found.append({**properties, "Condition": resource.get("Condition")})
+    return found
+
+
+# --------------------------------------------------------------------------------------
+# The database
+# --------------------------------------------------------------------------------------
+def test_the_database_is_not_publicly_accessible(network: dict[str, Any]) -> None:
+    """The acceptance criterion, and the reason the migration Lambda exists.
+
+    `PubliclyAccessible: false` is not a preference here — with no public address there is
+    no way to run a migration from a laptop, which is what makes "never open the database
+    to the internet" a property of the stack rather than of somebody's discipline.
+    """
+    assert resources(network)["Database"]["Properties"]["PubliclyAccessible"] is False
+
+
+def test_the_database_is_encrypted_at_rest_with_a_managed_key(
+    network: dict[str, Any],
+) -> None:
+    """Leads are personal data (plan section 8); encryption is not optional for them."""
+    properties = resources(network)["Database"]["Properties"]
+    assert properties["StorageEncrypted"] is True
+    assert properties["KmsKeyId"] == {"Fn::GetAtt": "DatabaseKmsKey.Arn"}
+    key = resources(network)["DatabaseKmsKey"]
+    assert key["Properties"]["EnableKeyRotation"] is True
+    assert key["DeletionPolicy"] == "Retain", (
+        "deleting the key destroys every snapshot taken with it, which would make the "
+        "Snapshot deletion policy on the instance meaningless"
+    )
+
+
+def test_automated_backups_are_on_and_cannot_be_switched_off(
+    network: dict[str, Any],
+) -> None:
+    """A retention of 0 disables automated backups; the parameter must not reach it."""
+    retention = parameters(network)["DbBackupRetentionDays"]
+    assert retention["MinValue"] >= 1
+    assert retention["Default"] >= 7
+    assert resources(network)["Database"]["Properties"]["BackupRetentionPeriod"] == {
+        "Fn::Ref": "DbBackupRetentionDays"
+    }
+
+
+def test_the_database_survives_the_stack_being_deleted(network: dict[str, Any]) -> None:
+    """The feedback loop in this database is the moat (plan section 4)."""
+    database = resources(network)["Database"]
+    assert database["DeletionPolicy"] == "Snapshot"
+    assert database["UpdateReplacePolicy"] == "Snapshot"
+    assert database["Properties"]["DeletionProtection"] is True
+
+
+def test_the_master_password_is_never_in_the_template(network: dict[str, Any]) -> None:
+    """RDS generates and rotates it in Secrets Manager; nothing here can hold a literal."""
+    properties = resources(network)["Database"]["Properties"]
+    assert properties["ManageMasterUserPassword"] is True
+    assert "MasterUserPassword" not in properties
+    for name, spec in parameters(network).items():
+        assert "password" not in name.lower(), f"{name} must not exist"
+        assert spec.get("NoEcho") is not True, f"{name} carries a secret; use an ARN"
+
+
+def test_the_parameter_group_family_matches_the_engine_version(
+    network: dict[str, Any],
+) -> None:
+    """A mismatch is rejected by RDS at create time, twenty minutes into a deploy."""
+    params = parameters(network)
+    major = params["DbEngineVersion"]["Default"].split(".")[0]
+    assert params["DbParameterGroupFamily"]["Default"] == f"postgres{major}"
+
+
+# --------------------------------------------------------------------------------------
+# The network
+# --------------------------------------------------------------------------------------
+def test_the_vpc_resolves_dns(network: dict[str, Any]) -> None:
+    """#18's finding, asserted.
+
+    A Lambda in a private subnet resolves names through the Amazon-provided resolver, and
+    that resolver only exists when `EnableDnsSupport` is true. Turn it off and every
+    lookup times out rather than failing: the enrichment circuit breaker opens, every lead
+    is enriched with nothing, every lead is still delivered, and no alarm fires because
+    nothing errored. That is the failure this assertion exists to prevent, and it is the
+    reason it is an assertion and not a comment.
+    """
+    properties = resources(network)["Vpc"]["Properties"]
+    assert properties["EnableDnsSupport"] is True
+    assert properties["EnableDnsHostnames"] is True
+
+
+def test_the_lambda_security_group_permits_dns_egress(network: dict[str, Any]) -> None:
+    """The other half of the same finding: egress rules apply to DNS queries too.
+
+    A group locked to 443 for "HTTPS only" resolves no names at all, and fails in exactly
+    the silent way above.
+    """
+    egress = _security_group_rules(network, "LambdaSecurityGroup", "Egress")
+    dns = [rule for rule in egress if rule.get("FromPort") == 53]
+    protocols = {rule["IpProtocol"] for rule in dns}
+    assert protocols == {"udp", "tcp"}, "DNS over TCP is needed for large responses"
+    destinations = [rule.get("CidrIp") for rule in dns]
+    assert {"Fn::Ref": "VpcCidr"} in destinations, (
+        "the Amazon-provided resolver sits at the VPC base address plus two"
+    )
+    assert "169.254.169.253/32" in destinations, "the link-local resolver alias"
+
+
+def test_the_private_subnets_span_at_least_two_availability_zones(
+    network: dict[str, Any],
+) -> None:
+    """One AZ is not a deployment, it is a database with a single point of failure."""
+    private = {
+        logical_id: resource["Properties"]
+        for logical_id, resource in resources(network).items()
+        if resource.get("Type") == "AWS::EC2::Subnet" and logical_id.startswith("Private")
+    }
+    assert len(private) >= 2
+    zones = [repr(properties["AvailabilityZone"]) for properties in private.values()]
+    assert len(set(zones)) >= 2, f"all private subnets land in one AZ: {zones}"
+
+    subnet_group = resources(network)["DatabaseSubnetGroup"]["Properties"]["SubnetIds"]
+    assert {ref["Fn::Ref"] for ref in subnet_group} == set(private)
+
+
+def test_the_private_subnets_have_no_route_to_an_internet_gateway(
+    network: dict[str, Any],
+) -> None:
+    """Private means private: egress is via the NAT, and ingress does not exist."""
+    private_route_tables = {
+        resource["Properties"]["RouteTableId"]["Fn::Ref"]
+        for logical_id, resource in resources(network).items()
+        if resource.get("Type") == "AWS::EC2::SubnetRouteTableAssociation"
+        and resource["Properties"]["SubnetId"]["Fn::Ref"].startswith("Private")
+    }
+    assert private_route_tables, "no private subnet is associated with a route table"
+
+    for resource in resources(network).values():
+        if resource.get("Type") != "AWS::EC2::Route":
+            continue
+        properties = resource["Properties"]
+        if properties["RouteTableId"]["Fn::Ref"] not in private_route_tables:
+            continue
+        assert "GatewayId" not in properties, "a private subnet routes to the IGW"
+        assert properties["NatGatewayId"] == {"Fn::Ref": "NatGateway"}
+
+
+def test_the_egress_path_exists_for_the_public_apis_the_worker_needs(
+    network: dict[str, Any],
+) -> None:
+    """Anthropic is a third-party public endpoint: without this the worker cannot work."""
+    egress = _security_group_rules(network, "LambdaSecurityGroup", "Egress")
+    https = [rule for rule in egress if rule.get("FromPort") == 443]
+    assert [rule["CidrIp"] for rule in https] == ["0.0.0.0/0"]
+    assert resources(network)["NatGateway"]["Properties"]["SubnetId"] == {"Fn::Ref": "NatSubnet"}
+
+
+# --------------------------------------------------------------------------------------
+# Security groups: identities, not addresses
+# --------------------------------------------------------------------------------------
+def test_no_security_group_lets_the_internet_reach_the_database(
+    network: dict[str, Any],
+) -> None:
+    """Every rule into the database names a group, so none of them can name the world."""
+    ingress = _security_group_rules(network, "DatabaseSecurityGroup", "Ingress")
+    assert ingress, "the database is unreachable; that is not the invariant either"
+    for rule in ingress:
+        assert "CidrIp" not in rule, f"CIDR ingress to the database: {rule}"
+        assert "CidrIpv6" not in rule, f"CIDR ingress to the database: {rule}"
+        assert "SourceSecurityGroupId" in rule
+        assert rule["FromPort"] == rule["ToPort"] == DATABASE_PORT
+
+
+def test_no_security_group_anywhere_is_open_to_the_world_inbound(
+    network: dict[str, Any],
+) -> None:
+    """Nothing in this VPC accepts an unsolicited connection from anywhere."""
+    for logical_id, resource in resources(network).items():
+        if resource.get("Type") == "AWS::EC2::SecurityGroup":
+            rules = resource["Properties"].get("SecurityGroupIngress", [])
+        elif resource.get("Type") == "AWS::EC2::SecurityGroupIngress":
+            rules = [resource["Properties"]]
+        else:
+            continue
+        for rule in rules:
+            assert rule.get("CidrIp") not in ("0.0.0.0/0", "::/0"), logical_id
+            assert rule.get("CidrIpv6") != "::/0", logical_id
+
+
+def test_the_worker_cannot_reach_the_database_except_through_the_proxy(
+    network: dict[str, Any],
+) -> None:
+    """Otherwise the proxy's connection cap is advice rather than a limit.
+
+    Every rule that would let the worker's security group open a direct connection must be
+    conditional on the proxy being switched off, so that turning the proxy back on removes
+    the bypass instead of leaving it in place.
+    """
+    egress = _security_group_rules(network, "LambdaSecurityGroup", "Egress")
+    for rule in egress:
+        if rule.get("DestinationSecurityGroupId") == {"Fn::Ref": "DatabaseSecurityGroup"}:
+            assert rule["Condition"] == "ProxyDisabled", (
+                "the worker has an unconditional direct path to Postgres"
+            )
+
+    ingress = _security_group_rules(network, "DatabaseSecurityGroup", "Ingress")
+    sources = {rule["SourceSecurityGroupId"]["Fn::Ref"]: rule["Condition"] for rule in ingress}
+    assert sources["ProxySecurityGroup"] is None, "the pooled path must always exist"
+    assert sources["MigrationSecurityGroup"] is None, (
+        "migrations bypass the proxy deliberately and unconditionally"
+    )
+    assert set(sources) <= {
+        "ProxySecurityGroup",
+        "MigrationSecurityGroup",
+        "LambdaSecurityGroup",
+    }, f"an unexpected group reaches the database: {sorted(sources)}"
+    if "LambdaSecurityGroup" in sources:
+        assert sources["LambdaSecurityGroup"] == "ProxyDisabled"
+
+
+def test_the_proxy_requires_tls_in_both_directions(network: dict[str, Any]) -> None:
+    proxy = resources(network)["DatabaseProxy"]["Properties"]
+    assert proxy["RequireTLS"] is True
+    group = resources(network)["DatabaseParameterGroup"]["Properties"]["Parameters"]
+    assert group["rds.force_ssl"] == "1"
+
+
+def test_the_proxy_idle_timeout_outlives_the_client_pool_recycle(
+    network: dict[str, Any],
+) -> None:
+    """The client must give up a connection before the proxy does, not the other way."""
+    from leadquali.adapters.store_postgres import DEFAULT_POOL_RECYCLE_SECONDS
+
+    idle = resources(network)["DatabaseProxy"]["Properties"]["IdleClientTimeout"]
+    assert idle > DEFAULT_POOL_RECYCLE_SECONDS
+
+
+# --------------------------------------------------------------------------------------
+# The arithmetic
+# --------------------------------------------------------------------------------------
+def test_the_adapter_still_holds_one_connection_per_container() -> None:
+    """The factor of 1 in the budget below is a property of the adapter, so check it.
+
+    If someone raises `pool_size`, every number in this file is silently wrong by that
+    factor, and nothing else in the codebase would notice.
+    """
+    from leadquali.adapters.store_postgres import DEFAULT_MAX_OVERFLOW, DEFAULT_POOL_SIZE
+
+    assert DEFAULT_POOL_SIZE + DEFAULT_MAX_OVERFLOW == CONNECTIONS_PER_CONTAINER
+
+
+def test_max_connections_is_pinned_rather_than_derived_from_instance_memory(
+    network: dict[str, Any],
+) -> None:
+    """The budget depends on this number, so the template sets it instead of inferring it.
+
+    Left to the RDS default of `LEAST({DBInstanceClassMemory/9531392}, 5000)` it is a
+    number nobody can read off a template and everybody has to remember.
+    """
+    group = resources(network)["DatabaseParameterGroup"]["Properties"]["Parameters"]
+    assert group["max_connections"] == {
+        "Fn::FindInMap": ["InstanceCapacity", {"Fn::Ref": "DbInstanceClass"}, "MaxConnections"]
+    }
+    allowed = set(parameters(network)["DbInstanceClass"]["AllowedValues"])
+    assert allowed <= set(network["Mappings"]["InstanceCapacity"]), (
+        "an instance class with no recorded max_connections makes the budget unresolvable"
+    )
+
+
+def test_the_connection_budget_is_not_oversubscribed(
+    network: dict[str, Any], application: dict[str, Any]
+) -> None:
+    """The relationship a future person will break, stated as arithmetic.
+
+        (worker + ingest concurrency) x connections-per-container
+            <= floor(max_connections x ProxyMaxConnectionsPercent / 100)
+
+    and, on the database side, the proxy's budget plus the migration function's direct
+    connection plus Postgres's own superuser reserve must still fit in max_connections.
+
+    It is checked for *every* allowed instance class, not just the default, so that
+    changing `DbInstanceClass` cannot quietly invalidate it in either direction.
+    """
+    net_params = parameters(network)
+    app_params = parameters(application)
+    capacity = network["Mappings"]["InstanceCapacity"]
+    percent = net_params["ProxyMaxConnectionsPercent"]["Default"]
+
+    group = resources(network)["DatabaseParameterGroup"]["Properties"]["Parameters"]
+    superuser_reserved = int(group["superuser_reserved_connections"])
+    migration_direct = resources(application)["MigrationFunction"]["Properties"][
+        "ReservedConcurrentExecutions"
+    ]
+
+    peak_containers = (
+        app_params["WorkerReservedConcurrency"]["MaxValue"]
+        + app_params["IngestReservedConcurrency"]["MaxValue"]
+    )
+    peak_connections = peak_containers * CONNECTIONS_PER_CONTAINER
+
+    for instance_class in net_params["DbInstanceClass"]["AllowedValues"]:
+        max_connections = int(capacity[instance_class]["MaxConnections"])
+        proxy_budget = max_connections * percent // 100
+
+        assert peak_connections <= proxy_budget, (
+            f"{instance_class}: the application stack may be deployed with "
+            f"{peak_connections} concurrent containers, each holding "
+            f"{CONNECTIONS_PER_CONTAINER} connection, against a proxy budget of "
+            f"{proxy_budget} ({max_connections} x {percent}%). Raise DbInstanceClass or "
+            f"lower the MaxValues."
+        )
+        assert proxy_budget + migration_direct + superuser_reserved <= max_connections, (
+            f"{instance_class}: proxy budget {proxy_budget} plus {migration_direct} "
+            f"migration connection plus {superuser_reserved} reserved for superusers "
+            f"exceeds max_connections {max_connections}; an operator with psql would be "
+            f"locked out of the incident they are trying to fix"
+        )
+
+
+def test_every_function_that_touches_postgres_has_a_concurrency_cap(
+    application: dict[str, Any],
+) -> None:
+    """Capping the worker alone bounds half the connections.
+
+    The ingest function reads Postgres too — the idempotency check in `api/main.py` and
+    the feedback links in `api/feedback.py` — so an uncapped ingest is an uncapped
+    connection count no matter what the worker is set to.
+    """
+    for logical_id, resource in resources(application).items():
+        if resource.get("Type") != "AWS::Serverless::Function":
+            continue
+        properties = resource["Properties"]
+        env = properties.get("Environment", {}).get("Variables", {})
+        if "DATABASE_URL_SECRET_ARN" not in env:
+            continue
+        assert "ReservedConcurrentExecutions" in properties, (
+            f"{logical_id} connects to Postgres with no cap on how many of it exist"
+        )
+
+
+def test_every_function_that_touches_postgres_is_in_the_vpc(
+    application: dict[str, Any],
+) -> None:
+    """With no public database endpoint, a function outside the VPC cannot connect at all.
+
+    This is not a latency preference. `PubliclyAccessible: false` means a function without
+    a `VpcConfig` fails on its first query, which for the ingest function is the first
+    lead the site ever posts.
+    """
+    for logical_id, resource in resources(application).items():
+        if resource.get("Type") != "AWS::Serverless::Function":
+            continue
+        properties = resource["Properties"]
+        env = properties.get("Environment", {}).get("Variables", {})
+        if "DATABASE_URL_SECRET_ARN" not in env:
+            continue
+        vpc = properties.get("VpcConfig")
+        assert vpc is not None, f"{logical_id} reads Postgres from outside the VPC"
+        assert vpc["Fn::If"][0] == "InVpc"
+        assert vpc["Fn::If"][1]["SubnetIds"] == {"Fn::Ref": "VpcSubnetIds"}
+
+
+def test_migrations_run_one_at_a_time(application: dict[str, Any]) -> None:
+    """Two concurrent alembic runs contend for the same DDL and advisory locks."""
+    properties = resources(application)["MigrationFunction"]["Properties"]
+    assert properties["ReservedConcurrentExecutions"] == 1

--- a/tests/unit/test_infra_template.py
+++ b/tests/unit/test_infra_template.py
@@ -10,51 +10,17 @@ dead letter, a plaintext secret, a handler path that no longer matches the code.
 
 from __future__ import annotations
 
-from pathlib import Path
 from typing import Any
 
 import pytest
-import yaml
 
-TEMPLATE_PATH = Path(__file__).resolve().parents[2] / "infra" / "template.yaml"
-
-
-class _SamLoader(yaml.SafeLoader):
-    """SafeLoader that tolerates CloudFormation's `!Ref`/`!Sub`/`!GetAtt` short forms."""
-
-
-def _tag(loader: yaml.Loader, tag_suffix: str, node: yaml.Node) -> dict[str, Any]:
-    if isinstance(node, yaml.ScalarNode):
-        value: Any = loader.construct_scalar(node)
-    elif isinstance(node, yaml.SequenceNode):
-        value = loader.construct_sequence(node, deep=True)
-    elif isinstance(node, yaml.MappingNode):
-        value = loader.construct_mapping(node, deep=True)
-    else:  # pragma: no cover - the three node kinds above are exhaustive in PyYAML
-        raise TypeError(f"unexpected node {type(node).__name__} for tag !{tag_suffix}")
-    return {f"Fn::{tag_suffix}": value}
-
-
-_SamLoader.add_multi_constructor("!", _tag)
+from tests.unit.cfn import APPLICATION_TEMPLATE_PATH, load_template
+from tests.unit.cfn import resources as _resources
 
 
 @pytest.fixture(scope="module")
 def template() -> dict[str, Any]:
-    # S506 is about untrusted YAML instantiating arbitrary objects. `_SamLoader` derives
-    # from `SafeLoader` and only adds constructors that turn CloudFormation's `!Ref`-style
-    # tags into plain dicts, and the input is a file from this repository.
-    loaded = yaml.load(
-        TEMPLATE_PATH.read_text(encoding="utf-8"),
-        Loader=_SamLoader,  # noqa: S506
-    )
-    assert isinstance(loaded, dict)
-    return loaded
-
-
-def _resources(template: dict[str, Any]) -> dict[str, Any]:
-    resources = template["Resources"]
-    assert isinstance(resources, dict)
-    return resources
+    return load_template(APPLICATION_TEMPLATE_PATH)
 
 
 def test_the_template_exists_and_is_a_sam_template(template: dict[str, Any]) -> None:


### PR DESCRIPTION
Closes #27. On top of #65 (SAM template).

This is the bill for the Postgres decision, made concrete. **Read `docs/infrastructure-cost.md` before this diff** — it is the deliverable plan §4 asked for.

## 💰 The number that should change how you think about this

**≈ $139.60/month** for the network and database, against plan §8's ~$25/month of tokens. At 1,000 leads/month that is **$0.140/lead of infrastructure vs $0.025/lead of model**.

**The dominant line is RDS Proxy at $87.60** — it bills an **8-vCPU floor for T-family instances**, so it costs *seven times* the `db.t4g.micro` database it fronts. At a worker concurrency of 5 it buys cold-start latency and failover transparency; it does **not** buy connection headroom, because the arithmetic already fits without it.

#27 mandates the proxy so `EnableRdsProxy` defaults true — but it is a **parameter**. Turning it off drops the stack to **≈ $52.00/month** and the connection arithmetic still holds. That is your call, and it is the single biggest cost lever in the deployment.

## Egress: NAT, not VPC endpoints — the brief's preference didn't survive contact

I asked for endpoints-plus-minimal-NAT as likely cheaper. It isn't, and the reason is worth recording: **`api.anthropic.com` has no PrivateLink endpoint**, so public egress is required *regardless*. That makes endpoints purely additive — one NAT at **$36.51/mo** versus endpoints ($58.40 for 4 × 2 AZs) **plus** the still-required NAT at **$94.91/mo**. The crossover on data volume is ~1.7 TB/month; this system moves ~50 MB.

One NAT, not two: SQS turns an AZ egress outage into a delay rather than a loss.

## A real bug this found in #65

**`IngestFunction` reads Postgres** — the idempotency check in `api/main.py` and the feedback links in `api/feedback.py` — **but had no `VpcConfig` and no concurrency cap.** Against a private database it would have 500'd on the very first lead, and it bounded no connections. Now in-VPC and capped.

## The arithmetic, enforced rather than remembered

```
(WorkerReservedConcurrency + IngestReservedConcurrency) × connections-per-container
    ≤ floor(max_connections × ProxyMaxConnectionsPercent / 100)
(50 + 30) × 1  ≤  floor(112 × 75/100) = 84
```

Container factor is 1 because `store_postgres` uses `pool_size=1`/`max_overflow=0` — **and a test asserts that still holds**, so growing the pool breaks the build rather than the database. `max_connections` is **pinned in a parameter group** rather than left to `LEAST({DBInstanceClassMemory/9531392}, 5000)`, which silently changes with instance class. CloudFormation enforces each half via `MaxValue`; a test enforces the sum for *every* allowed instance class.

## #58's invisible failure mode is now configuration

`EnableDnsSupport` and `EnableDnsHostnames`, plus explicit **UDP *and* TCP** port 53 egress to both the VPC resolver and `169.254.169.253`. A security group locked to 443 resolves nothing: every lookup times out, the circuit breaker opens, every lead is enriched with nothing, and no alarm fires.

## Verification

`cfn-lint` 1.56 clean on **both** templates. 1418 tests passing. **21/21 mutations caught** — public accessibility, storage encryption, KMS rotation, both subnets into one AZ, DNS support, DNS hostnames, DNS egress removed, `0.0.0.0/0` database ingress, a private subnet routed to the IGW, an unconditional worker→DB path, disable-able backups, proxy TLS, engine/family drift, unpinned `max_connections`, proxy share cut to 40%, worker ceiling past budget, ingest cap removed, ingest pulled out of the VPC, concurrent migrations, adapter pool grown to 5, and proxy idle timeout below `pool_recycle`.

**Separate network stack**, because a template deployed on every merge must not be able to replace a database — and NAT plus proxy take ~20 minutes to build against a 2-minute Lambda deploy.

**Only a real deploy can prove**: that the stack creates at all, that a Lambda in these subnets actually resolves and reaches Anthropic/SES/Secrets Manager, the real `SHOW max_connections` (pinned to 112 — verify), what VPC attachment costs ingest cold-start latency on the synchronous path, and the managed-password rotation window against a proxy that caches credentials.

**For #28:** consume `DatabaseEndpoint`, `DatabasePort`, `DatabaseName`, `DatabaseMasterUserSecretArn`, and append `sslmode=require` — `rds.force_ssl=1` will refuse plaintext.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy

---
_Generated by [Claude Code](https://claude.ai/code/session_01Tke8d1d5jMzzJL4CANy2cy)_